### PR TITLE
Fix bug in updateWith algorithm that resets shippingOption

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -1058,7 +1058,7 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
         <p>If the web page wishes to update the payment request then it should call <a><code>updateWith</code></a>
         and provide a promise that will resolve with a <a><code>PaymentDetails</code></a>
         dictionary containing changed values that the <a>user agent</a> SHOULD present to the user.</p>
-        <p>The PaymentRequestUpdateEvent constructor MUST set the internal slot [[\waitForUpdate]]
+        <p>The <a>PaymentRequestUpdateEvent</a> constructor MUST set the internal slot [[\waitForUpdate]]
         to <em>false</em>.</p>
         <p>The <code><dfn>updateWith</dfn></code> method MUST act as follows:</p>
         <ol>
@@ -1110,25 +1110,30 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
                 this value to the <code>displayItems</code> field of <em>target</em>@[[\details]].
               </li>
               <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence, then
-                copy this value to the <code>shippingOptions</code> field of <em>target</em>@[[\details]].
-              </li>
-              <li>Let <em>newOption</em> be <em>null</em>.</li>
-              <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length of 1, then set <em>newOption</em> to the <code>id</code> of the only
-                <a><code>ShippingOption</code></a> in the sequence.
-              </li>
-              <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length greater than 1, and if any <a><code>ShippingOption</code></a> in the sequence
-                has the <code>selected</code> field set to <code>true</code>, then set
-                <em>newOption</em> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
-                in the sequence with <code>selected</code> set to <code>true</code>.
-              </li>
-              <li>
-                Set the value of <a><code>shippingOption</code></a> on <em>target</em> to
-                <em>newOption</em>.
+                If <code>details</code> contains a <code>shippingOptions</code> sequence, then:
+                <ol>
+                  <li>
+                    Copy the <code>shippingOptions</code> sequence from <code>details</code> to the
+                    <code>shippingOptions</code> field of <em>target</em>@[[\details]].
+                  </li>
+                  <li>Let <em>newOption</em> be <em>null</em>.</li>
+                  <li>
+                    If <code>details</code> contains a <code>shippingOptions</code> sequence with a
+                    length of 1, then set <em>newOption</em> to the <code>id</code> of the only
+                    <a><code>ShippingOption</code></a> in the sequence.
+                  </li>
+                  <li>
+                    If <code>details</code> contains a <code>shippingOptions</code> sequence with a
+                    length greater than 1, and if any <a><code>ShippingOption</code></a> in the sequence
+                    has the <code>selected</code> field set to <code>true</code>, then set
+                    <em>newOption</em> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
+                    in the sequence with <code>selected</code> set to <code>true</code>.
+                  </li>
+                  <li>
+                    Set the value of <a><code>shippingOption</code></a> on <em>target</em> to
+                    <em>newOption</em>.
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>


### PR DESCRIPTION
There is a bug in the `updateWith` algorithm for `shippingOption`. If you do not include a new `shippingOptions` sequence in the `details` object then the current shipping option is set to null. This change ensures that the shipping option recalculation is only performed if a new sequence is provided (as originally planned).
