### PR TITLE
Add canMakePayment() method

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
         interface PaymentRequest : EventTarget {
           Promise&lt;PaymentResponse&gt; show();
           Promise&lt;void&gt; abort();
+          Promise&lt;boolean&gt; canMakePayment();
 
           readonly attribute PaymentAddress? shippingAddress;
           readonly attribute DOMString? shippingOption;
@@ -607,6 +608,66 @@
           with an <a>AbortError</a>.
           </li>
           <li>Resolve <var>promise</var> with undefined.
+          </li>
+        </ol>
+      </section>
+      <section data-dfn-for="PaymentRequest">
+        <h2>
+          <code>canMakePayment()</code> method
+        </h2>
+        <p>
+          The <dfn>canMakePayment</dfn> method can be used by the developer to
+          determine if the <a>PaymentRequest</a> object can be used to make a
+          payment, before they call <a data-lt="PaymentRequest.show">show</a>.
+          It returns a <a>Promise</a> that will be fulfilled with true if the
+          <a>user agent</a> supports any of the desired <a>payment methods</a>
+          supplied to the <a>PaymentRequest</a> constructor, and false if none
+          are supported. If the method is called too often, the user agent
+          might instead return a promise rejected with a
+          <a>QuotaExceededError</a>, at its discretion.
+        </p>
+        <p>
+          The <a data-lt="PaymentRequest.canMakePayment">canMakePayment</a>
+          method MUST act as follows:
+        </p>
+        <ol>
+          <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
+          which the method was called.
+          </li>
+          <li>If <var>request</var>.<a>[[\state]]</a> is not <i>created</i>,
+          then return a promise rejected with an <a>InvalidStateError</a>.
+          </li>
+          <li>Optionally, at the <a>user agent</a>'s discretion, return a
+          promise rejected with a <a>QuotaExceededError</a>.
+            <p class="note">
+              This allows user agents to apply heuristics to detect and prevent
+              abuse of the <a data-lt=
+              "PaymentRequest.canMakePayment">canMakePayment</a> method for
+              fingerprinting purposes, such as creating <a>PaymentRequest</a>
+              objects with a variety of supported <a>payment methods</a> and
+              calling <a>canMakePayment</a> on them one after the other. For
+              example, a user agent may restrict the number of successful calls
+              that can be made based on the <a>top-level browsing context</a>
+              or the time period in which those calls were made.
+            </p>
+          </li>
+          <li>Let <var>promise</var> be a new <a>Promise</a>.
+          </li>
+          <li>Return <var>promise</var>, and perform the remaining steps <a>in
+          parallel</a>.
+          </li>
+          <li>For each <var>methodData</var> in
+          <var>request</var>.<a>[[\methodData]]</a>:
+            <ol>
+              <li>If <var>methodData</var>.<a data-lt=
+              "PaymentMethodData.supportedMethods">supportedMethods</a>
+              contains a <a>payment method identifier</a> of a <a>payment
+              method</a> that the <a>user agent</a> supports, resolve
+              <var>promise</var> with true, and abort this algorithm.
+              </li>
+            </ol>
+          </li>
+          <li>Resolve <var>promise</var> with false.
           </li>
         </ol>
       </section>
@@ -2149,6 +2210,17 @@
               </td>
               <td>
                 The payment method was not supported
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>QuotaExceededError</dfn>
+              </td>
+              <td>
+                The <a data-lt=
+                "PaymentRequest.canMakePayment">canMakePayment</a> method was
+                called too often according to the <a>user agent</a>'s
+                heuristics.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This closes #310, and closes #316 (which it is roughly based on), and closes #367 by intentionally allowing user agent leeway in restricting repeated calls to canMakePayment().

---

The main difference from #316 is in allowing user agents maximum flexibility in protecting against fingerprinting, instead of trying to prescribe an algorithm for doing so. It also contains a number of fixes to the algorithm.