### PR TITLE
fix: broken links to HTML (closes #502)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2714,7 +2714,7 @@
               "!HTML#eventhandler">EventHandler</dfn></code>
             </li>
             <li>
-              <dfn data-cite="!HTML#queuing">queue a task</dfn>
+              <dfn data-cite="!HTML#queue-a-task">queue a task</dfn>
             </li>
             <li>
               <dfn data-cite="!HTML#user-interaction-task-source">user
@@ -2735,10 +2735,10 @@
               <dfn data-cite="!HTML#in-parallel">in parallel</dfn>
             </li>
             <li>the <code><dfn data-cite=
-            "!HTML#elementdef-iframe">iframe</dfn></code> element
+            "!HTML#the-iframe-element">iframe</dfn></code> element
             </li>
             <li>the <code><dfn data-cite=
-            "!HTML#element-attrdef-iframe-allowpaymentrequest">allowpaymentrequest</dfn></code>
+            "!HTML#attr-iframe-allowpaymentrequest">allowpaymentrequest</dfn></code>
             attribute
             </li>
           </ul>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/fix_html_links.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/9298cbd...aedf08c.html)