### PR TITLE
feat: put request id in details dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1644,6 +1644,7 @@
         interface PaymentResponse {
           serializer = { attribute };
 
+          readonly attribute DOMString requestId;
           readonly attribute DOMString methodName;
           readonly attribute object details;
           readonly attribute PaymentAddress? shippingAddress;

--- a/index.html
+++ b/index.html
@@ -347,11 +347,11 @@
           <li>Establish the request's id:
             <ol>
               <li>If <var>details</var>.<a data-lt="PaymentDetails.id">id</a>
-              is missing, set the value of <var>details</var>.<a data-lt=
-              "PaymentDetails.id">id</a> to a string that uniquely identifies
-              this payment request. It is RECOMMENDED that the string be a
-              <abbr title="Universally Unique Identifier">UUID</abbr>
-              [[!RFC4122]].
+              is missing, add an <a data-lt="PaymentDetails.id">id</a> member
+              to <var>details</var> and set its value to string that uniquely
+              identifies this payment request. It is RECOMMENDED that the
+              string be a <abbr title=
+              "Universally Unique Identifier">UUID</abbr> [[!RFC4122]].
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -1040,7 +1040,7 @@
       </h2>
       <pre class="idl">
         dictionary PaymentDetails {
-          DOMString paymentRequestId;
+          DOMString id;
           PaymentItem total;
           sequence&lt;PaymentItem&gt; displayItems;
           sequence&lt;PaymentShippingOption&gt; shippingOptions;

--- a/index.html
+++ b/index.html
@@ -344,6 +344,19 @@
           </li>
           <li>Let <var>serializedMethodData</var> be an empty list.
           </li>
+          <li>Establish the request's id:
+            <ol>
+              <li>Let <var>requestId</var> be the empty string.
+              </li>
+              <li>If <var>details.id</var> is present, set <var>requestId</var>
+              to the value of <var>details</var>.<a data-lt=
+              "PaymentDetails.id">id</a>. Otherwise, set <var>requestId</var>
+              to a string that uniquely identifies this payment request. It is
+              RECOMMENDED that the string be a <abbr title=
+              "Universally Unique Identifier">UUID</abbr> [[!RFC4122]].
+              </li>
+            </ol>
+          </li>
           <li>Process payment methods:
             <ol data-link-for="PaymentMethodData">
               <li>If the length of the <var>methodData</var> sequence is zero,
@@ -456,9 +469,6 @@
             </ol>
           </li>
           <li>Let <var>serializedModifierData</var> be an empty list.
-          <li>If <var>details.id</var> was not provided during
-          construction, populate the field with an [[RFC4122]] UUID.
-          </li>
           </li>
           <li data-link-for="PaymentDetailsBase">Process payment details
           modifiers:
@@ -537,6 +547,8 @@
             </ol>
           </li>
           <li>Let <var>request</var> be a new <a>PaymentRequest</a>.
+          </li>
+          <li>Set <var>request</var>.<a>id</a> to <var>requestId</var>.
           </li>
           <li>Set <var>request</var>.<a>[[\options]]</a> to <var>options</var>.
           </li>
@@ -1056,12 +1068,12 @@
           <dfn>id</dfn>
         </dt>
         <dd>
-          <a>id</a> is a freeform identifier for this
-          payment request. This field is intended to hold a unique
-          identifier for the purposes of recovering from failures and/or as a
-          foreign key into other systems. If a <a>id</a>
-          is not provided by the client then a UUID will be generated and stored
-          instead.
+          <a>id</a> is a free-form identifier for this payment request.
+          <p class="note">
+            If a <a>id</a> member is not present, then the UA will generate a
+            unique identifier for the payment request during <a data-lt=
+            "PaymentRequest.PaymentRequest()">construction</a>.
+          </p>
         </dd>
         <dt>
           <dfn>total</dfn>
@@ -1739,6 +1751,13 @@
           <a>PaymentRequest</a> constructor, then <a data-lt=
           "PaymentResponse.payerPhone">payerPhone</a> will be the phone number
           chosen by the user.
+        </dd>
+        <dt>
+          <dfn>requestId</dfn>
+        </dt>
+        <dd>
+          The corresponding payment request <a data-lt=
+          "PaymentRequest.id">id</a> that spawned this payment response.
         </dd>
       </dl>
       <section data-dfn-for="PaymentResponse" data-link-for="PaymentResponse">

--- a/index.html
+++ b/index.html
@@ -346,8 +346,8 @@
           </li>
           <li>Establish the request's id:
             <ol>
-              <li>If <var>details</var>.<a data-lt="PaymentDetails.id">id</a>
-              is missing, add an <a data-lt="PaymentDetails.id">id</a> member
+              <li>If <var>details</var>.<a data-lt="PaymentDetailsInit.id">id</a>
+              is missing, add an <a data-lt="PaymentDetailsInit.id">id</a> member
               to <var>details</var> and set its value to string that uniquely
               identifies this payment request. It is RECOMMENDED that the
               string be a <abbr title=
@@ -600,7 +600,7 @@
         <p>
           When getting, the <a>id</a> attribute returns this
           <a>PaymentRequest</a>'s <a>[[\details]]</a>.<a data-lt=
-          "PaymentDetails.id">id</a>.
+          "PaymentDetailsInit.id">id</a>.
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
@@ -1058,7 +1058,6 @@
       </h2>
       <pre class="idl">
         dictionary PaymentDetailsBase {
-          DOMString id;
           sequence&lt;PaymentItem&gt; displayItems;
           sequence&lt;PaymentShippingOption&gt; shippingOptions;
           sequence&lt;PaymentDetailsModifier&gt; modifiers;
@@ -1069,17 +1068,6 @@
         dictionary:
       </p>
       <dl>
-        <dt>
-          <dfn>id</dfn>
-        </dt>
-        <dd>
-          <a>id</a> is a free-form identifier for this payment request.
-          <p class="note">
-            If an <a>id</a> member is not present, then the <a>user agent</a>
-            will generate a unique identifier for the payment request during
-            <a data-lt="PaymentRequest.PaymentRequest()">construction</a>.
-          </p>
-        </dd>
         <dt>
           <dfn>displayItems</dfn>
         </dt>
@@ -1151,6 +1139,7 @@
       </h2>
       <pre class="idl">
         dictionary PaymentDetailsInit : PaymentDetailsBase {
+          DOMString id;
           required PaymentItem total;
         };
       </pre>
@@ -1164,6 +1153,17 @@
         <a>PaymentDetailsInit</a> dictionary:
       </p>
       <dl>
+        <dt>
+          <dfn>id</dfn>
+        </dt>
+        <dd>
+          <a>id</a> is a free-form identifier for this payment request.
+          <p class="note">
+            If an <a>id</a> member is not present, then the <a>user agent</a>
+            will generate a unique identifier for the payment request during
+            <a data-lt="PaymentRequest.PaymentRequest()">construction</a>.
+          </p>
+        </dd>
         <dt>
           <dfn>total</dfn>
         </dt>
@@ -2364,7 +2364,7 @@
           <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
           attribute value of <var>response</var> to the value of
           <var>request</var>.<a>[[\details]]</a>.<a data-lt=
-          "PaymentDetails.id">id</a>.
+          "PaymentDetailsInit.id">id</a>.
           </li>
           <li>Set the <a data-lt="PaymentResponse.methodName">methodName</a>
           attribute value of <var>response</var> to the <a>payment method

--- a/index.html
+++ b/index.html
@@ -599,7 +599,7 @@
         </h2>
         <p>
           When getting, the <a>id</a> attribute returns this
-          <a>PaymentRequest</a> <a>[[\details]]</a>.<a data-lt=
+          <a>PaymentRequest</a>'s <a>[[\details]]</a>.<a data-lt=
           "PaymentDetails.id">id</a>.
         </p>
       </section>
@@ -1057,9 +1057,8 @@
         <dfn>PaymentDetailsBase</dfn> dictionary
       </h2>
       <pre class="idl">
-        dictionary PaymentDetails {
+        dictionary PaymentDetailsBase {
           DOMString id;
-          PaymentItem total;
           sequence&lt;PaymentItem&gt; displayItems;
           sequence&lt;PaymentShippingOption&gt; shippingOptions;
           sequence&lt;PaymentDetailsModifier&gt; modifiers;
@@ -1079,18 +1078,6 @@
             If an <a>id</a> member is not present, then the <a>user agent</a>
             will generate a unique identifier for the payment request during
             <a data-lt="PaymentRequest.PaymentRequest()">construction</a>.
-          </p>
-        </dd>
-        <dt>
-          <dfn>total</dfn>
-        </dt>
-        <dd>
-          This <a>PaymentItem</a> contains the total amount of the payment
-          request.
-          <p>
-            <code>total</code> MUST be a non-negative value. This means that
-            the <code>total.amount.value</code> field MUST NOT begin with a
-            U+002D HYPHEN-MINUS character.
           </p>
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
           </p>
           <pre class="example" title="The 'details' argument">
             const details = {
-              id: "1234567890123",
+              id: "super-store-order-123-12312",
               displayItems: [
                 {
                   label: "Sub-total",

--- a/index.html
+++ b/index.html
@@ -346,14 +346,12 @@
           </li>
           <li>Establish the request's id:
             <ol>
-              <li>Let <var>requestId</var> be the empty string.
-              </li>
-              <li>If <var>details.id</var> is present, set <var>requestId</var>
-              to the value of <var>details</var>.<a data-lt=
-              "PaymentDetails.id">id</a>. Otherwise, set <var>requestId</var>
-              to a string that uniquely identifies this payment request. It is
-              RECOMMENDED that the string be a <abbr title=
-              "Universally Unique Identifier">UUID</abbr> [[!RFC4122]].
+              <li>If <var>details</var>.<a data-lt="PaymentDetails.id">id</a>
+              is missing, set the value of <var>details</var>.<a data-lt=
+              "PaymentDetails.id">id</a> to a string that uniquely identifies
+              this payment request. It is RECOMMENDED that the string be a
+              <abbr title="Universally Unique Identifier">UUID</abbr>
+              [[!RFC4122]].
               </li>
             </ol>
           </li>
@@ -548,8 +546,6 @@
           </li>
           <li>Let <var>request</var> be a new <a>PaymentRequest</a>.
           </li>
-          <li>Set <var>request</var>.<a>id</a> to <var>requestId</var>.
-          </li>
           <li>Set <var>request</var>.<a>[[\options]]</a> to <var>options</var>.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>created</a>".
@@ -596,6 +592,16 @@
           <li>Return <var>request</var>.
           </li>
         </ol>
+      </section>
+      <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
+        <h2>
+          <dfn>id</dfn> attribute
+        </h2>
+        <p>
+          When getting, the <a>id</a> attribute returns this
+          <a>PaymentRequest</a> <a>[[\details]]</a>.<a data-lt=
+          "PaymentDetails.id">id</a>.
+        </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
         <h2>
@@ -1070,9 +1076,9 @@
         <dd>
           <a>id</a> is a free-form identifier for this payment request.
           <p class="note">
-            If a <a>id</a> member is not present, then the UA will generate a
-            unique identifier for the payment request during <a data-lt=
-            "PaymentRequest.PaymentRequest()">construction</a>.
+            If an <a>id</a> member is not present, then the <a>user agent</a>
+            will generate a unique identifier for the payment request during
+            <a data-lt="PaymentRequest.PaymentRequest()">construction</a>.
           </p>
         </dd>
         <dt>
@@ -2370,7 +2376,8 @@
           </li>
           <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
           attribute value of <var>response</var> to the value of
-          <var>request</var>.<a data-lt="PaymentRequest.id">id</a>.
+          <var>request</var>.<a>[[\details]]</a>.<a data-lt=
+          "PaymentDetails.id">id</a>.
           </li>
           <li>Set the <a data-lt="PaymentResponse.methodName">methodName</a>
           attribute value of <var>response</var> to the <a>payment method

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
           </p>
           <pre class="example" title="The 'details' argument">
             const details = {
-              paymentRequestId: "1234567890123",
+              id: "1234567890123",
               displayItems: [
                 {
                   label: "Sub-total",
@@ -456,7 +456,7 @@
             </ol>
           </li>
           <li>Let <var>serializedModifierData</var> be an empty list.
-          <li>If <var>details.paymentRequestId</var> was not provided during
+          <li>If <var>details.id</var> was not provided during
           construction, populate the field with an [[RFC4122]] UUID.
           </li>
           </li>
@@ -1053,13 +1053,13 @@
       </p>
       <dl>
         <dt>
-          <dfn>paymentRequestId</dfn>
+          <dfn>id</dfn>
         </dt>
         <dd>
-          <a>paymentRequestId</a> is a freeform identifier for this
+          <a>id</a> is a freeform identifier for this
           payment request. This field is intended to hold a unique
           identifier for the purposes of recovering from failures and/or as a
-          foreign key into other systems. If a <a>paymentRequestId</a>
+          foreign key into other systems. If a <a>id</a>
           is not provided by the client then a UUID will be generated and stored
           instead.
         </dd>

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
           Promise&lt;void&gt; abort();
           Promise&lt;boolean&gt; canMakePayment();
 
-          readonly attribute DOMString? id;
+          readonly attribute DOMString id;
           readonly attribute PaymentAddress? shippingAddress;
           readonly attribute DOMString? shippingOption;
           readonly attribute PaymentShippingType? shippingType;

--- a/index.html
+++ b/index.html
@@ -202,6 +202,7 @@
           Promise&lt;void&gt; abort();
           Promise&lt;boolean&gt; canMakePayment();
 
+          readonly attribute DOMString? id;
           readonly attribute PaymentAddress? shippingAddress;
           readonly attribute DOMString? shippingOption;
           readonly attribute PaymentShippingType? shippingType;

--- a/index.html
+++ b/index.html
@@ -202,7 +202,6 @@
           Promise&lt;void&gt; abort();
           Promise&lt;boolean&gt; canMakePayment();
 
-          readonly attribute DOMString? paymentRequestId;
           readonly attribute PaymentAddress? shippingAddress;
           readonly attribute DOMString? shippingOption;
           readonly attribute PaymentShippingType? shippingType;
@@ -299,6 +298,7 @@
           </p>
           <pre class="example" title="The 'details' argument">
             const details = {
+              paymentRequestID: "1234567890123",
               displayItems: [
                 {
                   label: "Sub-total",
@@ -455,6 +455,9 @@
             </ol>
           </li>
           <li>Let <var>serializedModifierData</var> be an empty list.
+          <li>If <var>details.paymentRequestID</var> was not provided during
+          construction, populate the field with an [[RFC4122]] UUID.
+          </li>
           </li>
           <li data-link-for="PaymentDetailsBase">Process payment details
           modifiers:
@@ -1036,6 +1039,8 @@
       </h2>
       <pre class="idl">
         dictionary PaymentDetailsBase {
+          DOMString paymentRequestID;
+          PaymentItem total;
           sequence&lt;PaymentItem&gt; displayItems;
           sequence&lt;PaymentShippingOption&gt; shippingOptions;
           sequence&lt;PaymentDetailsModifier&gt; modifiers;
@@ -1046,6 +1051,29 @@
         dictionary:
       </p>
       <dl>
+        <dt>
+          <dfn>paymentRequestID</dfn>
+        </dt>
+        <dd>
+          <code>paymentRequestID</code> is a freeform identifier for this
+          payment request. This field is intended to hold a unique
+          identifier for the purposes of recovering from failures and/or as a
+          foreign key into other systems. If a <code>paymentRequestID</code>
+          is not provided by the client then a UUID will be generated and stored
+          instead.
+        </dd>
+        <dt>
+          <dfn>total</dfn>
+        </dt>
+        <dd>
+          This <a>PaymentItem</a> contains the total amount of the payment
+          request.
+          <p>
+            <code>total</code> MUST be a non-negative value. This means that
+            the <code>total.amount.value</code> field MUST NOT begin with a
+            U+002D HYPHEN-MINUS character.
+          </p>
+        </dd>
         <dt>
           <dfn>displayItems</dfn>
         </dt>
@@ -1615,7 +1643,6 @@
         interface PaymentResponse {
           serializer = { attribute };
 
-          readonly attribute DOMString paymentRequestId;
           readonly attribute DOMString methodName;
           readonly attribute object details;
           readonly attribute PaymentAddress? shippingAddress;
@@ -1639,13 +1666,6 @@
           Each attribute is <a data-cite=
           "WEBIDL-LS#dfn-convert-to-serialized-value">converted to serialized
           values</a> as per [[!WEBIDL-LS]].
-        </dd>
-        <dt>
-          <dfn>paymentRequestId</dfn>
-        </dt>
-        <dd>
-          The same <a>paymentRequestId</a> present in the original
-          <a>PaymentRequest</a>.
         </dd>
         <dt>
           <dfn>methodName</dfn>

--- a/index.html
+++ b/index.html
@@ -2368,6 +2368,10 @@
           </li>
           <li>Let <var>response</var> be a new <a>PaymentResponse</a>.
           </li>
+          <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
+          attribute value of <var>response</var> to the value of
+          <var>request</var>.<a data-lt="PaymentRequest.id">id</a>.
+          </li>
           <li>Set the <a data-lt="PaymentResponse.methodName">methodName</a>
           attribute value of <var>response</var> to the <a>payment method
           identifier</a> for the <a>payment method</a> that the user selected

--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
           </p>
           <pre class="example" title="The 'details' argument">
             const details = {
-              paymentRequestID: "1234567890123",
+              paymentRequestId: "1234567890123",
               displayItems: [
                 {
                   label: "Sub-total",
@@ -455,7 +455,7 @@
             </ol>
           </li>
           <li>Let <var>serializedModifierData</var> be an empty list.
-          <li>If <var>details.paymentRequestID</var> was not provided during
+          <li>If <var>details.paymentRequestId</var> was not provided during
           construction, populate the field with an [[RFC4122]] UUID.
           </li>
           </li>
@@ -1038,8 +1038,8 @@
         <dfn>PaymentDetailsBase</dfn> dictionary
       </h2>
       <pre class="idl">
-        dictionary PaymentDetailsBase {
-          DOMString paymentRequestID;
+        dictionary PaymentDetails {
+          DOMString paymentRequestId;
           PaymentItem total;
           sequence&lt;PaymentItem&gt; displayItems;
           sequence&lt;PaymentShippingOption&gt; shippingOptions;
@@ -1052,13 +1052,13 @@
       </p>
       <dl>
         <dt>
-          <dfn>paymentRequestID</dfn>
+          <dfn>paymentRequestId</dfn>
         </dt>
         <dd>
-          <code>paymentRequestID</code> is a freeform identifier for this
+          <a>paymentRequestId</a> is a freeform identifier for this
           payment request. This field is intended to hold a unique
           identifier for the purposes of recovering from failures and/or as a
-          foreign key into other systems. If a <code>paymentRequestID</code>
+          foreign key into other systems. If a <a>paymentRequestId</a>
           is not provided by the client then a UUID will be generated and stored
           instead.
         </dd>


### PR DESCRIPTION
* closes #388, #412, #415.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/request_id_construct.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/3c3a100...113fb60.html)