### PR TITLE
Remove unnecessary clause about validation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -655,8 +655,7 @@ dictionary PaymentCurrencyAmount {
     <dd>
       <code>currency</code> is a string containing a currency identifier. The most common
       identifiers are three-letter alphabetic codes as defined by [[!ISO4217]] (for example,
-      <code>"USD"</code> for US Dollars) however any string is considered valid and
-      <a data-lt="user agents">user agents</a> MUST not attempt to validate this string.
+      <code>"USD"</code> for US Dollars) however any string is considered valid.
     </dd>
     <dt><code><dfn>value</dfn></code></dt>
     <dd>


### PR DESCRIPTION
The spec doesn't define what it means to validate the currency string so it is impossible to know what NOT to do. Additionally, specs should describe what _should_ be done and not what should not be done in order to achieve the desired outcome.

Closes #175.
