### PR TITLE
Editorial fixes and xrefs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2454,9 +2454,9 @@
           "!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
           slot</dfn>, <code><dfn data-cite=
           "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
-          TypeError</dfn></code>, <code><dfn data-cite=
-          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code>, and
-          <dfn>JSON.parse</dfn> are defined by [[!ECMA-262-2015]].
+          TypeError</dfn></code>, and <code><dfn data-cite=
+          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code> are
+          defined by [[!ECMA-262-2015]].
           <p>
             The term <dfn data-lt=
             "JSON-serialize|JSON-serialized|JSON-serializing">JSON-serialize</dfn>

--- a/index.html
+++ b/index.html
@@ -2487,9 +2487,6 @@
           sub-algorithm and all ancestor algorithms until one is reached that
           explicitly describes procedures for catching exceptions.
           <p>
-            The term <dfn>extended attribute</dfn> is defined by [[!WEBIDL-2]].
-          </p>
-          <p>
             The algorithm for <dfn data-lt="converting">converting an
             ECMAScript value to a dictionary</dfn> and for <dfn>converting a
             dictionary to an ECMAScript value</dfn> is defined by

--- a/index.html
+++ b/index.html
@@ -2168,7 +2168,7 @@
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
-          <li>Let <var>name</var> be <dfn>shippingaddresschange</dfn>.
+          <li>Let <var>name</var> be "shippingaddresschange".
           </li>
           <li>
             <a>Queue a task</a> on the <a>user interaction task source</a> to

--- a/index.html
+++ b/index.html
@@ -2559,13 +2559,6 @@
             </tr>
           </table>
         </dd>
-        <dt>
-          Secure Contexts
-        </dt>
-        <dd>
-          The term <dfn>secure context</dfn> is defined by the Secure Contexts
-          specification [[SECURE-CONTEXTS]].
-        </dd>
       </dl>
     </section>
     <section id="conformance">

--- a/index.html
+++ b/index.html
@@ -2489,8 +2489,10 @@
           sub-algorithm and all ancestor algorithms until one is reached that
           explicitly describes procedures for catching exceptions.
           <p>
-            The algorithm for <dfn data-lt="converting">converting an
-            ECMAScript value to a dictionary</dfn> is defined by [[!WEBIDL-2]].
+            The algorithm for <dfn data-cite=
+            "!WEBIDL-2#dfn-convert-idl-to-ecmascript-value" data-lt=
+            "converting">converting an ECMAScript value to a dictionary</dfn>
+            is defined by [[!WEBIDL-2]].
           </p>
         </dd>
         <dd>

--- a/index.html
+++ b/index.html
@@ -2449,8 +2449,13 @@
           ECMA-262 6th Edition, The ECMAScript 2015 Language Specification
         </dt>
         <dd>
-          The terms <dfn>Promise</dfn>, <dfn>internal slot</dfn>,
-          <dfn><code>TypeError</code></dfn>, <dfn>JSON.stringify</dfn>, and
+          The terms <dfn data-cite=
+          "!ECMA-262-2015#sec-promise-objects">Promise</dfn>, <dfn data-cite=
+          "!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
+          slot</dfn>, <code><dfn data-cite=
+          "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
+          TypeError</dfn></code>, <code><dfn data-cite=
+          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code>, and
           <dfn>JSON.parse</dfn> are defined by [[!ECMA-262-2015]].
           <p>
             The term <dfn data-lt=

--- a/index.html
+++ b/index.html
@@ -229,11 +229,6 @@
         <a data-lt="PaymentOptions.requestShipping">requestShipping</a> flag is
         set.
       </p>
-      <p class="note">
-        The <code>[SecureContext]</code> <a>extended attribute</a> means that
-        the <a>PaymentRequest</a> is only exposed within a <a>secure
-        context</a> and won't be accessible elsewhere.
-      </p>
       <p>
         The following example shows how to construct a <a>PaymentRequest</a>
         and begin the user interaction:

--- a/index.html
+++ b/index.html
@@ -2425,9 +2425,6 @@
               <dfn>user interaction task source</dfn>
             </li>
             <li>
-              <dfn>node document</dfn>
-            </li>
-            <li>
               <dfn>top-level browsing context</dfn>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -1371,8 +1371,8 @@
         </dt>
         <dd>
           Each attribute is <a data-cite=
-          "WEBIDL-2#dfn-convert-to-serialized-value">converted to serialized
-          values</a> as per [[!WEBIDL-2]].
+          "WEBIDL-LS#dfn-convert-to-serialized-value">converted to serialized
+          values</a> as per [[!WEBIDL-LS]].
         </dd>
         <dt>
           <dfn>country</dfn>
