### PR TITLE
Use "NotAllowedError" instead of "QuotaExceededError"

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,7 +770,7 @@
           any of the desired <a>payment methods</a> supplied to the
           <a>PaymentRequest</a> constructor, and false if none are supported.
           If the method is called too often, the user agent might instead
-          return a promise rejected with a "<a>QuotaExceededError</a>"
+          return a promise rejected with a "<a>NotAllowedError</a>"
           <a>DOMException</a>, at its discretion.
         </p>
         <p>
@@ -785,7 +785,7 @@
             DOMException</a>.
           </li>
           <li>Optionally, at the <a>user agent</a>'s discretion, return a
-          promise rejected with a "<a>QuotaExceededError</a>"
+          promise rejected with a "<a>NotAllowedError</a>"
           <a>DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
@@ -2816,10 +2816,10 @@
             "!WEBIDL-LS#invalidstateerror">InvalidStateError</dfn></code>"
             </li>
             <li>"<code><dfn data-cite=
-            "!WEBIDL-LS#notsupportederror">NotSupportedError</dfn></code>"
+            "!WEBIDL-LS#notallowederror">NotAllowedError</dfn></code>"
             </li>
             <li>"<code><dfn data-cite=
-            "!WEBIDL-LS#quotaexceedederror">QuotaExceededError</dfn></code>"
+            "!WEBIDL-LS#notsupportederror">NotSupportedError</dfn></code>"
             </li>
             <li>"<code><dfn data-cite=
             "!WEBIDL-LS#securityerror">SecurityError</dfn></code>"


### PR DESCRIPTION
Fixes #485.

@nickjshearer is this what you had in mind?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/notallowederror.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/6421d94...2428ffe.html)