### PR TITLE
Reference W3C HTML for allowpaymentrequest definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1521,44 +1521,23 @@
     </section>
     <section>
       <h2>
-        PaymentRequest and iframes
+        PaymentRequest and <code>iframe</code> elements
       </h2>
       <p>
-        There are some circumstances where a cross-origin <a>iframe</a> wants
-        to make a payment request. A cross-origin iframe needs explicit
-        permission from the embedding page to invoke the payment request API.
+        There are some circumstances where a cross-origin
+        <a><code>iframe</code></a> wants to make a payment request. A
+        cross-origin <a><code>iframe</code></a> needs explicit permission
+        from the embedding page to invoke the payment request API.
       </p>
       <p>
-        The <a>HTMLIFrameElement</a> is extended with an
-        <dfn><code>allowpaymentrequest</code></dfn> content attribute.
-        <a>allowpaymentrequest</a> is a <a>boolean attribute</a>. When
-        specified, it indicates that scripts in the iframe element's browsing
-        context are <dfn>allowed to make payment requests</dfn> (if it's not
-        blocked for other reasons, e.g., there is another ancestor iframe
-        without this attribute set).
+        When an <a><code>iframe</code></a> element has an
+        <a><code>allowpaymentrequest</code></a> attribute, and does not
+        have any ancestor <a><code>iframe</code></a> element without an
+        <a><code>allowpaymentrequest</code></a> attribute, then
+        <code>Document</code> objects in the <a><code>iframe</code></a>
+        element's <span>browsing context</span> are <dfn>allowed to
+        make payment requests</dfn>.
       </p>
-      <section data-dfn-for="HTMLIFrameElement">
-        <h2>
-          <code>HTMLIFrameElement</code> extension
-        </h2>
-        <p>
-          The iframe DOM interface is extended as follows:
-        </p>
-        <pre class="idl">
-          partial interface HTMLIFrameElement {
-              attribute boolean allowPaymentRequest;
-          };
-        </pre>
-        <dl>
-          <dt>
-            <code>allowPaymentRequest</code>
-          </dt>
-          <dd>
-            The <code>allowPaymentRequest</code> IDL attribute MUST
-            <a>reflect</a> the <a>allowpaymentrequest</a> content attribute.
-          </dd>
-        </dl>
-      </section>
     </section>
     <section>
       <h2>
@@ -2059,10 +2038,16 @@
           HTML 5.1
         </dt>
         <dd>
-          The terms <dfn>global object</dfn>, <dfn>boolean attribute</dfn>,
-          <dfn>reflect</dfn>, <dfn>iframe</dfn>, <dfn>queue a task</dfn>,
-          <dfn>browsing context</dfn>, <dfn>nested browsing context</dfn>, and
-          <dfn>top-level browsing context</dfn> are defined by [[!HTML51]].
+          The following are defined by [[!HTML51]]:
+          <ul>
+            <li><dfn>queue a task</dfn></li>
+            <li>the <dfn>Document</dfn> object</li>
+            <li><dfn>browsing context</dfn></li>
+            <li><dfn>nested browsing context</dfn></li>
+            <li><dfn>top-level browsing context</dfn><li>
+            <li>the <dfn>iframe</dfn> element</li>
+            <li>the <dfn>allowpaymentrequest</dfn> attribute</li>
+          </ul>
         </dd>
         <dt>
           ECMA-262 6th Edition, The ECMAScript 2015 Language Specification

--- a/index.html
+++ b/index.html
@@ -346,8 +346,10 @@
           <li>If the <a>browsing context</a> of the script calling the
           constructor is a <a>nested browsing context</a> whose origin is
           different from the <a>top-level browsing context</a>'s origin and the
-          nested browsing context is not <a>allowed to make payment
-          requests</a>, then <a>throw</a> a <a>SecurityError</a>.
+          nested <a>browsing context</a>'s <a>browsing context container</a>'s
+          <a>node document</a> is not <a>allowed to use</a> the feature
+          indicated by attribute name <a><code>allowpaymentrequest</code></a>,
+          then <a>throw</a> a <a>SecurityError</a>.
           </li>
           <li>If the <var>details</var> argument does not contain a value for
           <a data-lt="PaymentDetails.total">total</a>, then throw a
