### PR TITLE
editorial: use DOM relatedTarget instead of .target (closes #513)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2034,7 +2034,7 @@
             instance.
             </li>
             <li>Let <var>target</var> be the value of <var>event</var>'s
-            <a data-cite="DOM#dom-event-target">target</a> attribute.
+            <a data-cite="!DOM#event-relatedtarget">relatedTarget</a>.
             </li>
             <li>If <var>target</var> is not a <a>PaymentRequest</a> object,
             then <a>throw</a> a <a>TypeError</a>.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/relatedTarget.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/fbb526e...5bc3ac4.html)