### PR TITLE
editorial: fix CR exit date, add exit criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,24 @@
         are strongly encouraged.
       </p>
       <p>
-        The deadline for comments for Candidate Recommendation is 30 September
-        2017.
+        The deadline for comments for Candidate Recommendation is <span title=
+        "👻">31 October 2017</span>.
+      </p>
+      <p>
+        W3C publishes a Candidate Recommendation to to encourage implementation
+        by the browser vendors and to encourage usage by the developer
+        community. The Web Payments Working Group expects to request that the
+        Director advance this document to Proposed Recommendation once the
+        Working Group has developed a comprehensive <a href=
+        "https://w3c-test.org/payment-request/">test suite</a>, and
+        demonstrated at least two interoperable implementations via an <a href=
+        "https://w3c.github.io/browser-payment-api/reports/implementation.html">
+        implementation report</a> (interoperable meaning at least two
+        independent, widely deployed, browser engines that pass each test in
+        the test suite). The Working Group expects to show these
+        implementations by October 2017. The Working Group does not plan to
+        request to advance to Proposed Recommendation prior to 31 November 2017
+        (or more likely early 2018).
       </p>
       <div class="note" title="Sending comments on this document">
         <p>


### PR DESCRIPTION
* Addresses "must document how adequate implementation experience will be demonstrated" requirement of CR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/advancement.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/browser-payment-api/daeb37d...a29f7a0.html)