@@ -1586,8 +1586,8 @@
         </dt>
         <dd>
           Each attribute is <a data-cite=
-          "WEBIDL-2#dfn-convert-to-serialized-value">converted to serialized
-          values</a> as per [[!WEBIDL-2]].
+          "WEBIDL-LS#dfn-convert-to-serialized-value">converted to serialized
+          values</a> as per [[!WEBIDL-LS]].
         </dd>
         <dt>
           <dfn>paymentRequestId</dfn>
@@ -2482,24 +2482,24 @@
           Web IDL
         </dt>
         <dd>
-          When this specification says to <dfn data-cite="!WEBIDL-2#dfn-throw"
+          When this specification says to <dfn data-cite="!WEBIDL-LS#dfn-throw"
           data-lt="throws">throw</dfn> an error, the <a>user agent</a> must
-          throw an error as described in [[!WEBIDL-2]]. When this occurs in a
+          throw an error as described in [[!WEBIDL-LS]]. When this occurs in a
           sub-algorithm, this results in termination of execution of the
           sub-algorithm and all ancestor algorithms until one is reached that
           explicitly describes procedures for catching exceptions.
           <p>
             The algorithm for <dfn data-cite=
-            "!WEBIDL-2#dfn-convert-idl-to-ecmascript-value" data-lt=
+            "!WEBIDL-LS#dfn-convert-idl-to-ecmascript-value" data-lt=
             "converting">converting an ECMAScript value to a dictionary</dfn>
-            is defined by [[!WEBIDL-2]].
+            is defined by [[!WEBIDL-LS]].
           </p>
         </dd>
         <dd>
           <p>
             <code><dfn data-cite=
-            "!WEBIDL-2#dfn-DOMException">DOMException</dfn></code> and the
-            following <a>DOMException</a> types from [[!WEBIDL-2]] are used:
+            "!WEBIDL-LS#dfn-DOMException">DOMException</dfn></code> and the
+            following <a>DOMException</a> types from [[!WEBIDL-LS]] are used:
           </p>
           <table>
             <tr>
@@ -2513,7 +2513,7 @@
             <tr>
               <td>
                 <code><dfn data-cite=
-                "!WEBIDL-2#aborterror">AbortError</dfn></code>
+                "!WEBIDL-LS#aborterror">AbortError</dfn></code>
               </td>
               <td>
                 The payment request was aborted
@@ -2522,7 +2522,7 @@
             <tr>
               <td>
                 <code><dfn data-cite=
-                "!WEBIDL-2#invalidstateerror">InvalidStateError</dfn></code>
+                "!WEBIDL-LS#invalidstateerror">InvalidStateError</dfn></code>
               </td>
               <td>
                 The object is in an invalid state
@@ -2531,7 +2531,7 @@
             <tr>
               <td>
                 <code><dfn data-cite=
-                "!WEBIDL-2#notsupportederror">NotSupportedError</dfn></code>
+                "!WEBIDL-LS#notsupportederror">NotSupportedError</dfn></code>
               </td>
               <td>
                 The payment method was not supported
@@ -2540,7 +2540,7 @@
             <tr>
               <td>
                 <code><dfn data-cite=
-                "!WEBIDL-2#quotaexceedederror">QuotaExceededError</dfn></code>
+                "!WEBIDL-LS#quotaexceedederror">QuotaExceededError</dfn></code>
               </td>
               <td data-link-for="PaymentRequest">
                 The <a>canMakePayment()</a> method was called too often
@@ -2550,7 +2550,7 @@
             <tr>
               <td>
                 <code><dfn data-cite=
-                "!WEBIDL-2#securityerror">SecurityError</dfn></code>
+                "!WEBIDL-LS#securityerror">SecurityError</dfn></code>
               </td>
               <td>
                 The operation is only supported in a secure context

--- a/index.html
+++ b/index.html
@@ -2490,9 +2490,7 @@
           explicitly describes procedures for catching exceptions.
           <p>
             The algorithm for <dfn data-lt="converting">converting an
-            ECMAScript value to a dictionary</dfn> and for <dfn>converting a
-            dictionary to an ECMAScript value</dfn> is defined by
-            [[!WEBIDL-2]].
+            ECMAScript value to a dictionary</dfn> is defined by [[!WEBIDL-2]].
           </p>
         </dd>
         <dd>


### PR DESCRIPTION
* removes terms that were defined but never used.
* now links to ES6 spec for various things
* drops "secure context" that's no longer needed 
*  links to WebIDL for "converting"