### PR TITLE
Wrong document names and British English

### DIFF
--- a/specs/basic-card-payment.html
+++ b/specs/basic-card-payment.html
@@ -108,7 +108,7 @@
         of the PaymentRequest API.
       </p>
       <p>
-        In the future, merchants should favour payment methods that provide a tokenized response rather than
+        In the future, merchants should favor payment methods that provide a tokenized response rather than
         clear text credit card details.
       </p>
     </section>
@@ -119,7 +119,7 @@
       This specification relies on several other underlying specifications. 
       </p> 
       <dl> 
-        <dt>Payment Request Document Architecture</dt>
+        <dt>Payment Request Architecture</dt>
         <dd>The terms <dfn data-lt="payment method|payment methods">Payment Method</dfn>,
         <dfn data-lt="payment app|payment apps">Payment App</dfn>, and <dfn>Payment Transaction
         Message Specification</dfn> are defined by the Payment Request Architecture document
@@ -127,7 +127,7 @@
         <dt>Payment Request API</dt>
         <dd>The term <dfn>PaymentRequest constructor</dfn> is defined by the PaymentRequest API
         specification [[!PAYMENTREQUESTAPI]].</dd>
-        <dt>Payment Request Document Architecture</dt>
+        <dt>Payment Method Identifiers</dt>
         <dd>The term <dfn data-lt="payment method identifier|payment method identifiers">Payment
         Method Identifier</dfn> is defined by the Payment Method Identifiers specification
         [[!METHODIDENTIFIERS]].</dd>


### PR DESCRIPTION
The dependencies section had incorrect document names in it.

The document used the term "favour" instead of the American English spelling "favor".
