### PR TITLE
Make activation language more permissive

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -244,7 +244,9 @@
 
       <p>
         A web page creates a <a><code>PaymentRequest</code></a> to make a payment request. This is
-        typically associated with the user activating a "Buy", "Purchase", or "Checkout" button.
+        typically associated with the user initiating a payment process 
+        (e.g., selecting a "Power Up" in an interactive game, pulling up to an automated kiosk in a parking structure,
+        or activating a "Buy", "Purchase", or "Checkout" button).
         The <a><code>PaymentRequest</code></a> allows the web page to exchange information with the
         <a>user agent</a> while the user is providing input before approving or denying a payment request.
       </p>


### PR DESCRIPTION
I know this is just an example anyway, but I would prefer that we not even have the perception that this is limited to activating a button.  It could, for example, be a voice command in an interactive game ("Level Up!") that starts the process.
