### PR TITLE
"Shown" is not inclusive enough

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -422,7 +422,7 @@
         <p>
           The <code><dfn>show</dfn></code> method is called when the page wants to begin user interaction for the
           payment request. The <code>show</code> method will return a <a>Promise</a> that will be resolved when the
-          <a>user accepts the payment request</a>. Some kind of user interface will be shown to the user to facilitate the
+          <a>user accepts the payment request</a>. Some kind of user interface will be presented to the user to facilitate the
           payment request after the <code>show</code> method returns.
         </p>
 


### PR DESCRIPTION
We all know that "shown" means presented, but it is important that we include / permit user agents and users that might not "see" things.  It is also important that we permit use models like a user agent in an automobile that might be presenting the offer to the user audibly.
