### PR TITLE
editorial: Clarify wording to not imply 'pull' only payments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1761,8 +1761,8 @@
         </h2>
         <p>
           An object that provides a <a>payment method</a> specific message used
-          by the merchant to process the transaction and determine successful
-          fund transfer. This data is returned by the <a>payment method</a>
+          by the merchant to process the transaction or validate the transaction
+          has been processed. This data is returned by the <a>payment method</a>
           specific code that satisfies the payment request.
         </p>
       </section>
@@ -1849,7 +1849,7 @@
           The <a>complete()</a> method is called after the user has accepted
           the payment request and the <a>[[\acceptPromise]]</a> has been
           resolved. Calling the <a>complete()</a> method tells the <a>user
-          agent</a> that the transaction is over (and SHOULD cause any
+          agent</a> that the payment interaction is over (and SHOULD cause any
           remaining user interface to be closed).
         </p>
         <p>


### PR DESCRIPTION
Some minor wording changes to make it clear that a paymentrequest may
actually process a transaction rather than just supply credentials


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mattsaxon/browser-payment-api/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/b68348f...mattsaxon:5552930.html)