### PR TITLE
Add billing shipping type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1210,7 +1210,8 @@
         enum PaymentShippingType {
           "shipping",
           "delivery",
-          "pickup"
+          "pickup",
+          "billing",
         };
       </pre>
       <dl>

--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,7 @@
           "shipping",
           "delivery",
           "pickup",
-          "billing",
+          "billing"
         };
       </pre>
       <dl>


### PR DESCRIPTION
There are cases (such as with digital goods), where an address is needed, but there is no notion of shipping. I would prefer to be more bold in this edit by changing the name of this enum to PaymentAddressType and changing requestShipping to requestAddress, but I wanted to be on the safe side to start. Please let me know if the renaming would be agreeable as well.