### PR TITLE
Take paymentRequestID in constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,8 +206,12 @@
         <dfn>PaymentRequest</dfn> interface
       </h2>
       <pre class="idl">
-        [Constructor(sequence&lt;PaymentMethodData&gt; methodData, PaymentDetails details, optional PaymentOptions options),
-        SecureContext]
+        [Constructor(
+          optional DOMString paymentRequestID, 
+          sequence&lt;PaymentMethodData&gt; 
+          methodData, PaymentDetails details, 
+          optional PaymentOptions options
+         ), SecureContext]
         interface PaymentRequest : EventTarget {
           Promise&lt;PaymentResponse&gt; show();
           Promise&lt;void&gt; abort();

--- a/index.html
+++ b/index.html
@@ -208,8 +208,8 @@
       <pre class="idl">
         [Constructor(
           optional DOMString paymentRequestID, 
-          sequence&lt;PaymentMethodData&gt; 
-          methodData, PaymentDetails details, 
+          sequence&lt;PaymentMethodData&gt; methodData, 
+          PaymentDetails details, 
           optional PaymentOptions options
          ), SecureContext]
         interface PaymentRequest : EventTarget {
@@ -281,7 +281,7 @@
           Constructor
         </h2>
         <p>
-          The <a>PaymentRequest</a> is constructed using the supplied
+          The <a>PaymentRequest</a> is constructed using the supplied <var>paymentRequestID</var>,
           <var>methodData</var> list including any <a>payment method</a>
           specific <a data-lt="PaymentMethodData.data">data</a>, the payment
           <var>details</var>, and the payment <var>options</var>. The
@@ -559,6 +559,8 @@
           specified in the constructor.
           </li>
           <li>Let <var>request</var> be a new <a>PaymentRequest</a>.
+          </li>
+          <li>Set <var>request</var>.<a>[[\paymentRequestID]]</a> to <var>paymentRequestID</var>.
           </li>
           <li>Set <var>request</var>.<a>[[\options]]</a> to <var>options</var>.
           </li>
@@ -845,6 +847,14 @@
             <th>
               Description (<em>non-normative</em>)
             </th>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\paymentRequestID]]</dfn>
+            </td>
+            <td>
+              The <code>paymentRequestID</code> supplied or generated during construction.
+            </td>
           </tr>
           <tr>
             <td>


### PR DESCRIPTION
We appear to use "?" and "optional" interchangeably to signify nullability in this webIDL definition. Is that intentional or should I convert the whole thing to one way or the other?