### PR TITLE
Add `enableLegacyCheckout` option to PaymentOptions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,9 +550,13 @@
           <em>acceptPromise</em> with a <a>NotSupportedError</a>.
           </li>
           <li>Show a user interface to allow the user to interact with the
-          payment request process. The <em>acceptPromise</em> will later be
-          resolved by the <a>user accepts the payment request algorithm</a>
-          through interaction with the user interface.
+          payment request process. If the <code>enableLegacyCheckout</code>
+          value of <em>request</em>@<a>[[\options]]</a> is <code>true</code>,
+          then provide an option on the user interface to complete checkout
+          on the payee's website without selecting a payment method. The
+          <em>acceptPromise</em> will later be resolved by the
+          <a>user accepts the payment request algorithm</a> through interaction
+          with the user interface.
           </li>
         </ol>
       </section>
@@ -1014,6 +1018,7 @@
           boolean requestPayerPhone = false;
           boolean requestShipping = false;
           DOMString shippingType = "shipping";
+          boolean enableLegacyCheckout = false;
         };
       </pre>
       <p>
@@ -1107,6 +1112,17 @@
             The <code>shippingType</code> field only affects the user interface
             for the payment request.
           </p>
+        </dd>
+        <dt>
+          <dfn>enableLegacyCheckout</dfn>
+        </dt>
+        <dd>
+          This <em>boolean</em> value indicates whether the <a>user agent</a>
+          should provide an additional option for the payer to complete the
+          checkout process on the payee's website. For example, setting this
+          to <code>true</code> would let a customer opt to complete checkout
+          on a merchant's website if the customer does not want to or cannot
+          select a payment method.
         </dd>
       </dl>
     </section>
@@ -1933,7 +1949,11 @@
           </li>
           <li>Set the <code>methodName</code> attribute value of
           <em>response</em> to the <a>payment method identifier</a> for the <a>
-            payment method</a> that the user selected to accept the payment.
+            payment method</a> that the user selected to accept the payment. If
+            the <code>enableLegacyCheckout</code> value of
+            <em>request</em>@<a>[[\options]]</a> is <code>true</code> and
+            the user selected the option to complete checkout on the payee's
+            website, then set <code>methodName</code> to <code>null</code>.
           </li>
           <li>Set the <code>details</code> attribute value of <em>response</em>
           to a <a>JSON-serializable object</a> containing the <a>payment


### PR DESCRIPTION
Currently, when a payer cannot or does not want to choose one of the payment methods provided in the PaymentRequest, they must cancel it. However, it could be that they can still complete the payment on the payee website via a custom checkout experience (and their shipping information could still be propagated). Requiring the payer to cancel the PaymentRequest in these circumstances is less than graceful.

This proposal adds a flag to tell the user agent to provide an option (on the user interface) to complete checkout on the payee's website if the payer can't or does not want to select a payment method. The payer can make this selection when necessary instead of canceling the PaymentRequest.

We may also want to consider adding options to the `show()` method instead of adding an option to the PaymentRequest constructor. That would allow other calls to be made on the PaymentRequest instance before a decision is made as to whether or not the legacy checkout option should be shown.

The `enableLegacyCheckout` name is open to bikeshedding.

The current version of this proposal sets the `methodName` on the PaymentResponse to `null` to indicate that no payment method was selected (instead, legacy checkout was selected) by the user. I'd like to know if that seems reasonable to implementers or if they have a better approach. Note that the user can still provide their shipping information through this mechanism (as currently proposed), even if they handle the payment via the legacy checkout.