### PR TITLE
Remove 2119 language from privacy section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,8 +798,7 @@
             DOMException</a>.
           </li>
           <li>Optionally, at the <a>user agent</a>'s discretion, return a
-          promise rejected with a "<a>NotAllowedError</a>"
-          <a>DOMException</a>.
+          promise rejected with a "<a>NotAllowedError</a>" <a>DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
               abuse of the <a>canMakePayment()</a> method for fingerprinting
@@ -2690,8 +2689,10 @@
           Exposing user information
         </h2>
         <p>
-          The <a>user agent</a> MUST NOT share information about the user to
-          the web page (such as the shipping address) without user consent.
+          A page might try to call the payment request API to retrieve
+          information about the user. Information about the user (such as the
+          shipping address) should only be shared with the web page with user
+          consent.
         </p>
       </section>
       <section>


### PR DESCRIPTION
Fixes #439.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/adrianba/browser-payment-api/issue439.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/e0cf815...adrianba:4c3b4a7.html)