### PR TITLE
fields in abort() Update paymentrequest.html

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -500,14 +500,14 @@
       <section>
         <h2>abort()</h2>
         <p>The <code><dfn>abort</dfn></code> method may be called if the web page wishes to abort the payment
-        request after the <a><code>show</code></a> method has been called and before the <em>request</em>[[\acceptPromise]]
+        request after the <a><code>show</code></a> method has been called and before the <em>request</em>@[[\acceptPromise]]
         has been resolved.</p>
 
         <p>The <a><code>abort</code></a> method MUST act as follows:</p>
         <ol>
-          <li>If the value of <em>request</em>[[\state]] is not <em>interactive</em> then
+          <li>If the value of <em>request</em>@[[\state]] is not <em>interactive</em> then
           <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
-          <li>Set the value of the internal slot <em>request</em>[[\state]] to <em>closed</em>.</li>
+          <li>Set the value of the internal slot <em>request</em>@[[\state]] to <em>closed</em>.</li>
           <li>Return from the method and asynchronously perform the remaining steps.</li>
           <li>Abort the current user interaction and close down any remaining user interface</li>
         </ol>

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -500,14 +500,14 @@
       <section>
         <h2>abort()</h2>
         <p>The <code><dfn>abort</dfn></code> method may be called if the web page wishes to abort the payment
-        request after the <a><code>show</code></a> method has been called and before the [[\acceptPromise]]
+        request after the <a><code>show</code></a> method has been called and before the <em>request</em>[[\acceptPromise]]
         has been resolved.</p>
 
         <p>The <a><code>abort</code></a> method MUST act as follows:</p>
         <ol>
-          <li>If the value of [[\state]] is not <em>interactive</em> then
+          <li>If the value of <em>request</em>[[\state]] is not <em>interactive</em> then
           <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
-          <li>Set the value of the internal slot [[\state]] to <em>closed</em>.</li>
+          <li>Set the value of the internal slot <em>request</em>[[\state]] to <em>closed</em>.</li>
           <li>Return from the method and asynchronously perform the remaining steps.</li>
           <li>Abort the current user interaction and close down any remaining user interface</li>
         </ol>

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -1175,7 +1175,7 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
           </li>
           <li>
             If <em>request</em>@[[\state]] is not <em>interactive</em> and
-            the not <code>delegated</code>, then terminate this algorithm and take no further action.
+            not <code>delegated</code>, then terminate this algorithm and take no further action.
             The <a>user agent</a> user interface should ensure that this never occurs.
           </li>
           <li>

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -500,11 +500,14 @@
       <section>
         <h2>abort()</h2>
         <p>The <code><dfn>abort</dfn></code> method may be called if the web page wishes to abort the payment
-        request after the <a><code>show</code></a> method has been called and before the <em>request</em>@[[\acceptPromise]]
+        <em>request</em> after the <a><code>show</code></a> method has been called and before the <em>request</em>@[[\acceptPromise]]
         has been resolved.</p>
 
         <p>The <a><code>abort</code></a> method MUST act as follows:</p>
         <ol>
+          <li>
+            Let <em>request</em> be the <a><code>PaymentRequest</code></a> object on which the method is called..
+          </li>
           <li>If the value of <em>request</em>@[[\state]] is not <em>interactive</em> then
           <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
           <li>Set the value of the internal slot <em>request</em>@[[\state]] to <em>closed</em>.</li>

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -710,7 +710,7 @@ dictionary PaymentOptions {
           a shipping address as part of the payment request. For example, this would be set to
           <code>true</code> when physical goods need to be shipped by the merchant to the user.
           This would be set to <code>false</code> for an online-only electronic purchase transaction.
-          If this value is not supplied then the the <a><code>PaymentRequest</code></a> behaves as
+          If this value is not supplied then the <a><code>PaymentRequest</code></a> behaves as
           if a value of <code>false</code> had been supplied.
         </dd>
       </dl>


### PR DESCRIPTION
Hi,
https://cdn.rawgit.com/w3c/browser-payment-api/0d1d5d7ff0f1bb7b37970994f1eb719101aaccbc/fpwd/paymentrequest.html#abort

I think that “ [[“ should be replaced by “request@[[“ in this section.
E.g.: “If the value of [[state]] is not interactive then throw an InvalidStateError.” Should be “If the value of request@[[state]] is not interactive then throw an InvalidStateError.”

Kind regards
Axel

The default branch is gh-pages but my understanding of how w3c specs at github work is that gh-pages should not be touched by humans.
