### PR TITLE
Proposal to abort if updateWith promise is rejected

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,8 +400,17 @@
         <a><code>TypeError</code></a>. <code>total</code> MUST be a non-negative amount.
       </li>
       <li>
+        If a <a>payment method identifier</a> appears more than once in the <code>methodData</code>
+        or <code>details.modififiers</code> sequences, then <a>throw</a> a <a><code>TypeError</code></a>.
+      </li>
+      <li>
         For each <a><code>PaymentMethodData</code></a> in <code>methodData</code>, if the <code>data</code> field
         is supplied but is not a <a>JSON-serializable object</a>, then <a>throw</a> a <a><code>TypeError</code></a>.
+      </li>
+      <li>
+        For each <a><code>PaymentDetailsModifier</code></a> in <code>details.modifiers</code>, if the <code>total</code> field
+        is supplied and the first character of <code>total.amount.value</code> is U+002D HYPHEN-MINUS, then throw a
+        <a><code>TypeError</code></a>. <code>total</code> MUST be a non-negative amount.
       </li>
       <li>Let <em>request</em> be a new <a><code>PaymentRequest</code></a>.</li>
       <li>
@@ -686,6 +695,7 @@ dictionary PaymentDetails {
   PaymentItem total;
   sequence&lt;PaymentItem&gt; displayItems;
   sequence&lt;PaymentShippingOption&gt; shippingOptions;
+  sequence&lt;PaymentDetailsModifier&gt; modifiers;
 };
       </pre>
 
