### PR TITLE
Explain how to treat unrecognised complete values

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -935,8 +935,9 @@ dictionary PaymentOptions {
           </li>
           <li>Set the value of the internal slot [[\completeCalled]] to <em>true</em>.</li>
           <li>Return <em>promise</em> and asynchronously perform the remaining steps.</li>
-          <li>Close down any remaining user interface. The user agent MAY use the value <code>result</code>
-          to influence the user experience.</li>
+          <li>Close down any remaining user interface. The <a>user agent</a> MAY use the value <code>result</code>
+          to influence the user experience. <a>User agents</a> SHOULD treat unrecognized <code>result</code>
+          values as the value <code>""</code>.</li>
           <li>Resolve <em>promise</em> with <code>undefined</code>.</li>
         </ol>
 


### PR DESCRIPTION
I don't think we should make any further changes related to #122 for now. It's hard to make a trinary value fit into the promises model in an obvious way.

We should be clear on what to do with unrecognised values to allow us to add new ones in future.

Closes #122.
