### PR TITLE
Adding support for phone and email

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -688,6 +688,8 @@ dictionary PaymentDetails {
       <h2>PaymentOptions dictionary</h2>
       <pre class="idl">
 dictionary PaymentOptions {
+  boolean requestPayerEmail = false;
+  boolean requestPayerPhone = false;
   boolean requestShipping = false;
 };
       </pre>
@@ -700,14 +702,24 @@ dictionary PaymentOptions {
         The following fields MAY be passed to the <a><code>PaymentRequest</code></a> constructor:
       </p>
       <dl>
+        <dt><code><dfn>requestPayerEmail</dfn></code></dt>
+        <dd>
+          This <em>boolean</em> value indicates whether the <a>user agent</a> should collect and return
+          the payer's email address as part of the payment request. For example, this would be set to
+          <code>true</code> to allow a merchant to email a receipt.
+        </dd>
+        <dt><code><dfn>requestPayerPhone</dfn></code></dt>
+        <dd>
+          This <em>boolean</em> value indicates whether the <a>user agent</a> should collect and return
+          the payer's phone number as part of the payment request. For example, this would be set to
+          <code>true</code> to allow a merchant to phone a customer with a billing enquiry.
+        </dd>
         <dt><code><dfn>requestShipping</dfn></code></dt>
         <dd>
           This <em>boolean</em> value indicates whether the <a>user agent</a> should collect and return
           a shipping address as part of the payment request. For example, this would be set to
           <code>true</code> when physical goods need to be shipped by the merchant to the user.
           This would be set to <code>false</code> for an online-only electronic purchase transaction.
-          If this value is not supplied then the <a><code>PaymentRequest</code></a> behaves as
-          if a value of <code>false</code> had been supplied.
         </dd>
       </dl>
     </section>
@@ -760,6 +772,7 @@ dictionary PaymentOptions {
           readonly attribute DOMString languageCode;
           readonly attribute DOMString organization;
           readonly attribute DOMString recipient;
+          readonly attribute DOMString phone;
         };
       </pre>
       <dl>
@@ -788,6 +801,8 @@ dictionary PaymentOptions {
         <dd>This is the organization, firm, company, or institution at this address.</dd>
         <dt><code>recipient</code></dt>
         <dd>This is the name of the recipient or contact person.</dd>
+        <dt><code>phone</code></dt>
+        <dd>This is the phone number of the recipient or contact person.</dd>
       </dl>
       <p>
         If the <a>requestShipping</a> flag was set to <code>true</code> in the <a>PaymentOptions</a>
@@ -842,6 +857,8 @@ dictionary PaymentOptions {
           readonly attribute DOMString methodName;
           readonly attribute object details;
           readonly attribute ShippingAddress? shippingAddress;
+          readonly attribute DOMString? payerEmail;
+          readonly attribute DOMString? payerPhone;
 
           Promise&lt;void&gt; complete(optional PaymentComplete result = "");
         };
@@ -868,6 +885,18 @@ dictionary PaymentOptions {
         If the <a>requestShipping</a> flag was set to <code>true</code> in the <a>PaymentOptions</a>
         passed to the <a>PaymentRequest</a> constructor, then <a><code>shippingAddress</code></a> will
         be the full and final shipping address chosen by the user.
+      </dd>
+      <dt><code><dfn>payerEmail</dfn></code></dt>
+      <dd>
+        If the <a>requestPayerEmail</a> flag was set to <code>true</code> in the <a>PaymentOptions</a>
+        passed to the <a>PaymentRequest</a> constructor, then <a><code>payerEmail</code></a> will
+        be the email address chosen by the user.
+      </dd>
+      <dt><code><dfn>payerPhone</dfn></code></dt>
+      <dd>
+        If the <a>requestPayerPhone</a> flag was set to <code>true</code> in the <a>PaymentOptions</a>
+        passed to the <a>PaymentRequest</a> constructor, then <a><code>payerPhone</code></a> will
+        be the phone number chosen by the user.
       </dd>
       </dl>
 
@@ -1229,6 +1258,21 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             containing the <a>payment method</a> specific message used by the merchant to process
             the transaction. The format of this response will be defined by a <a>Payment Transaction
             Message Specification</a>.
+          </li>
+          <li>
+            If the <code>requestShipping</code> value of <em>request</em>@[[\options]]
+            is <code>true</code>, then copy the <code>shippingAddress</code> attribute of
+            <em>request</em> to the <code>shippingAddress</code> attribute of <em>response</em>.
+          </li>
+          <li>
+            If the <code>requestPayerEmail</code> value of <em>request</em>@[[\options]]
+            is <code>true</code>, then set the <code>payerEmail</code> attribute of
+            <em>response</em> to the payer's email address selected by the user.
+          </li>
+          <li>
+            If the <code>requestPayerPhone</code> value of <em>request</em>@[[\options]]
+            is <code>true</code>, then set the <code>payerPhone</code> attribute of
+            <em>response</em> to the payer's phone number selected by the user.
           </li>
           <li>
             Set <em>response</em>@[[\completeCalled]] to <em>false</em>.


### PR DESCRIPTION
This is a proposed solution for issue #1 and a counter proposal to PR
#65.

This change adds support for two new `PaymentOptions` for payer's email
and payer's phone number. These values are provided on the
`PaymentResponse` object. Since these values should not change the total
price, no `PaymentRequestUpdate` event is fired for them.

The change also adds a phone number to the `ShippingAddress` data
structure with the implication that this gets populated when
`requestShipping` is `true`.

Here are some variations to this change that should be considered:
- Do not include `requestPayerPhone` (issue #1 actually only mentions
  shipping phone number)
- Do include a `requestShippingPhone` value and only populate the
  `ShippingAddress.phone` value if both `requestShipping` and
  `requestShippingPhone` are true.
