### PR TITLE
Remove must in complete()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,9 +1095,9 @@ dictionary PaymentDetails {
 
   <section>
     <h2>complete()</h2>
-    <p>The <code><dfn>complete</dfn></code> method must be called after the user has accepted the payment
+    <p>The <code><dfn>complete</dfn></code> method is called after the user has accepted the payment
       request and the [[\acceptPromise]] has been resolved. Calling the <code>complete</code> method tells
-      the <a>user agent</a> that the user interaction is over (and should cause any remaining user interface to be
+      the <a>user agent</a> that the user interaction is over (and SHOULD cause any remaining user interface to be
       closed).</p>
     <p>The <code>complete</code> method takes a string argument from the <code><dfn>PaymentComplete</dfn></code>
       enum (<code>result</code>). These values are used to influence the user experience provided by the <a>user agent</a>


### PR DESCRIPTION
The complete method description indicated that the method must be called after the user has accepted the payment request.  This use of "must" was a requirement on the web page, and as an RFC 2119 term was misleading.  

Also, there is a SHOULD requirement on user agents in the paragraph, but the SHOULD was not in upper case so it was not called out as an assertion.
