### PR TITLE
Make other Payments-drafts refs be absolute URLs

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -38,7 +38,7 @@
           localBiblio:  {
               "PAYMENTARCH": {
                   title:    "Payment Request Architecture"
-              ,   href:     "architecture.html"
+              ,   href:     "https://w3c.github.io/browser-payment-api/specs/architecture.html"
               ,   authors:  [
                       "Adrian Bateman"
                   ,   "Zach Koch"
@@ -48,7 +48,7 @@
               },
               "METHODIDENTIFIERS": {
                   title:    "Payment Method Identifiers"
-              ,   href:     "method-identifiers.html"
+              ,   href:     "https://w3c.github.io/browser-payment-api/specs/method-identifiers.html"
               ,   authors:  [
                       "Adrian Bateman"
                   ,   "Zach Koch"


### PR DESCRIPTION
I don’t think we’re going to be allowed to publish the API FPWD with relative URLs in the References section. The URLs need to absolute. And when we publish the FPWDs of the specs, they are not going to be relative to one other in the same way but instead will each of their own shortname under `www.w3.org/TR/`

We’re allowed to list EDs in the References section, so I suggest we just put the ED URLs and keep them until the point in the W3C process where we need to reference the `www.w3.org/TR/` equivalents (which I think will not be strictly necessary until the specs go to Rec).
