### PR TITLE
Make privacy section normative (closes #439)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2729,7 +2729,7 @@
         </p>
       </section>
     </section>
-    <section class='informative' id="privacy">
+    <section id="privacy">
       <h2>
         Privacy Considerations
       </h2>
@@ -2753,13 +2753,13 @@
         <p>
           Developers might try to call the payment request API repeatedly with
           only one payment method identifier to try to determine what payment
-          methods a <a>user agent</a> has installed. There may be legitimate
+          methods a <a>user agent</a> has installed. There are legitimate
           scenarios for calling repeatedly (for example, to control the flow of
           payment method selection). The fact that a successful match to a
           payment method causes a user interface to be displayed mitigates the
-          disclosure risk. Implementations may also require a user action to
-          initiate a payment request or they may choose to rate limit the calls
-          to the API to prevent too many repeated calls.
+          disclosure risk. Implementations MAY require a user action to
+          initiate a payment request or they MAY rate limit the calls to the
+          API to prevent too many repeated calls.
         </p>
       </section>
     </section>


### PR DESCRIPTION
Supersedes https://github.com/w3c/browser-payment-api/pull/511 - based on discussion there.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/priv_sec.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/a7e1bda...00e4364.html)