### PR TITLE
Update the shippingType option to not allow invalid strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1235,7 +1235,7 @@
           boolean requestPayerEmail = false;
           boolean requestPayerPhone = false;
           boolean requestShipping = false;
-          DOMString shippingType = "shipping";
+          PaymentShippingType shippingType = "shipping";
         };
       </pre>
       <p>


### PR DESCRIPTION
This allows better future extensibility, including for proposals such as #409 which give shippingType new meaning.

Closes #337.