@@ -1519,24 +1521,15 @@
         </table>
       </section>
     </section>
-    <section>
+    <section class="informative">
       <h2>
         PaymentRequest and <code>iframe</code> elements
       </h2>
       <p>
-        There are some circumstances where a cross-origin
-        <a><code>iframe</code></a> wants to make a payment request. A
-        cross-origin <a><code>iframe</code></a> needs explicit permission
-        from the embedding page to invoke the payment request API.
-      </p>
-      <p>
-        When an <a><code>iframe</code></a> element has an
-        <a><code>allowpaymentrequest</code></a> attribute, and does not
-        have any ancestor <a><code>iframe</code></a> element without an
-        <a><code>allowpaymentrequest</code></a> attribute, then
-        <code>Document</code> objects in the <a><code>iframe</code></a>
-        element's <span>browsing context</span> are <dfn>allowed to
-        make payment requests</dfn>.
+        To indicate that a cross-origin <a><code>iframe</code></a> is
+        allowed to invoke the payment request API, the
+        <a><code>allowpaymentrequest</code></a> attribute can be
+        specified on the <a><code>iframe</code></a> element.
       </p>
     </section>
     <section>
@@ -2041,10 +2034,12 @@
           The following are defined by [[!HTML51]]:
           <ul>
             <li><dfn>queue a task</dfn></li>
-            <li>the <dfn>Document</dfn> object</li>
+            <li><dfn>node document</dfn></li>
             <li><dfn>browsing context</dfn></li>
+            <li><dfn>browsing context container</dfn></li>
             <li><dfn>nested browsing context</dfn></li>
-            <li><dfn>top-level browsing context</dfn><li>
+            <li><dfn>top-level browsing context</dfn></li>
+            <li><dfn>allowed to use</dfn></li>
             <li>the <dfn>iframe</dfn> element</li>
             <li>the <dfn>allowpaymentrequest</dfn> attribute</li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -343,13 +343,24 @@
               </li>
             </ol>
           </li>
-          <li>If the <a>browsing context</a> of the script calling the
-          constructor is a <a>nested browsing context</a> whose origin is
-          different from the <a>top-level browsing context</a>'s origin and the
-          nested <a>browsing context</a>'s <a>browsing context container</a>'s
-          <a>node document</a> is not <a>allowed to use</a> the feature
-          indicated by attribute name <a><code>allowpaymentrequest</code></a>,
-          then <a>throw</a> a <a>SecurityError</a>.
+          <li>If the constructor is called from a <a>nested browsing context</a>, then
+            <ol>
+              <li>
+                Let <var>context</var> be the <a>nested browsing context</a>.
+              </li>
+              <li>
+                Let <var>origin</var> be the origin of the <a>active document</a>
+                of <var>context</var>.
+              </li>
+              <li>
+                If any <a>ancestor browsing context</a> of <var>context</var> has
+                an <a>active document</a> with an origin that is not the same as
+                <var>origin</var> and <var>context</var>'s <a>browsing context container</a>'s
+                <a>node document</a> is not <a>allowed to use</a> the feature
+                indicated by attribute name <a><code>allowpaymentrequest</code></a>,
+                then <a>throw</a> a <a>SecurityError</a>.
+              </li>
+            </ol>
           </li>
           <li>If the <var>details</var> argument does not contain a value for
           <a data-lt="PaymentDetails.total">total</a>, then throw a
@@ -2038,8 +2049,10 @@
             <li><dfn>browsing context</dfn></li>
             <li><dfn>browsing context container</dfn></li>
             <li><dfn>nested browsing context</dfn></li>
+            <li><dfn>ancestor browsing context</dfn></li>
             <li><dfn>top-level browsing context</dfn></li>
             <li><dfn>allowed to use</dfn></li>
+            <li><dfn>active document</dfn></li>
             <li>the <dfn>iframe</dfn> element</li>
             <li>the <dfn>allowpaymentrequest</dfn> attribute</li>
           </ul>


### PR DESCRIPTION
Following https://github.com/w3c/html/pull/743, which adds the definition of the `<iframe>` `allowpaymentrequest` attribute to W3C HTML, this change updates the W3C Payment Request API to reference W3C HTML for that definition of `allowpaymentrequest` from W3C HTML.

See also https://github.com/w3c/browser-payment-api/issues/311