### PR TITLE
Reject with SecurityError if the UA rejects the call to show().

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,6 +623,24 @@
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
           which the method is called.
           </li>
+          <li>
+            <p>
+              If the <a>user agent</a> rejects the call to <a>show()</a> to
+              protect the user, then return a promise rejected with a
+              "<a>SecurityError</a>" <a>DOMException</a>. For example, this
+              might occur if the <a>user agent</a> requires a user gesture to
+              allow a page to call <a>show()</a>, or the <a>user agent</a> may
+              limit the rate at which a page can call <a>show()</a>, as
+              described in the the <a href="#privacy">privacy
+              considerations</a> section.
+            </p>
+            <p class="note">
+              Implementations are expected to experiment in this area.
+              Developers using the payment request API should investigate and
+              anticipate such experiments and understand under what
+              circumstances a <a>SecurityError</a> might occur.
+            </p>
+          </li>
           <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>"
           then return a promise rejected with an "<a>InvalidStateError</a>" <a>
             DOMException</a>.
@@ -798,8 +816,7 @@
             DOMException</a>.
           </li>
           <li>Optionally, at the <a>user agent</a>'s discretion, return a
-          promise rejected with a "<a>NotAllowedError</a>"
-          <a>DOMException</a>.
+          promise rejected with a "<a>NotAllowedError</a>" <a>DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
               abuse of the <a>canMakePayment()</a> method for fingerprinting
@@ -2677,7 +2694,7 @@
         </p>
       </section>
     </section>
-    <section class='informative'>
+    <section class='informative' id="privacy">
       <h2>
         Privacy Considerations
       </h2>

--- a/index.html
+++ b/index.html
@@ -625,20 +625,20 @@
           </li>
           <li>
             <p>
-              If the <a>user agent</a> rejects the call to <a>show()</a> to
-              protect the user, then return a promise rejected with a
-              "<a>SecurityError</a>" <a>DOMException</a>. For example, this
-              might occur if the <a>user agent</a> requires a user gesture to
-              allow a page to call <a>show()</a>, or the <a>user agent</a> may
-              limit the rate at which a page can call <a>show()</a>, as
-              described in the the <a href="#privacy">privacy
-              considerations</a> section.
+              Optionally, if the <a>user agent</a> wishes to disallow the call
+              to <a>show()</a> to protect the user, then return a promise
+              rejected with a "<a>SecurityError</a>" <a>DOMException</a>. For
+              example, the <a>user agent</a> may require the call to be
+              <a>triggered by user activation</a>, or may limit the rate at
+              which a page can call <a>show()</a>, as described in the the
+              <a href="#privacy">privacy considerations</a> section.
             </p>
-            <p class="note">
+            <p>
               Implementations are expected to experiment in this area.
               Developers using the payment request API should investigate and
               anticipate such experiments and understand under what
-              circumstances a <a>SecurityError</a> might occur.
+              circumstances a "<a>SecurityError</a>" <a>DOMException</a> might
+              occur.
             </p>
           </li>
           <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>"
@@ -2770,6 +2770,10 @@
             </li>
             <li>
               <dfn data-cite="!HTML#allowed-to-use">allowed to use</dfn>
+            </li>
+            <li>
+              <dfn data-cite="!HTML#triggered-by-user-activation">triggered by
+              user activation</dfn>
             </li>
             <li>
               <dfn data-cite="!HTML#in-parallel">in parallel</dfn>


### PR DESCRIPTION
Fixes #486.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/adrianba/browser-payment-api/issue486.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/e0cf815...adrianba:cd50c27.html)