### PR TITLE
Remove issue #119 note and assert that total should be non-negative

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -390,8 +390,12 @@
             </div>
           </li>
           <li>
-            If <code>details</code> does not contain a sequence of <code>items</code> with length greater
-            than zero, then <a>throw</a> a <a><code>TypeError</code></a>.
+            If <code>details</code> does not contain a value for <code>total</code>, then throw a
+            <a><code>TypeError</code></a>.
+          </li>
+          <li>
+            If the first character of <code>details.total.amount.value</code> is U+002D HYPHEN-MINUS, then throw a
+            <a><code>TypeError</code></a>. <code>total</code> MUST be a non-negative amount.
           </li>
           <li>
             For each <a><code>PaymentMethodData</code></a> in <code>methodData</code>, if the <code>data</code> field

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -601,13 +601,6 @@ dictionary CurrencyAmount {
   required DOMString value;
 };
       </pre>
-      <div class="issue" data-number="119" title="Should negative amounts be reflected using signed values?">  
-      The resolution of the WG per <a href="https://github.com/w3c/webpayments/issues/57"> Issue #57</a> defined  
-      a format for currencies and amounts that lacked support for negative values. The format below adds this  
-      capability in a way that is not common for financial messaging standards (using signed numbers). The
-      rationale for negative numbers is to support discounts. The group is still discussing whether functionality
-      to support discounts might be implemented in a different manner (e.g., via a transaction type).
-      </div>  
       <p>
         A <a><code>CurrencyAmount</code></a> dictionary is used to supply monetary amounts.
         The following fields MUST be supplied for a <a><code>CurrencyAmount</code></a> to be valid:
@@ -663,6 +656,10 @@ dictionary PaymentDetails {
         <dt><code>total</code></dt>
         <dd>
           This <a><code>PaymentItem</code></a> contains the total amount of the payment request.
+          <p>
+            <code>total</code> MUST be a non-negative value. This means that the <code>total.amount.value</code>
+            field MUST NOT begin with a U+002D HYPHEN-MINUS character.
+          </p>
         </dd>
         <dt><code>displayItems</code></dt>
         <dd>


### PR DESCRIPTION
`CurrentAmount` defines a monetary value. It is currently used in two places in the PaymentRequest API:
- In the total field indicating the total amount of the payment request; and
- In the `displayItems` collection that contain optional line items to be displayed by the user agent.

For the first version of the specification, I propose that we shouldn't try to address the meaning of a negative total. Changing the direction of the payment request and supporting things like refunds should be out of scope (at least for now). This means that we should assert that total must be a non-negative number.

A common use case for the `displayItems` will be to show discounts. These are commonly shown on web pages as negative amounts. For example, here is a recent order summary from a transaction I made:

![image](https://cloud.githubusercontent.com/assets/2166064/14902858/513aa794-0d52-11e6-84ce-238f5eb80194.png)

There has been some discussion about whether the API should use "[financial industry norms and  existing payment messaging standards like ISO20022 and ISO8583](https://github.com/w3c/browser-payment-api/issues/119#issue-145613354)." This would presumably lead us to use terms like debit and credit for values. However, we're not designing an API for the financial industry - we're designing it for web developers who are trying to construct the UX shown above. In the PaymentRequest API, negative amounts are only ever used for display. In the checkout case, for example, it is clear what a negative number means here. Web developers will be more confused if we ask them to think in terms of debit and credit.

I believe we should keep the current spec text for negative amounts. It is simple determine if a value is negative (by testing whether the first character is U+002D HYPHEN-MINUS). It is more succinct than requiring an additional field in the dictionary to indicate a negative value. Web developers will readily understand what it is for.

This pull request removes the issue #119 note and asserts that total must be non-negative.

Fixes #119.
