### PR TITLE
Remove explanation using "parties"

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,12 +109,12 @@
     checkout flows that support various payment schemes.</p>
 
   <p>This specification describes an API that allows <a>user agents</a> (e.g., browsers) to act
-    as an intermediary between the three key parties in every transaction: the merchant (e.g., an
-    online web store), the buyer (e.g., the user buying from the online web store), and the
-    <dfn data-lt="payment method|payment methods">Payment Method</dfn> (e.g., credit card). Information
-    necessary to process and confirm a transaction is passed between the <a>Payment Method</a> and the
-    merchant via the <a>user agent</a>  with the buyer confirming and authorizing as necessary across
-    the flow.</p>
+    as an intermediary between three systems in every transaction: the merchant (e.g., an
+    online web store), the buyer represented by the <a>user agent</a> (e.g., the user buying from the
+    online web store), and the <dfn data-lt="payment method|payment methods">Payment Method</dfn>
+    (e.g., credit card). Information necessary to process and confirm a transaction is passed between
+    the <a>Payment Method</a> and the  merchant via the <a>user agent</a> with the buyer confirming
+    and authorizing as necessary across the flow.</p>
 
   <p>In addition to better, more consistent user experiences, this also enables web sites to take
     advantage of more secure payment schemes (e.g., tokenization and system-level authentication)


### PR DESCRIPTION
Fixes #121.

Per @rsolomakhin's [comment](https://github.com/w3c/browser-payment-api/issues/121#issuecomment-227622592), removing use of the term "party" in the introduction.
