### PR TITLE
Add PaymentItem type to deal with transaction types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 
-.idea/workspace.xml
+.idea/

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -641,7 +641,8 @@ dictionary CurrencyAmount {
       <h2>PaymentDetails dictionary</h2>
       <pre class="idl">
 dictionary PaymentDetails {
-  sequence&lt;PaymentItem&gt; items;
+  PaymentItem total;
+  sequence&lt;PaymentItem&gt;? items;
   sequence&lt;ShippingOption&gt; shippingOptions;
 };
       </pre>
@@ -655,17 +656,22 @@ dictionary PaymentDetails {
         The following fields are part of the <code>PaymentDetails</code> dictionary:
       </p>
       <dl>
+        <dt><code>total</code></dt>
+        <dd>
+          A <a><code>PaymentItem</code></a> dictionary that represents the total amount of the payment
+          request. It is the responsibility of the calling code to ensure that the total amount is
+          the sum of <a><code>PaymentItem</code></a> dictionaries in <code>items</code>. The <a>user agent</a>
+          MAY not validate that this is true.
+        </dd>
         <dt><code>items</code></dt>
         <dd>
-          This sequence of <a><code>PaymentItem</code></a> dictionaries indicates what the payment
-          request is for. The sequence must contain at least one <code>PaymentItem</code>. The last
-          <code>PaymentItem</code> in the sequence represents the total amount of the payment
-          request. It is the responsibility of the calling code to ensure that the total amount is
-          the sum of the preceding items. The <a>user agent</a> MAY not validate that this is true.
+          This optional sequence of <a><code>PaymentItem</code></a> dictionaries indicates what the payment
+          request is for. It may be used to enumerate the basket of goods or additional costs and discounts such
+          as shipping costs or discounts as a result of a voucher or coupon.
         </dd>
         <dt><code>shippingOptions</code></dt>
         <dd>
-          A sequence containing the different shipping options that the use may choose from.
+          A sequence containing the different shipping options that the user may choose from.
           <p>If the sequence is empty, then this indicates that the merchant
           cannot ship to the current <a><code>shippingAddress</code></a>.</p>
           <p>If the sequence only contains one item, then this is the shipping option that
@@ -736,13 +742,14 @@ dictionary PaymentOptions {
         and <a>payment app</a> about how to display and process the request.
       </p>
       <p>
-        All but the last <code>PaymentItem</code> should have a <code>type</code> of either <code>debit</code> or
-        <code>credit</code> indicating if the payer is being debited or credited as a result of this item.
-        For example, a sub-total for a goods purchase would be a debit whereas a discount would be a credit.
+        All <code>PaymentItem</code> dictionaries in the <code>items</code> sequence of <a><code>PaymentDetails</code></a>
+        must have a <code>type</code> of either <code>debit</code> or <code>credit</code> indicating if the payer
+        is being debited or credited as a result of this item. For example, a sub-total for a goods purchase would
+        be a debit whereas a discount would be a credit.
       </p>
       <p>
-        The type of the final <code>PaymentItem</code> indicates to the <a>user agent</a> and <a>Payment App</a>
-        the type of transaction that the payee is requesting.
+        The type of the <code>PaymentItem</code> that is the <code>total</code> element of <a>PaymentDetails</a>
+        indicates to the <a>Payment App</a> the type of transaction that the payee is requesting.
       </p>
       <p>The following types MUST be supported:</p>
       <dl>

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -295,16 +295,19 @@
                 {
                   "id": "basket",
                   "label": "Sub-total",
+                  "type" : "debit"
                   "amount": { "currencyCode": "USD", "value" : "55.00" }, // US$55.00
                 },
                 {
                   "id": "tax",
                   "label": "Sales Tax",
+                  "type" : "debit"
                   "amount": { "currencyCode": "USD", "value" : "5.00" }, // US$5.00
                 },
                 {
                   "id": "total",
                   "label": "Total due",
+                  "type" : "capture"
                   "amount": { "currencyCode": "USD", "value" : "60.00" }, // US$60.00
                 }
               ]
@@ -685,17 +688,76 @@ dictionary PaymentOptions {
     </section>
 
     <section>
+      <h2>Transaction Types</h2>
+      <pre class="idl">
+
+        enum TransactionType {
+          "debit",
+          "credit",
+          "auth",
+          "capture",
+          "repeat-debit",
+          "repeat-credit"
+        };
+      </pre>
+      <div class="issue" title="Should the set of transaction types be fixed?">
+        Defining a fixed list will allow <a>user agents</a> to manage the user interface for each transaction type
+        appropriately however it is possible that new payment methods may wish to define new types that are not
+        currently widely known.
+      </div>
+      <p>
+        The <code>type</code> attribute of a <code>PaymentItem</code> provides hints to the <a>user agent</a>
+        and <a>payment app</a> about how to display and process the request.
+      </p>
+      <p>
+        All but the last <code>PaymentItem</code> should have a <code>type</code> of either <code>debit</code> or
+        <code>credit</code> indicating if the payer is being debited or credited as a result of this item.
+        For example, a sub-total for a goods purchase would be a debit whereas a discount would be a credit.
+      </p>
+      <p>
+        The type of the final <code>PaymentItem</code> indicates to the <a>user agent</a> and <a>Payment App</a>
+        the type of transaction that the payee is requesting.
+      </p>
+      <p>The following types MUST be supported:</p>
+      <dl>
+        <dt><code>debit</code></dt>
+        <dd>A standard payment/debit against the payer's account.</dd>
+        <dt><code>credit</code></dt>
+        <dd>A refund/credit against the payer's account.</dd>
+        <dt><code>authorization</code></dt>
+        <dd>A request to authorize a payment that may be settled between the payer and payee at some
+          time in the future. The specifics of an authorization will depend on the payment method that is used
+          to process the payment.</dd>
+        <dt><code>capture</code></dt>
+        <dd>A request to capture the details of the payer (and possibly the payment itself) for future use.</dd>
+        <dt><code>repeat-debit</code></dt>
+        <dd>A request to peform repeated future debits against the payer's account. This may be for any recurring
+          payment such as a subscription. The details of the recurring payment should be handled by the payment
+          method.</dd>
+        <dt><code>repeat-credit</code></dt>
+        <dd>A request to peform repeated future credits against the payer's account. This may be for any recurring
+          credit such as a wage payment or proceeds of a sale. The details of the recurring payment should be
+          handled by the payment method.</dd>
+      </dl>
+    </section>
+
+    <section>
       <h2>PaymentItem dictionary</h2>
       <pre class="idl">
         dictionary PaymentItem {
           required DOMString id;
           required DOMString label;
+          required TransactionType type;
           required CurrencyAmount amount;
         };
       </pre>
       <p>
         A sequence of one or more <code>PaymentItem</code> dictionaries is included in the <a><code>PaymentDetails</code></a>
-        dictionary to indicate the what the payment request is for and the value asked for.
+        dictionary to indicate what the payment request is for and the value asked for.
+      </p>
+      <p>
+        The <a>user agent</a> MAY use the provided <code>PaymentItem</code> dictionaries to infer appropriate user interface details
+        to be displayed to the user.
       </p>
       <p>
         The following fields MUST be included in a <code>PaymentItem</code> for it to be valid:
@@ -706,7 +768,10 @@ dictionary PaymentOptions {
         unique for a given <a><code>PaymentRequest</code></a>.</dd>
         <dt><code>label</code></dt>
         <dd>This is a human-readable description of the item. The <a>user agent</a> may display
-        this to the user.</dd>
+          this to the user.</dd>
+        <dt><code>type</code> (Defaults to <code>debit</code>.)</dt>
+        <dd>The type of transaction that should be performed for this line item. The value for all but the
+          last line item SHOULD be either <code>debit</code> or <code>credit</code>.</dd>
         <dt><code>amount</code></dt>
         <dd>
           A <a><code>CurrencyAmount</code></a> containing the monetary amount for the item.

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -689,6 +689,7 @@ dictionary PaymentOptions {
 
     <section>
       <h2>Transaction Types</h2>
+
       <pre class="idl">
 
         enum TransactionType {
@@ -700,10 +701,14 @@ dictionary PaymentOptions {
           "repeat-credit"
         };
       </pre>
-      <div class="issue" title="Should the set of transaction types be fixed?">
+      <div class="issue" data-number="112" title="Should the set of transaction types be fixed?">
         Defining a fixed list will allow <a>user agents</a> to manage the user interface for each transaction type
         appropriately however it is possible that new payment methods may wish to define new types that are not
         currently widely known.
+      </div>
+      <div class="issue" data-number="19" title="What is the appropriate set of payment method agnostic transaction types?">
+        There is currently a discussion around the approriate set of transaction types that should be defined in this
+        specification. This list is just the initial proposal.
       </div>
       <p>
         The <code>type</code> attribute of a <code>PaymentItem</code> provides hints to the <a>user agent</a>


### PR DESCRIPTION
The TransaactionType is a new property of the PaymentItem which helps
the user agent infer appropriate display logic for the payment such as
locale appropriate values display and button labels.

Addresses:
https://github.com/w3c/browser-payment-api/issues/56
https://github.com/w3c/browser-payment-api/issues/19
