### PR TITLE
Clarified value to use to resove [[acceptPromise]]

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -1244,7 +1244,7 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             Set <em>request</em>@[[\state]] to <em>closed</em>.
           </li>
           <li>
-            Resolve the pending promise <em>request</em>@[[\acceptPromise]].
+            Resolve the pending promise <em>request</em>@[[\acceptPromise]] with <em>response</em>.
           </li>
         </ol>
       </section>


### PR DESCRIPTION
I think this is implied by the purpose and signature of the show() method, but it's better to be explicit.
