### PR TITLE
Cater for platform-specific limitations

### DIFF
--- a/index.html
+++ b/index.html
@@ -2904,7 +2904,7 @@
         result that would be obtained by the specification's algorithms.
       </p>
       <p>
-        User agents impose implementation-specific limits on otherwise
+        User agents MAY impose implementation-specific limits on otherwise
         unconstrained inputs, e.g., to prevent denial of service attacks, to
         guard against running out of memory, or to work around
         platform-specific limitations. When an input exceeds

--- a/index.html
+++ b/index.html
@@ -2904,6 +2904,12 @@
         result that would be obtained by the specification's algorithms.
       </p>
       <p>
+        User agents MAY impose implementation-specific limits on otherwise
+        unconstrained inputs, e.g., to prevent denial of service attacks, to
+        guard against running out of memory, or to work around
+        platform-specific limitations.
+      </p>
+      <p>
         The working group will demonstrate implementation experience by
         creating a <a href=
         "https://github.com/w3c/web-platform-tests/tree/master/payment-request">

--- a/index.html
+++ b/index.html
@@ -2904,10 +2904,13 @@
         result that would be obtained by the specification's algorithms.
       </p>
       <p>
-        User agents MAY impose implementation-specific limits on otherwise
+        User agents impose implementation-specific limits on otherwise
         unconstrained inputs, e.g., to prevent denial of service attacks, to
         guard against running out of memory, or to work around
-        platform-specific limitations.
+        platform-specific limitations. When an input exceeds
+        implementation-specific limit, the user agent MUST throw a
+        <a>TypeError</a> optionally informing the developer of how a particular
+        input exceeded a implementation-specific limit.
       </p>
       <p>
         The working group will demonstrate implementation experience by

--- a/index.html
+++ b/index.html
@@ -2910,7 +2910,7 @@
         platform-specific limitations. When an input exceeds
         implementation-specific limit, the user agent MUST throw, or, in the
         context of a promise, reject with, a <a>TypeError</a> optionally
-        informing the developer of how a particular input exceeded a
+        informing the developer of how a particular input exceeded an
         implementation-specific limit.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -2908,9 +2908,10 @@
         unconstrained inputs, e.g., to prevent denial of service attacks, to
         guard against running out of memory, or to work around
         platform-specific limitations. When an input exceeds
-        implementation-specific limit, the user agent MUST throw a
-        <a>TypeError</a> optionally informing the developer of how a particular
-        input exceeded a implementation-specific limit.
+        implementation-specific limit, the user agent MUST throw, or, in the
+        context of a promise, reject with, a <a>TypeError</a> optionally
+        informing the developer of how a particular input exceeded a
+        implementation-specific limit.
       </p>
       <p>
         The working group will demonstrate implementation experience by


### PR DESCRIPTION
Through [newly added web platform tests](https://w3c-test.org/payment-request/), we discovered that it was possible to crash various browsers through unreasonably large inputs (e.g., unrealistically large currency values of sizes of  10<sup>102</sup>). Or [absurdly sized payment request `id`s values](https://bugs.chromium.org/p/chromium/issues/detail?id=725744#c16). 

This differs across platforms, because of various platform specific limits. E.g., string size limits are different on Android vs on desktop platforms etc.   

As such, naturally, user agents will need to guard against unreasonably-large inputs (hence this PR).  

Accompanying this change, we will change the web platform tests to limit inputs to a size of 1024 characters. That's large enough to accommodate must ridiculous values (again, e.g., a currency being 1024 characters long), but not risk hitting platform specific limits. 

What we might do, is include these stress tests nonetheless, but just have them in try/catch blocks, to ensure the browser doesn't crash - but make no assumption that browsers will be able to handle these large values. 

@foolip, @jgraham, @zcorpan, would appreciate your input. Does the change to the web platform tests sound reasonable? Is there precedence we should follow? 

N.B.: Firefox and Chrome have been patched or are being patched to fix the crashes. But more evil tests to come! 😈


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/limits.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/a3c35fb...140b18c.html)