### PR TITLE
De-duplicate markup for “user agents” def

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -613,7 +613,7 @@ dictionary CurrencyAmount {
           <code>currency</code> is a string containing a currency identifier. The most common
           identifiers are three-letter alphabetic codes as defined by [[!ISO4217]] (for example,
           <code>"USD"</code> for US Dollars) however any string is considered valid and
-          <dfn data-lt="user agents">user agents</dfn> MUST not attempt to validate this string.
+          <a>user agents</a> MUST not attempt to validate this string.
         </dd>
         <dt><code><dfn>value</dfn></code></dt>
         <dd>


### PR DESCRIPTION
The current markup defines _user agents_ twice, and causes Respec to emit errors about that.
