### PR TITLE
Remove special case handling for single shipping option.

### DIFF
--- a/index.html
+++ b/index.html
@@ -715,9 +715,6 @@ dictionary PaymentDetails {
       A sequence containing the different shipping options for the user to choose from.
       <p>If the sequence is empty, then this indicates that the merchant
         cannot ship to the current <a><code>shippingAddress</code></a>.</p>
-      <p>If the sequence only contains one item, then this is the shipping option that
-        will be used and <a><code>shippingOption</code></a> will be set to the <code>id</code>
-        of this option without running the <a>shipping option changed algorithm</a>.</p>
       <p>If an item in the sequence has the <code>selected</code> field set to <code>true</code>,
         then this is the shipping option that will be used by default and <a><code>shippingOption</code></a>
         will be set to the <code>id</code> of this option without running the <a>shipping option changed
@@ -728,7 +725,7 @@ dictionary PaymentDetails {
         constructed with <a><code>PaymentOptions</code></a> <code>requestShipping</code>
         set to <code>true</code>.</p>
       <p class="note">
-        If the sequence contains only one item or if the sequence has an item with the <code>selected</code>
+        If the sequence has an item with the <code>selected</code>
         field set to <code>true</code>, then authors SHOULD ensure that the <code>total</code> field includes
         the cost of the shipping option. This is because no <a><code>shippingoptionchange</code></a> event
         will be fired for this option unless the user selects an alternative option first.

--- a/index.html
+++ b/index.html
@@ -423,13 +423,8 @@
         Set the value of the <a><code>shippingOption</code></a> attribute on <em>request</em> to <em>null</em>.
       </li>
       <li>
-        If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-        length of 1, then set <a><code>shippingOption</code></a> to the <code>id</code> of
-            the only <a><code>PaymentShippingOption</code></a> in the sequence.
-      </li>
-      <li>
-        If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-            length greater than 1, and if any <a><code>PaymentShippingOption</code></a> in the sequence
+        If <code>details</code> contains a <code>shippingOptions</code> sequence and
+        if any <a><code>PaymentShippingOption</code></a> in the sequence
         has the <code>selected</code> field set to <code>true</code>, then set
         <a><code>shippingOption</code></a> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
         in the sequence with <code>selected</code> set to <code>true</code>.
@@ -1123,13 +1118,8 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
               </li>
               <li>Let <em>newOption</em> be <em>null</em>.</li>
               <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length of 1, then set <em>newOption</em> to the <code>id</code> of the only
-                <a><code>ShippingOption</code></a> in the sequence.
-              </li>
-              <li>
-                If <code>details</code> contains a <code>shippingOptions</code> sequence with a
-                length greater than 1, and if any <a><code>ShippingOption</code></a> in the sequence
+                If <code>details</code> contains a <code>shippingOptions</code> sequence
+                and if any <a><code>ShippingOption</code></a> in the sequence
                 has the <code>selected</code> field set to <code>true</code>, then set
                 <em>newOption</em> to the <code>id</code> of the last <a><code>ShippingOption</code></a>
                 in the sequence with <code>selected</code> set to <code>true</code>.


### PR DESCRIPTION
We originally added special support for a single shipping option to allow a more streamlined user experience for the cases where you want to get a shipping address but you only have one shipping option. This means the user wouldn't have to select anything.

Since then, we added the `selected` field which allows you to indicate any shipping option should be the selected one. This means the special handling for a single option isn't really necessary any longer. If we remove this then it makes the mental model for developers easier. Developers are responsible for maintaining the selected state for shipping options. If they don't do this then an update to the shipping options causes the current option to be deselected and requires the user reselect.

One of the primary goals here is to ensure that a user never accepts a payment request with details they didn't expect. Another is that we should make it harder for web developer mistakes from misunderstanding the model to result in accepted payment requests with incorrect details. This proposal improves this by removing some of the magic from the API and making web developers be explicit.
