### PR TITLE
Remove confusing IDL comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,10 +219,8 @@
           readonly attribute DOMString? shippingOption;
           readonly attribute PaymentShippingType? shippingType;
 
-          /* Supports "shippingaddresschange" event */
           attribute EventHandler onshippingaddresschange;
 
-          /* Supports "shippingoptionchange" event */
           attribute EventHandler onshippingoptionchange;
         };
       </pre>


### PR DESCRIPTION
These comments are not particularly helpful. Additionally, they look odd when the WebIDL is taken out of context (e.g., Mozilla extracts WebIDL from specs to generate our bindings, so comments like this look weird on their own). 