### PR TITLE
editorial: s/target/request in updateWith() algo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2033,10 +2033,10 @@
             <li>Let <var>event</var> be this <a>PaymentRequestUpdateEvent</a>
             instance.
             </li>
-            <li>Let <var>target</var> be the value of <var>event</var>'s
+            <li>Let <var>request</var> be the value of <var>event</var>'s
             <a data-cite="DOM#dom-event-target">target</a> attribute.
             </li>
-            <li>If <var>target</var> is not a <a>PaymentRequest</a> object,
+            <li>If <var>request</var> is not a <a>PaymentRequest</a> object,
             then <a>throw</a> a <a>TypeError</a>.
             </li>
             <li>If the <a>dispatch flag</a> is unset, then <a>throw</a> an
@@ -2045,11 +2045,11 @@
             <li>If <var>event</var>.<a>[[\waitForUpdate]]</a> is true, then <a>
               throw</a> an "<a>InvalidStateError</a>" <a>DOMException</a>.
             </li>
-            <li>If <var>target</var>.<a>[[\state]]</a> is not
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
             "<a>interactive</a>", then <a>throw</a> an
             "<a>InvalidStateError</a>" <a>DOMException</a>.
             </li>
-            <li>If <var>target</var>.<a>[[\updating]]</a> is true, then
+            <li>If <var>request</var>.<a>[[\updating]]</a> is true, then
             <a>throw</a> an "<a>InvalidStateError</a>" <a>DOMException</a>.
             </li>
             <li>Set <var>event</var>'s <a>stop propagation flag</a> and <a>stop
@@ -2057,7 +2057,7 @@
             </li>
             <li>Set <var>event</var>.<a>[[\waitForUpdate]]</a> to true.
             </li>
-            <li>Set <var>target</var>.<a>[[\updating]]</a> to true.
+            <li>Set <var>request</var>.<a>[[\updating]]</a> to true.
             </li>
             <li>The <a>user agent</a> SHOULD disable the user interface that
             allows the user to accept the payment request. This is to ensure


### PR DESCRIPTION
Makes this algorithm consistent with other algorithms.
Also avoids having to backtrack to check the type of "target".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/request_instead_of_target.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/fbb526e...029d1aa.html)