### PR TITLE
Change "SHOULD NEVER" to "MUST NOT"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2014,7 +2014,7 @@
           Exposing user information
         </h2>
         <p>
-          The <a>user agent</a> should never share information about the user
+          The <a>user agent</a> MUST NOT share information about the user
           to the web page (such as the shipping address) without user consent.
         </p>
       </section>


### PR DESCRIPTION
“Should never” is strong enough that if that is what we mean, then
we should use the corresponding RFC 2119 language.

If we mean less than MUST NOT, then let’s say “SHOULD NOT.”

In this edit I swap in MUST NOT for SHOULD NEVER because I think the
intention is the same.