### PR TITLE
Remove restriction that payment method identifier only appear once

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,10 +395,6 @@
         <a><code>TypeError</code></a>. <code>total</code> MUST be a non-negative amount.
       </li>
       <li>
-        If a <a>payment method identifier</a> appears more than once in the <code>methodData</code>
-        or <code>details.modifiers</code> sequences, then <a>throw</a> a <a><code>TypeError</code></a>.
-      </li>
-      <li>
         For each <a><code>PaymentMethodData</code></a> in <code>methodData</code>, if the <code>data</code> field
         is supplied but is not a <a>JSON-serializable object</a>, then <a>throw</a> a <a><code>TypeError</code></a>.
       </li>
@@ -755,6 +751,7 @@ dictionary PaymentDetails {
       required sequence&lt;DOMString&gt; supportedMethods;
       PaymentItem total;
       sequence&lt;PaymentItem&gt; additionalDisplayItems;
+      object data;
     };
   </pre>
 
@@ -790,6 +787,9 @@ dictionary PaymentDetails {
       and the <code>additionalDisplayItems</code>, but it is the responsibility of the calling code to ensure that.
       </p>
     </dd>
+    <dt><code>data</code></dt>
+    <dd><code>data</code> is a <a>JSON-serializable object</a> that provides optional information that
+      might be needed by the supported payment methods.</dd>
   </dl>
 </section>
 


### PR DESCRIPTION
Based on recent discussions about how to support payment modifiers with basic-card and different card types, we agreed that we need to support modifiers with the same identifier but different data. This change removes the restriction on a single identifier and adds the data field to supply the different data.

One use case for this is to support card payments with different modifiers for credit vs. debit cards.
