### PR TITLE
Remove merchant preference language

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="generator" content=
-    "HTML Tidy for HTML5 for Mac OS X version 5.4.0">
     <title>
       Payment Request API
     </title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="generator" content=
+    "HTML Tidy for HTML5 for Mac OS X version 5.4.0">
     <title>
       Payment Request API
     </title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="generator" content=
+    "HTML Tidy for HTML5 for Mac OS X version 5.4.0">
     <title>
       Payment Request API
     </title>
@@ -181,6 +183,10 @@
           <li>Allow the user agent to act as intermediary between merchants,
           users, and <a>payment method</a> providers.
           </li>
+          <li>Enable user agents to streamline the user's payment experience by
+          taking into account user preferences, merchant information, security
+          considerations, and other factors.
+          </li>
           <li>Standardize (to the extent that it makes sense) the communication
           flow between a merchant, user agent, and <a>payment method</a>
           provider.
@@ -310,9 +316,7 @@
           The <a>PaymentRequest</a> is constructed using the supplied
           <var>methodData</var> list including any <a>payment method</a>
           specific <a data-lt="PaymentMethodData.data">data</a>, the payment
-          <var>details</var>, and the payment <var>options</var>. The
-          <var>methodData</var> supplied to the <a>PaymentRequest</a>
-          constructor SHOULD be in the order of preference of the caller.
+          <var>details</var>, and the payment <var>options</var>.
         </p>
         <div class="note">
           <p>
@@ -721,10 +725,8 @@
               Otherwise, show a user interface to allow the user to interact
               with the payment request process, using those <a>payment handlers</a>
               and <a>payment methods</a> which the above step identified as
-              feasible. The user agent MAY show payment methods in the order
-              given by <var>supportedMethods</var>, but SHOULD prioritize the
-              preference of the user when presenting payment methods and
-              applications.
+              feasible. The user agent SHOULD prioritize the preference of the
+              user when presenting payment methods and applications.
             </p>
             <p>
               The <a>payment handler</a> should be sent the appropriate data from
@@ -2746,8 +2748,8 @@
           A page might try to call the payment request API repeatedly with only
           one payment method identifier to try to determine what payment
           methods a <a>user agent</a> has installed. There may be legitimate
-          scenarios for calling repeatedly (for example, to control the order
-          of payment method selection). The fact that a successful match to a
+          scenarios for calling repeatedly (for example, to control the flow of
+          payment method selection). The fact that a successful match to a
           payment method causes a user interface to be displayed mitigates the
           disclosure risk. Implementations may also require a user action to
           initiate a payment request or they may choose to rate limit the calls


### PR DESCRIPTION
Redoing previous PR that I accidentally killed:
 https://github.com/w3c/browser-payment-api/pull/506#issue-220225305

This version takes into account the previous editorial suggestions (and tidy).

(Apologies for not doing this on a separate branch. In my rush to recover the
lost commit history I neglected to create a separate branch.)

This PR does not address feedback from @mattsaxon and @mountainhippo;
I am merely recreating what I deleted in error.

Ian


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ianbjacobs/browser-payment-api/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/df83baf...ianbjacobs:de74e6a.html)