### PR TITLE
Remove note and add description for diagram

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -478,11 +478,10 @@
       </section>
 
       <section>
-        <h2 id="state-transitions">State transitions</h2>
-        <div class="note">
+        <h2 id="state-transitions" class="informative">State transitions</h2>
           <p>The internal slot [[\state]] follows the following state transitions:</p>
-          <img src="state-transitions.svg" width="608" height="235">
-        </div>
+          <img alt="Transition diagram for internal slot state of a PaymentRequest object" 
+               src="state-transitions.svg" width="608" height="235">
       </section>
 
       <section>


### PR DESCRIPTION
The diagram as it stood was not accessible.  Also, it was in a "note", which was not really needed and made it format poorly in a printed version.  Since notes are non-normative by definition, also marked the section as informative so that it is tagged accordingly.

This should really have a more accessible description if it is important.  The right way to do that is to mark up the SVG.  I have not done that at this time.
