### PR TITLE
Specification of required fields

### DIFF
--- a/specs/basic-card-payment.html
+++ b/specs/basic-card-payment.html
@@ -142,14 +142,21 @@
 
       <table>
         <tr><th>Identifier String</th><th>Description</th></tr>
-        <tr><td>visa</td><td>Visa (Credit, Debit, Delta or Electron)</td></tr>
-        <tr><td>mastercard</td><td>MasterCard and EuroCard</td></tr>
+        <tr><td>visa</td><td>Visa (Credit, Debit and Electron)</td></tr>
+        <tr><td>visa/credit</td><td>Visa Credit</td></tr>
+        <tr><td>visa/debit</td><td>Visa Debit</td></tr>
+        <tr><td>visa/electron</td><td>Visa Electron</td></tr>
+        <tr><td>mastercard</td><td>MasterCard (and EuroCard)</td></tr>
+        <tr><td>mastercard/credit</td><td>MasterCard Credit</td></tr>
+        <tr><td>mastercard/debit</td><td>MasterCard Debit</td></tr>
         <tr><td>amex</td><td>American Express</td></tr>
         <tr><td>discover</td><td>Discover</td></tr>
         <tr><td>maestro</td><td>Maestro</td></tr>
 	    <tr><td>diners</td><td>Diners Club</td></tr>
         <tr><td>jcb</td><td>JCB</td></tr>
-	    <tr><td>unionpay</td><td>Union Pay</td></tr>
+	    <tr><td>unionpay</td><td>UnionPay</td></tr>
+	    <tr><td>unionpay/credit</td><td>UnionPay Credit</td></tr>
+	    <tr><td>unionpay/debit</td><td>UnionPay Debit</td></tr>
       </table>
     </section>
 

--- a/specs/basic-card-payment.html
+++ b/specs/basic-card-payment.html
@@ -166,8 +166,33 @@
       <h2>Payment Method Specific Data for the PaymentRequest constructor</h2>
       <p>This section describes payment method specific data that is supplied as part of the <code>data</code>
       argument to the PaymentRequest constructor.</p>
-      <p>There is no payment method specific data used by the PaymentRequest constructor when processing
-      Basic Card Payment methods.</p>
+      <p>The PaymentRequest constructor can optionally take a BaseRequest object to indicate where generally optional fields in the BasicCardResponse
+	  must be returned for this instance</p>
+	  
+	  
+	  <section>
+      <h2>BaseRequestData</h2>
+      <pre class="idl">
+        dictionary BaseRequestData {
+          sequence<DOMString> requiredFields;
+        };
+      </pre>
+
+      <p>
+        The <code>BasicRequestData</code> dictionary contains the following fields:
+      </p>
+
+      <dl>
+        <dt><dfn><code>requiredFields</code></dfn></dt>
+        <dd>The <code>requiredFields</code> field contains the list of fields that the Payment App must attempt to return, if this requirements cannot be met, e.g. the payment instrument does not support that field, an empty field must be returned to indicate this</dd>
+      </dl>
+
+      </section>
+	  
+	<div class="issue" title="Should BasicRequest be moved into PaymentRequestAPI">
+      This type should be generic to any PaymentRequest and should be moved to the PaymentRequest API as a base type
+    </div>
+	
     </section>
 
     <section id="response">
@@ -179,10 +204,10 @@
       <h2>BasicCardResponse</h2>
       <pre class="idl">
         dictionary BasicCardResponse {
-          required DOMString cardholderName;
+          DOMString cardholderName;
           required DOMString cardNumber;
-          required DOMString expiryMonth;
-          required DOMString expiryYear;
+          DOMString expiryMonth;
+          DOMString expiryYear;
 		  DOMString cardSecurityCode;
 		  
           BillingAddress? billingAddress;


### PR DESCRIPTION
I'm suggesting a sequence string field that allows mandatory fields to
be specified and have removed some of the 'required' specifications in
the BasicCardResponse, related to discussion on
#9. I've only left PAN as

required as I think that is a safe assumption, then the merchant can
specify for example that CSC must be supplied for a particular
transaction using the requiredFields sequence in the BaseRequestData
dictionary.

I'm suggesting that if we like this model, we would move this
BaseRequestData dictionary object into the PaymentRequest API spec to
allow other payment methods to extend it.

I'm sure there are other ways to do this and am a newbie to
WebIDL/JavaScript APIs, so please forgive  if I've modelled this
completely wrong for the language. I'll learn!
