### PR TITLE
fix(complete): bugus result value will have thrown already

### DIFF
--- a/index.html
+++ b/index.html
@@ -1880,8 +1880,6 @@
           </li>
           <li>Close down any remaining user interface. The <a>user agent</a>
           MAY use the value <var>result</var> to influence the user experience.
-          <a>User agents</a> SHOULD treat unrecognized <var>result</var> values
-          as the value "<a href="#dom-paymentcomplete-unknown">unknown</a>".
           </li>
           <li>Resolve <var>promise</var> with undefined.
           </li>


### PR DESCRIPTION
To be clear, this algorithm takes an enum, so invalid values won't be see because WebIDL would have already thrown if bogus values are encountered.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/marcos-travel/browser-payment-api/unknown.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/427d0d5...marcos-travel:1483e34.html)