### PR TITLE
Change “MUST…to be valid” to just “are required”

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,7 +612,9 @@ dictionary PaymentCurrencyAmount {
       </pre>
   <p>
         A <a><code>PaymentCurrencyAmount</code></a> dictionary is used to supply monetary amounts.
-        The following fields MUST be supplied for a <a><code>PaymentCurrencyAmount</code></a> to be valid:
+  </p>
+  <p>
+    The following fields are required:
   </p>
   <dl>
     <dt><code><dfn>currency</dfn></code></dt>
@@ -807,7 +809,7 @@ dictionary PaymentOptions {
     dictionary to indicate the what the payment request is for and the value asked for.
   </p>
   <p>
-    The following fields MUST be included in a <code>PaymentItem</code> for it to be valid:
+    The following fields are required:
   </p>
   <dl>
     <dt><code>label</code></dt>
@@ -899,7 +901,7 @@ dictionary PaymentOptions {
     method in response to a change event.
   </p>
   <p>
-    The following fields MUST be included in a <code>PaymentItem</code> for it to be valid:
+    The following fields are required:
   </p>
   <dl>
     <dt><code>id</code></dt>


### PR DESCRIPTION
There are several instances in the spec of this pattern:

> The following fields MUST be included in a FOO for it to be valid

One problem with those as normative statements is that the spec doesn’t explicitly define what ”to be valid” means or what must happen if an instance of something is found to not be “valid”.

But it doesn’t really matter because those statements are anyway just redundant with the requirements that are already normatively specified in the associated WebIDL definitions.

For example, [the WebIDL for PaymentCurrencyAmount](https://w3c.github.io/browser-payment-api/#paymentcurrencyamount) already normatively specifies the `currency` & `value` fields as `required`, so the normative statement after it that “The following fields must be supplied for a `PaymentCurrencyAmount` to be valid“ is redundant with what’s specified in the WebIDL.

So this PR replaces those redundant normative “The following fields MUST be included in a FOO for it to be valid:” instances with just the non-normative “The following fields are required:”
