### PR TITLE
l10n: adds Localizable dict + TextDirection enum

### DIFF
--- a/index.html
+++ b/index.html
@@ -1504,7 +1504,7 @@
       </h2>
       <pre class="idl">
         dictionary PaymentItem {
-          required DOMString label;
+          required LocalizableString label;
           required PaymentCurrencyAmount amount;
           boolean pending = false;
         };
@@ -1680,7 +1680,7 @@
       <pre class="idl">
         dictionary PaymentShippingOption {
           required DOMString id;
-          required DOMString label;
+          required LocalizableString label;
           required PaymentCurrencyAmount amount;
           boolean selected = false;
         };
@@ -2847,6 +2847,10 @@
           Web IDL
         </dt>
         <dd>
+          <p>
+            The <code><dfn>LocalizableString</dfn></code> <a data-cite=
+            "!WEBIDL-LS#dfn-typedef">typedef</a> is defined by [[!WEBIDL-LS]].
+          </p>
           <p>
             When this specification says to <dfn data-cite="!WEBIDL#dfn-throw"
             data-lt="throws">throw</dfn> an error, the <a>user agent</a> must


### PR DESCRIPTION
*  closes #327
* `PaymentShippingOption` and `PaymentItem` inherits from WebIDL `Localizable`
* The `label` members of the above are defined as localizable members


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/l10n.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/035d129...7da7748.html)