### PR TITLE
Changes to show() and canMakePayment() to take into account

### DIFF
--- a/index.html
+++ b/index.html
@@ -661,11 +661,14 @@
           <li>For each <var>paymentMethod</var> in
           <var>request</var>.<a>[[\serializedMethodData]]</a>:
             <ol>
-              <li>Consult the appropriate <a>payment apps</a> to see if they
-              support any of the <a>payment method identifiers</a> given by the
-              first element of the <var>paymentMethod</var> tuple, passing
-              along the data string given by the second element of the tuple in
-              order to help them determine their support.
+
+              <li>Determine which <a>payment apps</a> support any of
+                  the <a>payment method identifiers</a> given by the
+                  first element of the <var>paymentMethod</var> tuple.
+                  For each resulting payment app, if payment method
+                  specific capabilities supplied by the payment app
+                  match those provided by the second element of the
+                  tuple, the payment app matches.
               </li>
             </ol>
           </li>
@@ -812,8 +815,10 @@
             <ol>
               <li>If <var>methodData</var>.<a data-lt=
               "PaymentMethodData.supportedMethods">supportedMethods</a>
-              contains a <a>payment method identifier</a> of a <a>payment
-              method</a> that the <a>user agent</a> supports, resolve
+              contains a <a>payment method identifier</a> of
+              a <a>payment method</a> that the <a>user agent</a> or
+              other <a>payment app</a> supports (including its <a>payment
+              method</a> specific capabilities), resolve
               <var>promise</var> with true, and abort this algorithm.
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -661,14 +661,12 @@
           <li>For each <var>paymentMethod</var> in
           <var>request</var>.<a>[[\serializedMethodData]]</a>:
             <ol>
-
-              <li>Determine which <a>payment apps</a> support any of
-                  the <a>payment method identifiers</a> given by the
-                  first element of the <var>paymentMethod</var> tuple.
-                  For each resulting payment app, if payment method
-                  specific capabilities supplied by the payment app
-                  match those provided by the second element of the
-                  tuple, the payment app matches.
+              <li>Determine which <a>payment apps</a> support any of the
+              <a>payment method identifiers</a> given by the first element of
+              the <var>paymentMethod</var> tuple. For each resulting payment
+              app, if payment method specific capabilities supplied by the
+              payment app match those provided by the second element of the
+              tuple, the payment app matches.
               </li>
             </ol>
           </li>
@@ -815,11 +813,11 @@
             <ol>
               <li>If <var>methodData</var>.<a data-lt=
               "PaymentMethodData.supportedMethods">supportedMethods</a>
-              contains a <a>payment method identifier</a> of
-              a <a>payment method</a> that the <a>user agent</a> or
-              other <a>payment app</a> supports (including its <a>payment
-              method</a> specific capabilities), resolve
-              <var>promise</var> with true, and abort this algorithm.
+              contains a <a>payment method identifier</a> of a <a>payment
+              method</a> that the <a>user agent</a> or other <a>payment app</a>
+              supports (including its <a>payment method</a> specific
+              capabilities), resolve <var>promise</var> with true, and abort
+              this algorithm.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
third party payment app capabilities (matching them with
merchant-provided payment method specific filters).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ianbjacobs/browser-payment-api/add_capabilities.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/81c4e0a...ianbjacobs:3f721be.html)