@@ -737,6 +747,57 @@ dictionary PaymentDetails {
         field set to <code>true</code>, then authors SHOULD ensure that the <code>total</code> field includes
         the cost of the shipping option. This is because no <a><code>shippingoptionchange</code></a> event
         will be fired for this option unless the user selects an alternative option first.
+      </p>
+    </dd>
+    <dt><code>modifiers</code></dt>
+    <dd>
+      This sequence of <a><code>PaymentDetailsModifier</code></a> dictionaries contains modifiers
+      for particular payment method identifiers. For example, it allows you to adjust the total
+      amount based on payment method.
+    </dd>
+  </dl>
+</section>
+
+<section>
+  <h2>PaymentDetailsModifier dictionary</h2>
+  <pre class="idl">
+    dictionary PaymentDetailsModifier {
+      required sequence&lt;DOMString&gt; supportedMethods;
+      PaymentItem total;
+      sequence&lt;PaymentItem&gt; additionalDisplayItems;
+    };
+  </pre>
+
+  <p>
+    The <code><dfn>PaymentDetailsModifier</dfn></code> dictionary provides details that modify the
+    <a><code>PaymentDetails</code></a> based on <a>payment method identifier</a>. It contains the
+    following fields:
+  </p>
+
+  <dl>
+    <dt><code>supportedMethods</code></dt>
+    <dd>
+      The <code>supportedMethods</code> field contains a sequence of <a>payment method identifiers</a>.
+      The remaining fields in the <a><code>PaymentDetailsModifier</code></a> apply only if the user selects
+      a <a>payment method</a> included in this sequence.
+    </dd>
+    <dt><code>total</code></dt>
+    <dd>
+      This <a><code>PaymentItem</code></a> value overrides the <code>total</code> field in the
+      <a><code>PaymentDetails</code></a> dictionary for the <a>payment method identifiers</a>
+      in the <code>supportedMethods</code> field.
+    </dd>
+    <dt><code>additionalDisplayItems</code></dt>
+    <dd>
+      This sequence of <a><code>PaymentItem</code></a> dictionaries provides additional display
+      items that are appended to the <code>displayItems</code> field in the <a><code>PaymentDetails</code></a>
+      dictionary for the <a>payment method identifiers</a> in the <code>supportedMethods</code>
+      field. This field is commonly used to add a discount or surcharge line item indicating the
+      reason for the different <code>total</code> amount for the selected <a>payment method</a>
+      that the user agent MAY display.
+      <p>
+      The user agent MAY validate that the <code>total</code> amount is the sum of the <code>displayItems</code>
+      and the <code>additionalDisplayItems</code>, but it is the responsibility of the calling code to ensure that.
       </p>
     </dd>
   </dl>
@@ -921,6 +982,7 @@ dictionary PaymentOptions {
 
         interface PaymentResponse {
           readonly attribute DOMString methodName;
+          readonly attribute PaymentCurrencyAmount totalAmount;
           readonly attribute object details;
           readonly attribute PaymentAddress? shippingAddress;
           readonly attribute DOMString? payerEmail;
@@ -938,6 +1000,15 @@ dictionary PaymentOptions {
     <dt><code><dfn>methodName</dfn></code></dt>
     <dd>
       The <a>payment method identifier</a> for the <a>payment method</a> that the user selected
+      to fulfil the transaction.
+    </dd>
+    <dt><code>totalAmount</code></dt>
+    <dd>
+      This is the <code>amount</code> value from the <a><code>PaymentItem</code></a> representing
+      the payment request total. This will either be the <code>total.amount</code> value from
+      the <a><code>PaymentDetails</code></a> dictionary for the payment request or it will
+      be the <code>total.amount</code> value from a <a><code>PaymentDetailsModifier</code></a>
+      matching the <a>payment method identifier</a> for the <a>payment method</a> that the user selected
       to fulfil the transaction.
     </dd>
     <dt><code><dfn>details</dfn></code></dt>
@@ -1115,6 +1186,10 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             this value to the <code>displayItems</code> field of <em>target</em>@[[\details]].
           </li>
           <li>
+            If <code>details</code> contains a <code>modifiers</code> value, then copy
+            this value to the <code>modifiers</code> field of <em>target</em>@[[\details]].
+          </li>
+          <li>
             If <code>details</code> contains a <code>shippingOptions</code> sequence, then:
             <ol>
               <li>
@@ -1268,6 +1343,18 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
       <li>
         Set the <code>methodName</code> attribute value of <em>response</em> to the <a>payment method identifier</a>
         for the <a>payment method</a> that the user selected to accept the payment.
+      </li>
+      <li>
+        Let <em>amount</em> be the <code>total.amount</code> value from <em>request</em>@[[\details]].
+      </li>
+      <li>
+        If there is a <a><code>PaymentDetailsModifier</code></a> <em>modifier</em> in the <code>modifiers</code> sequence
+        in <em>request</em>@[[\details]] that matches the <a>payment method identifier</a> for the
+        <a>payment method</a> that the user selected to accept the payment, then let <em>amount</em>
+        be the <code>total.amount</code> value from <em>modifier</em>.
+      </li>
+      <li>
+        Set the <code>totalAmount</code> attribute value of <em>response</em> to <em>amount</em>.
       </li>
       <li>
         Set the <code>details</code> attribute value of <em>response</em> to a <a>JSON-serializable object</a>

--- a/index.html
+++ b/index.html
@@ -1065,92 +1065,112 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
       dictionary containing changed values that the <a>user agent</a> SHOULD present to the user.</p>
     <p>The <a>PaymentRequestUpdateEvent</a> constructor MUST set the internal slot [[\waitForUpdate]]
       to <em>false</em>.</p>
-    <p>The <code><dfn>updateWith</dfn></code> method MUST act as follows:</p>
-    <ol>
-      <li>
-        Let <em>target</em> be the <a><code>PaymentRequest</code></a> object that is the target of
-        the event.
-      </li>
-      <li>If the <a>dispatch flag</a> is unset, then <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
-      <li>
-        If [[\waitForUpdate]] is <em>true</em>, then <a>throw</a> an <a><code>InvalidStateError</code></a>.
-      </li>
-      <li>
-        If <em>target</em>@[[\state]] is not <em>interactive</em>, then <a>throw</a> an
-        <a><code>InvalidStateError</code></a>.
-      </li>
-      <li>
-        If <em>target</em>@[[\updating]] is <em>true</em>, then <a>throw</a>
-        an <a><code>InvalidStateError</code></a>.
-      </li>
-      <li>Set the <a>stop propagation flag</a> and <a>stop immediate propagation flag</a>.</li>
-      <li>Set [[\waitForUpdate]] to <em>true</em>.</li>
-      <li>Set <em>target</em>@[[\updating]] to <em>true</em>.</li>
-      <li>
-        The <a>user agent</a> SHOULD disable the user interface that allows the user to accept
-        the payment request. This is to ensure that the payment is not accepted until the web page
-        has made changes required by the change. The web page MUST settle the promise <code>d</code>
-        to indicate that the payment request is valid again.
-        <p>The <a>user agent</a> SHOULD disable any part of the user interface that could cause
-          another update event to be fired. Only one update may be processed at a time.</p>
-        <div class="issue" title="Consider adding a timeout to the updating flag in case page doesn't resolve promise from updateWith">
-          We should consider adding a timeout mechanism so that if the page never resolves
-          the promise within a reasonable amount of time then the user agent behaves as if
-          the promise was rejected.
-        </div>
-      </li>
-      <li>Return from the method and asynchronously perform the remaining steps.</li>
-      <li>Wait until <code>d</code> settles.</li>
-      <li>If <code>d</code> is resolved with <code>details</code> and <code>details</code> is a
-        <a><code>PaymentDetails</code></a> dictionary, then:
-        <ol>
-          <li>
-            If <code>details</code> contains a <code>total</code> value and the first character of
-            <code>total.amount.value</code> is NOT U+002D HYPHEN-MINUS, then copy
-            <code>total</code> value to the <code>total</code> field of <em>target</em>@[[\details]]
-            (<code>total</code> MUST be a non-negative amount).
-          </li>
-          <li>
-            If <code>details</code> contains a <code>displayItems</code> value, then copy
-            this value to the <code>displayItems</code> field of <em>target</em>@[[\details]].
-          </li>
-          <li>
-            If <code>details</code> contains a <code>shippingOptions</code> sequence, then:
-            <ol>
-              <li>
-                Copy the <code>shippingOptions</code> sequence from <code>details</code> to the
-                <code>shippingOptions</code> field of <em>target</em>@[[\details]].
-              </li>
-              <li>Let <em>newOption</em> be <em>null</em>.</li>
-              <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length of 1, then set <em>newOption</em> to the <code>id</code> of the only
-                <a><code>ShippingOption</code></a> in the sequence.
-              </li>
-              <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length greater than 1, and if any <a><code>ShippingOption</code></a> in the sequence
-                has the <code>selected</code> field set to <code>true</code>, then set
-                <em>newOption</em> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
-                in the sequence with <code>selected</code> set to <code>true</code>.
-              </li>
-              <li>
-                Set the value of <a><code>shippingOption</code></a> on <em>target</em> to
-                <em>newOption</em>.
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-      <li>Set [[\waitForUpdate]] to <em>false</em>.</li>
-      <li>Set <em>target</em>@[[\updating]] to <em>false</em>.</li>
-      <li>
-        The <a>user agent</a> should update the user interface based on any changed values
-        in <em>target</em>. The user agent SHOULD re-enable user interface elements that might
-        have been disabled in the steps above if appropriate.
-      </li>
-    </ol>
 
+    <section>
+      <h2>updateWith()</h2>
+      <p>The <code><dfn>updateWith</dfn></code> method MUST act as follows:</p>
+      <ol>
+        <li>
+          Let <em>target</em> be the <a><code>PaymentRequest</code></a> object that is the target of
+          the event.
+        </li>
+        <li>If the <a>dispatch flag</a> is unset, then <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
+        <li>
+          If [[\waitForUpdate]] is <em>true</em>, then <a>throw</a> an <a><code>InvalidStateError</code></a>.
+        </li>
+        <li>
+          If <em>target</em>@[[\state]] is not <em>interactive</em>, then <a>throw</a> an
+          <a><code>InvalidStateError</code></a>.
+        </li>
+        <li>
+          If <em>target</em>@[[\updating]] is <em>true</em>, then <a>throw</a>
+          an <a><code>InvalidStateError</code></a>.
+        </li>
+        <li>Set the <a>stop propagation flag</a> and <a>stop immediate propagation flag</a>.</li>
+        <li>Set [[\waitForUpdate]] to <em>true</em>.</li>
+        <li>Set <em>target</em>@[[\updating]] to <em>true</em>.</li>
+        <li>
+          The <a>user agent</a> SHOULD disable the user interface that allows the user to accept
+          the payment request. This is to ensure that the payment is not accepted until the web page
+          has made changes required by the change. The web page MUST settle the promise <code>d</code>
+          to indicate that the payment request is valid again.
+          <p>The <a>user agent</a> SHOULD disable any part of the user interface that could cause
+            another update event to be fired. Only one update may be processed at a time.</p>
+          <div class="issue" title="Consider adding a timeout to the updating flag in case page doesn't resolve promise from updateWith">
+            We should consider adding a timeout mechanism so that if the page never resolves
+            the promise within a reasonable amount of time then the user agent behaves as if
+            the promise was rejected.
+          </div>
+        </li>
+        <li>Return from the method and asynchronously perform the remaining steps.</li>
+        <li>Wait until <code>d</code> settles.</li>
+        <li>If <code>d</code> is rejected, then:
+          <ol>
+            <li>Abort the current user interaction and close down any remaining user interface.</li>
+            <li>Set the value of the internal slot <em>target</em>@[[\state]] to <em>closed</em>.</li>
+            <li>Reject the promise <em>target</em>@[[\acceptPromise]] with an <a><code>AbortError</code></a>.</li>
+            <li>Abort this algorithm.</li>
+          </ol>
+          <div class="note">
+            If the promise <code>d</code> is rejected then this is a fatal error for the payment request.
+            This would potentially leave the payment request in an inconsistent state since the web page
+            hasn't successfully handled the change event. Consequently, if <code>d</code> is rejected then
+            the payment request is aborted.
+            <p>
+              <a>User agents</a> MAY show an error message to the user when this occurs.
+            </p>
+          </div>
+        </li>
+        <li>If <code>d</code> is resolved with <code>details</code> and <code>details</code> is a
+          <a><code>PaymentDetails</code></a> dictionary, then:
+          <ol>
+            <li>
+              If <code>details</code> contains a <code>total</code> value and the first character of
+              <code>total.amount.value</code> is NOT U+002D HYPHEN-MINUS, then copy
+              <code>total</code> value to the <code>total</code> field of <em>target</em>@[[\details]]
+              (<code>total</code> MUST be a non-negative amount).
+            </li>
+            <li>
+              If <code>details</code> contains a <code>displayItems</code> value, then copy
+              this value to the <code>displayItems</code> field of <em>target</em>@[[\details]].
+            </li>
+            <li>
+              If <code>details</code> contains a <code>shippingOptions</code> sequence, then:
+              <ol>
+                <li>
+                  Copy the <code>shippingOptions</code> sequence from <code>details</code> to the
+                  <code>shippingOptions</code> field of <em>target</em>@[[\details]].
+                </li>
+                <li>Let <em>newOption</em> be <em>null</em>.</li>
+                <li>
+                  If <code>details</code> contains a <code>shippingOptions</code> sequence with a
+                  length of 1, then set <em>newOption</em> to the <code>id</code> of the only
+                  <a><code>ShippingOption</code></a> in the sequence.
+                </li>
+                <li>
+                  If <code>details</code> contains a <code>shippingOptions</code> sequence with a
+                  length greater than 1, and if any <a><code>ShippingOption</code></a> in the sequence
+                  has the <code>selected</code> field set to <code>true</code>, then set
+                  <em>newOption</em> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
+                  in the sequence with <code>selected</code> set to <code>true</code>.
+                </li>
+                <li>
+                  Set the value of <a><code>shippingOption</code></a> on <em>target</em> to
+                  <em>newOption</em>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>Set [[\waitForUpdate]] to <em>false</em>.</li>
+        <li>Set <em>target</em>@[[\updating]] to <em>false</em>.</li>
+        <li>
+          The <a>user agent</a> should update the user interface based on any changed values
+          in <em>target</em>. The user agent SHOULD re-enable user interface elements that might
+          have been disabled in the steps above if appropriate.
+        </li>
+      </ol>
+    </section>
   </section>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -291,10 +291,10 @@
       and the payment <code>options</code>.
     </p>
     <div class="issue" data-number="40" title="How does a website pass additional (not payment method specific) data to the payment app?">
-      It is proposed that a conformance criteria for implementations of this API be
+      It is proposed that a conformance criterion for implementations of this API be
       that any data passed into the request is passed on to the payment app unaltered.
       This would allow extensions of the data schema such as the addition of
-      properties that are not documented in this specification or known to implementors
+      properties that are not documented in this specification or known to implementers
       such as JSON-LD @context or similar to be passed between the website and
       payment app.
     </div>
@@ -660,7 +660,7 @@ dictionary PaymentCurrencyAmount {
     </dd>
     <dt><code><dfn>value</dfn></code></dt>
     <dd>
-      A string containing the decimal monetary value. If a decimal separator is needed then the string
+      A string containing the decimal monetary value. If a decimal separator is needed, then the string
       MUST use a single U+002E FULL STOP character as the decimal separator. The string MUST begin
       with a single U+002D HYPHEN-MINUS character if the value is negative. All other characters must
       be characters in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9).
@@ -709,7 +709,7 @@ dictionary PaymentDetails {
     <dt><code>displayItems</code></dt>
     <dd>
       This sequence of <a><code>PaymentItem</code></a> dictionaries contains line items
-      for the payment request that the user agent MAY display. For example, it might include
+      for the payment request that the <a>user agent</a> MAY display. For example, it might include
       details of products or breakdown of tax and shipping. It is optional to provide this
       information.
       <p>The <a>user agent</a> MAY validate that the <code>total</code> amount is the
@@ -880,7 +880,7 @@ dictionary PaymentOptions {
 </section>
 
 <section>
-      <h2>PaymentShippingOption interface</h2>
+      <h2>PaymentShippingOption dictionary</h2>
       <pre class="idl">
         dictionary PaymentShippingOption {
           required string id;
@@ -970,20 +970,20 @@ dictionary PaymentOptions {
     <h2>complete()</h2>
     <p>The <code><dfn>complete</dfn></code> method must be called after the user has accepted the payment
       request and the [[\acceptPromise]] has been resolved. Calling the <code>complete</code> method tells
-      the user agent that the user interaction is over (and should cause any remaining user interface to be
+      the <a>user agent</a> that the user interaction is over (and should cause any remaining user interface to be
       closed).</p>
     <p>The <code>complete</code> method takes a string argument from the <code><dfn>PaymentComplete</dfn></code>
-      enum (<code>result</code>). These values are used to influence the user experience provided by the user agent
+      enum (<code>result</code>). These values are used to influence the user experience provided by the <a>user agent</a>
       when the user interface is dismissed. The value of <code>result</code> has the following meaning:</p>
     <dl>
       <dt><dfn id="dom-paymentcomplete-success"><code>"success"</code></dfn></dt>
-      <dd>Indicates the payment was successfully processed. The user agent MAY display UI indicating
+      <dd>Indicates the payment was successfully processed. The <a>user agent</a> MAY display UI indicating
         success.</dd>
       <dt><dfn id="dom-paymentcomplete-fail"><code>"fail"</code></dfn></dt>
-      <dd>Indicates that processing of the payment failed. The user agent MAY display UI indicating
+      <dd>Indicates that processing of the payment failed. The <a>user agent</a> MAY display UI indicating
         failure.</dd>
       <dt><dfn id="dom-paymentcomplete-"><code>""</code></dfn></dt>
-      <dd>The web page did not indicate success or failure and the user agent SHOULD NOT display
+      <dd>The web page did not indicate success or failure and the <a>user agent</a> SHOULD NOT display
         UI indicating success or failure. This is the default value if the web page does not
         supply a value for <code>result</code>.</dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -432,13 +432,8 @@
         Set the value of the <a><code>shippingOption</code></a> attribute on <em>request</em> to <em>null</em>.
       </li>
       <li>
-        If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-        length of 1, then set <a><code>shippingOption</code></a> to the <code>id</code> of
-            the only <a><code>PaymentShippingOption</code></a> in the sequence.
-      </li>
-      <li>
-        If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-            length greater than 1, and if any <a><code>PaymentShippingOption</code></a> in the sequence
+        If <code>details</code> contains a <code>shippingOptions</code> sequence and
+        if any <a><code>PaymentShippingOption</code></a> in the sequence
         has the <code>selected</code> field set to <code>true</code>, then set
         <a><code>shippingOption</code></a> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
         in the sequence with <code>selected</code> set to <code>true</code>.
@@ -730,9 +725,6 @@ dictionary PaymentDetails {
       A sequence containing the different shipping options for the user to choose from.
       <p>If the sequence is empty, then this indicates that the merchant
         cannot ship to the current <a><code>shippingAddress</code></a>.</p>
-      <p>If the sequence only contains one item, then this is the shipping option that
-        will be used and <a><code>shippingOption</code></a> will be set to the <code>id</code>
-        of this option without running the <a>shipping option changed algorithm</a>.</p>
       <p>If an item in the sequence has the <code>selected</code> field set to <code>true</code>,
         then this is the shipping option that will be used by default and <a><code>shippingOption</code></a>
         will be set to the <code>id</code> of this option without running the <a>shipping option changed
@@ -743,7 +735,7 @@ dictionary PaymentDetails {
         constructed with <a><code>PaymentOptions</code></a> <code>requestShipping</code>
         set to <code>true</code>.</p>
       <p class="note">
-        If the sequence contains only one item or if the sequence has an item with the <code>selected</code>
+        If the sequence has an item with the <code>selected</code>
         field set to <code>true</code>, then authors SHOULD ensure that the <code>total</code> field includes
         the cost of the shipping option. This is because no <a><code>shippingoptionchange</code></a> event
         will be fired for this option unless the user selects an alternative option first.
@@ -1198,13 +1190,8 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
               </li>
               <li>Let <em>newOption</em> be <em>null</em>.</li>
               <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length of 1, then set <em>newOption</em> to the <code>id</code> of the only
-                <a><code>ShippingOption</code></a> in the sequence.
-              </li>
-              <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length greater than 1, and if any <a><code>ShippingOption</code></a> in the sequence
+                If <code>details</code> contains a <code>shippingOptions</code> sequence
+                and if any <a><code>ShippingOption</code></a> in the sequence
                 has the <code>selected</code> field set to <code>true</code>, then set
                 <em>newOption</em> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
                 in the sequence with <code>selected</code> set to <code>true</code>.


### PR DESCRIPTION
This is a proposal for how to handle #187. It causes the payment request to be aborted if the promise passed to `updateWith()` is then rejected.

If the promise passed to `updateWith()` is rejected then you end up in an inconsistent state. Either the page hasn't correctly processed the change event (which might mean it didn't correctly update the price, for example) or, if you revert the user's change, the user may end up in a state that they didn't expect. Neither option is good. Instead, after discussion with @zkoch, we're proposing that this aborts the payment request.
