### PR TITLE
Reject acceptedPromise if converting method data fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
     </title>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class=
-    'remove'>
-    </script>
+    'remove'></script>
     <script class='remove'>
     var respecConfig = {
       github: "https://github.com/w3c/browser-payment-api/",
@@ -704,11 +703,11 @@
               <var>acceptPromise</var> with that error and terminate this
               algorithm.
               </li>
-              <li>Determine which <a>payment handlers</a> support any of the
-              <a>payment method identifiers</a> given <var>identifier</var>.
-              For each resulting payment handler, if payment method specific
-              capabilities supplied by the payment handler match those provided
-              by <var>data</var>, the payment handler matches.
+              <li>Determine which <a>payment handlers</a> support
+              <var>identifier</var>. For each resulting payment handler, if
+              payment method specific capabilities supplied by the payment
+              handler match those provided by <var>data</var>, the payment
+              handler matches.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
     </title>
     <meta charset='utf-8'>
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class=
-    'remove'></script>
+    'remove'>
+    </script>
     <script class='remove'>
     var respecConfig = {
       github: "https://github.com/w3c/browser-payment-api/",
@@ -685,8 +686,8 @@
           <li>For each <var>paymentMethod</var> tuple in
           <var>request</var>.<a>[[\serializedMethodData]]</a>:
             <ol>
-              <li>Let <var>identifier</var> be the first element in the <var>
-                paymentMethod</var> tuple.
+              <li>Let <var>identifier</var> be the first element in the
+              <var>paymentMethod</var> tuple.
               </li>
               <li>Let <var>data</var> be the result of <a data-cite=
               "!ECMA-262-2015#sec-json.parse">JSON-parsing</a> the second
@@ -703,9 +704,11 @@
               <var>acceptPromise</var> with that error and terminate this
               algorithm.
               </li>
-              <li>If payment method specific capabilities supplied by the
-              payment handler match those provided by <var>data</var>, the
-              payment handler matches.
+              <li>Determine which <a>payment handlers</a> support any of the
+              <a>payment method identifiers</a> given <var>identifier</var>.
+              For each resulting payment handler, if payment method specific
+              capabilities supplied by the payment handler match those provided
+              by <var>data</var>, the payment handler matches.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -700,8 +700,8 @@
                   <li>If required by the specification that defines the
                   <var>handler</var>, <a data-cite=
                   "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-                  <var>data</var> to an IDL value. If it results in a error,
-                  reject <var>acceptPromise</var> with that error an terminate
+                  <var>data</var> to an IDL value. If it results in an error,
+                  reject <var>acceptPromise</var> with that error and terminate
                   this algorithm.
                   </li>
                   <li>If payment method specific capabilities supplied by the

--- a/index.html
+++ b/index.html
@@ -693,9 +693,20 @@
               </li>
               <li>Determine which <a>payment handlers</a> support any of the
               <a>payment method identifiers</a> given <var>identifiers</var>.
-              For each resulting payment handler, if payment method specific
-              capabilities supplied by the payment handler match those provided
-              by <var>data</var>, the payment handler matches.
+              </li>
+              <li>For each <var>handler</var> of the resulting payment
+              handlers:
+                <ol>
+                  <li>If required by the specification that defines the
+                  <var>handler</var>, <a data-cite=
+                  "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
+                  <var>data</var> to an IDL value. Rethrow any exceptions.
+                  </li>
+                  <li>If payment method specific capabilities supplied by the
+                  payment handler match those provided by <var>data</var>, the
+                  payment handler matches.
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -688,21 +688,25 @@
               <li>Let <var>identifiers</var> be the first element in the <var>
                 paymentMethod</var> tuple.
               </li>
-              <li>Let <var>data</var> be the second element in
-              <var>paymentMethod</var> tuple.
+              <li>Let <var>data</var> be the result of <a data-cite=
+              "!ECMA-262-2015#sec-json.parse">JSON-parsing</a> the second
+              element in <var>paymentMethod</var> tuple.
               </li>
-              <li>Determine which <a>payment handlers</a> support any of the
-              <a>payment method identifiers</a> given <var>identifiers</var>.
+              <li>Let <var>methods</var> be a list of <a>payment methods</a>
+              that support <var>identifiers</var>.
               </li>
-              <li>For each <var>handler</var> of the resulting payment
-              handlers:
+              <li>For each <var>paymentMethod</var> of <var>methods</var>:
                 <ol>
                   <li>If required by the specification that defines the
-                  <var>handler</var>, <a data-cite=
+                  <var>paymentMethod</var>, then <a data-cite=
                   "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-                  <var>data</var> to an IDL value. If it results in an error,
-                  reject <var>acceptPromise</var> with that error and terminate
-                  this algorithm.
+                  <var>data</var> to an IDL value. Otherwise, <a data-cite=
+                  "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
+                  <a data-cite="!WEBIDL#idl-object">object</a>.
+                  </li>
+                  <li>If conversion results in an error, reject
+                  <var>acceptPromise</var> with that error and terminate this
+                  algorithm.
                   </li>
                   <li>If payment method specific capabilities supplied by the
                   payment handler match those provided by <var>data</var>, the

--- a/index.html
+++ b/index.html
@@ -700,7 +700,9 @@
                   <li>If required by the specification that defines the
                   <var>handler</var>, <a data-cite=
                   "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-                  <var>data</var> to an IDL value. Rethrow any exceptions.
+                  <var>data</var> to an IDL value. If it results in a error,
+                  reject <var>acceptPromise</var> with that error an terminate
+                  this algorithm.
                   </li>
                   <li>If payment method specific capabilities supplied by the
                   payment handler match those provided by <var>data</var>, the

--- a/index.html
+++ b/index.html
@@ -685,34 +685,27 @@
           <li>For each <var>paymentMethod</var> tuple in
           <var>request</var>.<a>[[\serializedMethodData]]</a>:
             <ol>
-              <li>Let <var>identifiers</var> be the first element in the <var>
+              <li>Let <var>identifier</var> be the first element in the <var>
                 paymentMethod</var> tuple.
               </li>
               <li>Let <var>data</var> be the result of <a data-cite=
               "!ECMA-262-2015#sec-json.parse">JSON-parsing</a> the second
               element in <var>paymentMethod</var> tuple.
               </li>
-              <li>Let <var>methods</var> be a list of <a>payment methods</a>
-              that support <var>identifiers</var>.
+              <li>If required by the specification that defines the
+              <var>identifer</var>, then <a data-cite=
+              "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
+              <var>data</var> to an IDL value. Otherwise, <a data-cite=
+              "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
+              <a data-cite="!WEBIDL#idl-object">object</a>.
               </li>
-              <li>For each <var>paymentMethod</var> of <var>methods</var>:
-                <ol>
-                  <li>If required by the specification that defines the
-                  <var>paymentMethod</var>, then <a data-cite=
-                  "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-                  <var>data</var> to an IDL value. Otherwise, <a data-cite=
-                  "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
-                  <a data-cite="!WEBIDL#idl-object">object</a>.
-                  </li>
-                  <li>If conversion results in an error, reject
-                  <var>acceptPromise</var> with that error and terminate this
-                  algorithm.
-                  </li>
-                  <li>If payment method specific capabilities supplied by the
-                  payment handler match those provided by <var>data</var>, the
-                  payment handler matches.
-                  </li>
-                </ol>
+              <li>If conversion results in an error, reject
+              <var>acceptPromise</var> with that error and terminate this
+              algorithm.
+              </li>
+              <li>If payment method specific capabilities supplied by the
+              payment handler match those provided by <var>data</var>, the
+              payment handler matches.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Align with https://github.com/w3c/webpayments-methods-card/pull/23/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/conversion.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/a3c35fb...5896b12.html)