### PR TITLE
Fixed a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,7 +765,7 @@ dictionary PaymentDetails {
     <dd>
       When the payment request is updated using <a><code>updateWith</code></a>, the <code>PaymentDetails</code>
       can contain a message in the <code>error</code> field that will be displayed to the user. For example,
-      this might commonly be used to explain why good cannot be shipped to the chosen shipping address.
+      this might commonly be used to explain why goods cannot be shipped to the chosen shipping address.
       <p>
         The <code>error</code> field cannot be passed to the <a><code>PaymentRequest</code></a> constructor.
         Doing so will cause a <a><code>TypeError</code></a> to be thrown. 


### PR DESCRIPTION
Changing "explain why good cannot be shipped" to "explain why goods cannot be shipped".
