### PR TITLE
editorial: remove redundant event declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2406,8 +2406,6 @@
           further action. The <a>user agent</a> user interface should ensure
           that this never occurs.
           </li>
-          <li>Let <var>event</var> be a new <a>PaymentRequestUpdateEvent</a>.
-          </li>
           <li>
             <a>Fire an event</a> named <var>name</var> at <var>request</var>
             using <a>PaymentRequestUpdateEvent</a>.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/marcos-travel/browser-payment-api/redundant_event.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/427d0d5...marcos-travel:d36e79a.html)