### PR TITLE
Editorial changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
     </title>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class=
-    'remove'></script>
+    'remove'>
+    </script>
     <script class='remove'>
     var respecConfig = {
       shortName: "payment-request",
@@ -123,14 +124,15 @@
         transaction:
       </p>
       <ul>
-        <li>the payee, such as a merchant with an online store,
+        <li>the payee: the merchant that runs an online store, or other party
+        that requests to be paid.
         </li>
-        <li>the payer, such as a person making a purchase on that online store,
-        and who authenticates and authorizes payment as required,
+        <li>the payer: the party that makes a purchase at that online store,
+        and who authenticates and authorizes payment as required.
         </li>
-        <li>the provider of a <dfn data-lt="payment methods">payment
-        method</dfn> (e.g., credit card) that the payer uses to pay, and that
-        is accepted by the payee.
+        <li>the <dfn data-lt="payment methods">payment method</dfn> provider:
+        the party that provides the means (e.g., credit card) that the payer
+        uses to pay, and that is accepted by the payee.
         </li>
       </ul>
       <p>

--- a/index.html
+++ b/index.html
@@ -119,15 +119,17 @@
       </h2>
       <p>
         This specification describes an API that allows <a>user agents</a>
-        (e.g., browsers) to act as an intermediary between three systems in
-        every transaction: the merchant (e.g., an online web store), the buyer,
-        represented by the <a>user agent</a> (e.g., the user buying from the
-        online web store), and the <dfn data-lt="payment methods">payment
-        method</dfn> (e.g., credit card). Information necessary to process and
-        confirm a transaction is passed between the <a>payment method</a> and
-        the merchant via the <a>user agent</a> with the buyer confirming and
-        authorizing as necessary across the flow.
-      </p>
+        (e.g., browsers) to act as an intermediary between three parties in
+        a transaction:</p>
+
+      <ul>
+	<li>the payee, such as a merchant with an online store,</li>
+	<li>the payer, such as a person making a purchase on that online store, and who authenticates and authorizes payment as required,</li>
+	<li>the provider of a <dfn data-lt="payment methods">payment
+            method</dfn> (e.g., credit card) that the payer uses to pay, and
+	  that is accepted by the payee.</li>
+      </ul>
+
       <p>
         The details of how to fulfill a payment request for a given <a>payment
         method</a> are handled by <dfn data-lt="payment app">payment
@@ -148,13 +150,12 @@
         </h2>
         <ul>
           <li>Allow the user agent to act as intermediary between merchants,
-          users, and <a>payment methods</a>
+          users, and <a>payment method</a> providers.
           </li>
           <li>Standardize (to the extent that it makes sense) the communication
-          flow between a merchant, user agent, and <a>payment method</a>
+          flow between a merchant, user agent, and <a>payment method</a> provider.
           </li>
-          <li>Allow <a>payment methods</a> to bring more secure payment
-          transactions to the web
+          <li>Enable <a>payment method</a> providers to bring more secure payment transactions to the web.
           </li>
         </ul>
         <section id="out-of-scope">
@@ -223,9 +224,10 @@
       <p>
         A web page creates a <a>PaymentRequest</a> to make a payment request.
         This is typically associated with the user initiating a payment process
-        (e.g., selecting a "Power Up" in an interactive game, pulling up to an
-        automated kiosk in a parking structure, or activating a "Buy",
-        "Purchase", or "Checkout" button). The <a>PaymentRequest</a> allows the
+        (e.g., by activating a "Buy," "Purchase," or "Checkout" button
+	on a web site, selecting a "Power Up" in an interactive game, or
+	paying at a kiosk in a parking structure).
+	The <a>PaymentRequest</a> allows the
         web page to exchange information with the <a>user agent</a> while the
         user is providing input before approving or denying a payment request.
       </p>
@@ -288,11 +290,11 @@
             const methodData = [{
               supportedMethods: ["basic-card"],
               data: {
-                supportedNetworks: ['aFamousBrand', 'aDebitNetwork'],
+                supportedNetworks: ['visa, 'mastercard'],
                 supportedTypes: ['debit']
               }
             }, {
-              supportedMethods: ["bobpay.com"],
+              supportedMethods: ["https://example.com/bobpay"],
               data: {
                 merchantIdentifier: "XXXX",
                 bobPaySpecificField: true

--- a/index.html
+++ b/index.html
@@ -119,17 +119,20 @@
       </h2>
       <p>
         This specification describes an API that allows <a>user agents</a>
-        (e.g., browsers) to act as an intermediary between three parties in
-        a transaction:</p>
-
+        (e.g., browsers) to act as an intermediary between three parties in a
+        transaction:
+      </p>
       <ul>
-	<li>the payee, such as a merchant with an online store,</li>
-	<li>the payer, such as a person making a purchase on that online store, and who authenticates and authorizes payment as required,</li>
-	<li>the provider of a <dfn data-lt="payment methods">payment
-            method</dfn> (e.g., credit card) that the payer uses to pay, and
-	  that is accepted by the payee.</li>
+        <li>the payee, such as a merchant with an online store,
+        </li>
+        <li>the payer, such as a person making a purchase on that online store,
+        and who authenticates and authorizes payment as required,
+        </li>
+        <li>the provider of a <dfn data-lt="payment methods">payment
+        method</dfn> (e.g., credit card) that the payer uses to pay, and that
+        is accepted by the payee.
+        </li>
       </ul>
-
       <p>
         The details of how to fulfill a payment request for a given <a>payment
         method</a> are handled by <dfn data-lt="payment app">payment
@@ -153,9 +156,11 @@
           users, and <a>payment method</a> providers.
           </li>
           <li>Standardize (to the extent that it makes sense) the communication
-          flow between a merchant, user agent, and <a>payment method</a> provider.
+          flow between a merchant, user agent, and <a>payment method</a>
+          provider.
           </li>
-          <li>Enable <a>payment method</a> providers to bring more secure payment transactions to the web.
+          <li>Enable <a>payment method</a> providers to bring more secure
+          payment transactions to the web.
           </li>
         </ul>
         <section id="out-of-scope">
@@ -224,12 +229,11 @@
       <p>
         A web page creates a <a>PaymentRequest</a> to make a payment request.
         This is typically associated with the user initiating a payment process
-        (e.g., by activating a "Buy," "Purchase," or "Checkout" button
-	on a web site, selecting a "Power Up" in an interactive game, or
-	paying at a kiosk in a parking structure).
-	The <a>PaymentRequest</a> allows the
-        web page to exchange information with the <a>user agent</a> while the
-        user is providing input before approving or denying a payment request.
+        (e.g., by activating a "Buy," "Purchase," or "Checkout" button on a web
+        site, selecting a "Power Up" in an interactive game, or paying at a
+        kiosk in a parking structure). The <a>PaymentRequest</a> allows the web
+        page to exchange information with the <a>user agent</a> while the user
+        is providing input before approving or denying a payment request.
       </p>
       <p data-link-for="PaymentRequest">
         The <a>shippingAddress</a>, <a>shippingOption</a>, and


### PR DESCRIPTION
Some editorial changes:

 * Payment methods describe data; they are not participants in a transaction.
   Therefore, recast the description of parties as payers/payees/providers
   of payment methods. (Both in Intro and Goals)

 * The word "buyer" was used in the intro and not used elsewhere in the
   spec. Therefore, I use payer/payee which are used further down.

 * The first examples the reader should encounter in the PaymentRequest
   interface description should be those most likely found in practice.
   The "Buy" button should come first. The other examples of in-app
   and POS are much further out and so I have listed them after.

 * Updated example 2 as follows:

   - We have network id values; we should use those instead of fictitious
     ones.

   - bobpay.com does not confirm (I believe) to the PMI spec. So I have
     used an example URL instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ianbjacobs/browser-payment-api/editorial20170320.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/654d0f7...ianbjacobs:08a0dc8.html)