### PR TITLE
Invoke "allowed to use" always

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,8 +347,8 @@
             If a <code>paymentRequestID</code> was not provided during construction, generate a <code>paymentRequestID</code>.  
           </li>
           <li>If the <a>current settings object</a>'s
-          <a>responsible document</a> is not <a>allowed to use</a> the feature
-          indicated by attribute name <a><code>allowpaymentrequest</code></a>,
+          <a data-cite="!html5#responsible-document">responsible document</a> is not <a>allowed to use</a> the feature
+          indicated by attribute name <a>allowpaymentrequest</a>,
           then <a>throw</a> a <a>SecurityError</a>.
           </li>
           <li>Process payment methods:
@@ -2283,9 +2283,6 @@
             </li>
             <li>
               <dfn>node document</dfn>
-            </li>
-            <li>
-              <dfn>responsible document</dfn>
             </li>
             <li>
               <dfn>top-level browsing context</dfn>

--- a/index.html
+++ b/index.html
@@ -346,23 +346,10 @@
           <li>
             If a <code>paymentRequestID</code> was not provided during construction, generate a <code>paymentRequestID</code>.  
           </li>
-          <li>If the <a>current settings object</a> has a <a>responsible
-          browsing context</a> that is not a <a>top-level browsing context</a>,
-          then
-            <ol>
-              <li>Let <var>context</var> be the <a>nested browsing context</a>.
-              </li>
-              <li>Let <var>origin</var> be the origin of the <a>active
-              document</a> of <var>context</var>.
-              </li>
-              <li>If any <a>ancestor browsing context</a> of <var>context</var>
-              has an <a>active document</a> with an origin that is not the same
-              as <var>origin</var> and <var>context</var>'s <a>active
-              document</a> is not <a>allowed to use</a> the feature indicated
-              by attribute name <a><code>allowpaymentrequest</code></a>, then
-              <a>throw</a> a <a>SecurityError</a>.
-              </li>
-            </ol>
+          <li>If the <a>current settings object</a>'s
+          <a>responsible document</a> is not <a>allowed to use</a> the feature
+          indicated by attribute name <a><code>allowpaymentrequest</code></a>,
+          then <a>throw</a> a <a>SecurityError</a>.
           </li>
           <li>Process payment methods:
             <ol>
@@ -2298,19 +2285,7 @@
               <dfn>node document</dfn>
             </li>
             <li>
-              <dfn>browsing context</dfn>
-            </li>
-            <li>
-              <dfn>browsing context container</dfn>
-            </li>
-            <li>
-              <dfn>nested browsing context</dfn>
-            </li>
-            <li>
-              <dfn>responsible browsing context</dfn>
-            </li>
-            <li>
-              <dfn>ancestor browsing context</dfn>
+              <dfn>responsible document</dfn>
             </li>
             <li>
               <dfn>top-level browsing context</dfn>
@@ -2320,9 +2295,6 @@
             </li>
             <li>
               <dfn>allowed to use</dfn>
-            </li>
-            <li>
-              <dfn>active document</dfn>
             </li>
             <li>
               <dfn>in parallel</dfn>


### PR DESCRIPTION
The old text was only invoking "allowed to use" for non-top-level
browsing contexts, which means the active document check is not
done for the top-level document case.

The old text was only invoking "allowed to use" if a document in
the chain of ancestor browsing contexts were not same origin,
but this does not match Chromium. Chromium will throw an exception
for PaymentRequest in an iframe even if it's same origin. It also
means that if everything *is* same origin, then the active document
check in "allowed to use" would not be called.

The use case for allowpaymentrequest must be to allow cross-origin
documents in iframes to make payments. Otherwise, if everything is
same-origin, the document could just construct top.PaymentRequest
to bypass any checks, or set the allowpaymentrequest attribute on
its frameElement.

Fixes #361.

The active document check in "allowed to use" was added in
https://github.com/whatwg/html/pull/2160.