### PR TITLE
Fix constructor handling of shippingType

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,10 +567,6 @@
           <li>Set the value of the <a data-lt="PaymentRequest.shippingAddress">
             shippingAddress</a> attribute on <var>request</var> to null.
           </li>
-          <li>Set the value of the <a data-lt=
-          "PaymentRequest.shippingType">shippingType</a> attribute on
-          <var>request</var> to null.
-          </li>
           <li>If <var>options</var>.<a data-lt=
           "PaymentOptions.requestShipping">requestShipping</a> is set to true,
           then set the value of the <a data-lt=

--- a/index.html
+++ b/index.html
@@ -576,18 +576,8 @@
           then set the value of the <a data-lt=
           "PaymentRequest.shippingType">shippingType</a> attribute on
           <var>request</var> to <var>options</var>.<a data-lt=
-          "PaymentOptions.shippingType">shippingType</a>. If
-          <var>options</var>.<a data-lt=
-          "PaymentOptions.shippingType">shippingType</a> is not a valid
-          <a>PaymentShippingType</a> value then set the value of the
-            <a data-lt="PaymentRequest.shippingType">shippingType</a> attribute
-            on <var>request</var> to "<code>shipping</code>".
-            <div class="note">
-              This behavior allows a page to detect if it supplied an
-              unsupported shipping type. This will be important if new shipping
-              types are added to a future version of this specification but a
-              page is run in a <a>user agent</a> supporting an earlier version.
-            </div>
+          "PaymentOptions.shippingType">shippingType</a>. Otherwise, set it to
+          null.
           </li>
           <li>Return <var>request</var>.
           </li>


### PR DESCRIPTION
If shippingType is provided, it will always be a valid shipping type, now that we are using an enum (as of 7e9a3323ac7ed932597fe4b3963331f9fa883041). But we also need to correctly handle the case where it is not provided, or where requestShipping is false, in which case it should be null.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/fix-shipping-type.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/361e720...cfe929b.html)