### PR TITLE
Remove trailing comma from IDL enums

### DIFF
--- a/index.html
+++ b/index.html
@@ -1340,7 +1340,7 @@
         enum PaymentShippingType {
           "shipping",
           "delivery",
-          "pickup",
+          "pickup"
         };
       </pre>
       <dl>
@@ -1677,7 +1677,7 @@
         enum PaymentComplete {
           "fail",
           "success",
-          "unknown",
+          "unknown"
         };
       </pre>
       <dl>


### PR DESCRIPTION
28d01b4fdca2da26efe622a0082f8f3956815328 introduced trailing commas
in IDL enums. From what I can tell from
https://heycam.github.io/webidl/#idl-enums that is not allowed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/zcorpan/enum-trailing-comma.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/361e720...3066910.html)