### PR TITLE
validate PaymentCurrencyAmount.currency (closes #490)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1318,12 +1318,11 @@
           <li>Optionally, a single U+002D (-), to indicate that the amount is
           negative.
           </li>
-          <li>One or more <a>code points</a> in the range U+0030 DIGIT ZERO (0)
-          to U+0039 DIGIT NINE (9).
+          <li>One or more <a>code points</a> in the range U+0030 (0) to U+0039
+          (9).
           </li>
-          <li>Optionally, a single U+002E FULL STOP (.) followed by one or more
-          <a>code points</a> in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT
-          NINE (9).
+          <li>Optionally, a single U+002E (.) followed by one or more <a>code
+          points</a> in the range U+0030 (0) to U+0039 (9).
           </li>
         </ol>
         <div class="note">
@@ -1374,9 +1373,9 @@
             <a>Check and canonicalize <var>amount</var></a>. Rethrow any
             exceptions.
           </li>
-          <li>If the first <a>code point</a> of <var>value</var> is U+002D
-          HYPHEN-MINUS, then throw a <a>TypeError</a> optionally informing the
-          developer that a total can't be a negative number.
+          <li>If the first <a>code point</a> of <var>value</var> is U+002D (-),
+          then throw a <a>TypeError</a> optionally informing the developer that
+          a total can't be a negative number.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -1346,7 +1346,7 @@
           currency is invalid.
           </li>
           <li>Set <var>amount</var>.<a>currency</a> to the result of
-          <a data-cite="!infra#ascii-uppercase">ASCII uppercasing</a>
+          <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>
           <var>amount</var>.<a>currency</a>.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -1252,7 +1252,7 @@
           <dd>
             A URL that indicates the currency system that the <a>currency</a>
             identifier belongs to. By default, the value is
-            <code>urn:iso:std:iso:4217</code> indicating that <a>currency</a>
+            "<code>urn:iso:std:iso:4217</code>" indicating that <a>currency</a>
             is defined by [[!ISO4217]] (for example, <code>USD</code> for US
             Dollars).
           </dd>

--- a/index.html
+++ b/index.html
@@ -537,14 +537,11 @@
           </li>
           <li data-link-for="PaymentDetailsInit">Process the total:
             <ol>
-              <li>Let <var>total</var> be
-              <var>details</var>.<a>total</a>.<a data-lt=
-              "PaymentItem.amount">amount</a>.
-              </li>
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
-                <a>Check and canonicalize <var>total</var></a>. Rethrow any
-                exceptions.
+                <a>Check and canonicalize total</a>
+                <var>details</var>.<a>total</a>.<a data-lt=
+                "PaymentItem.amount">amount</a>. Rethrow any exceptions.
               </li>
             </ol>
           </li>
@@ -552,13 +549,11 @@
           present, then for each <var>item</var> in
           <var>details</var>.<a>displayItems</a>:
             <ol>
-              <li>Let <var>amount</var> be <var>item</var>.<a data-lt=
-              "PaymentItem.amount">amount</a>.
-              </li>
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
-                <a>Check and canonicalize <var>amount</var></a>. Rethrow any
-                exceptions.
+                <a>Check and canonicalize amount</a>
+                <var>item</var>.<a data-lt="PaymentItem.amount">amount</a>.
+                Rethrow any exceptions.
               </li>
             </ol>
           </li>
@@ -580,13 +575,12 @@
                   </li>
                   <li>For each <var>option</var> in <var>options</var>:
                     <ol>
-                      <li>Let <var>amount</var> be
-                        <var>item</var>.<a data-lt="PaymentItem.amount">amount</a>.
-                      </li>
                       <li data-tests=
                       "payment-request-ctor-currency-code-checks.https.html">
-                        <a>Check and canonicalize <var>amount</var></a>.
-                        Rethrow any exceptions.
+                        <a>Check and canonicalize amount</a>
+                        <var>item</var>.<a data-lt=
+                        "PaymentItem.amount">amount</a>. Rethrow any
+                        exceptions.
                       </li>
                       <li>If <var>seenIDs</var> contains
                       <var>option</var>.<a>id</a>, then set <var>options</var>
@@ -635,13 +629,11 @@
                       "PaymentDetailsModifier.total">total</a> member of <var>
                         modifier</var> is present, then:
                         <ol>
-                          <li>Let <var>total</var> be
-                          <var>modifier</var>.<a data-lt=
-                          "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>
-                          </li>
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
-                            <a>Check and canonicalize <var>total</var></a>.
+                            <a>Check and canonicalize total</a>
+                            <var>modifier</var>.<a data-lt=
+                            "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>.
                             Rethrow any exceptions.
                           </li>
                         </ol>
@@ -652,14 +644,12 @@
                       <var>item</var> of <var>modifier</var>.<a data-lt=
                       "PaymentDetailsModifier.additionalDisplayItems">additionalDisplayItems</a>:
                         <ol>
-                          <li>Let <var>amount</var> be
-                          <var>item</var>.<a data-lt=
-                          "PaymentItem.amount">amount</a>.
-                          </li>
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
-                            <a>Check and canonicalize <var>amount</var></a>.
-                            Rethrow any exceptions.
+                            <a>Check and canonicalize amount</a>
+                            <var>item</var>.<a data-lt=
+                            "PaymentItem.amount">amount</a>. Rethrow any
+                            exceptions.
                           </li>
                         </ol>
                       </li>
@@ -1370,7 +1360,7 @@
           <code>urn:iso:std:iso:4217</code>, terminate this algorithm.
           </li>
           <li>
-            <a>Check and canonicalize <var>amount</var></a>. Rethrow any
+            <a>Check and canonicalize amount</a> <var>amount</var>. Rethrow any
             exceptions.
           </li>
           <li>If the first <a>code point</a> of <var>value</var> is U+002D (-),
@@ -2395,14 +2385,12 @@
                     <li data-link-for="PaymentDetailsUpdate">If the
                     <a>total</a> member of <var>details</var> is present, then:
                       <ol>
-                        <li>Let <var>total</var> be
-                        <var>details</var>.<a>total</a>.<a data-lt=
-                        "PaymentItem.amount">amount</a>.
-                        </li>
                         <li>
-                          <a>Check and canonicalize <var>total</var></a>. If an
-                          exception is thrown, then <a>abort the update</a>
-                          with that exception.
+                          <a>Check and canonicalize total</a>
+                          <var>details</var>.<a>total</a>.<a data-lt=
+                          "PaymentItem.amount">amount</a>. If an exception is
+                          thrown, then <a>abort the update</a> with that
+                          exception.
                         </li>
                       </ol>
                     </li>
@@ -2410,13 +2398,12 @@
                     is present, then for each <var>item</var> in
                     <var>details</var>.<a>displayItems</a>:
                       <ol>
-                        <li>Let <var>amount</var> be
-                          <var>item</var>.<a data-lt="PaymentItem.amount">amount</a>.
-                        </li>
                         <li>
-                          <a>Check and canonicalize <var>amount</var></a>. If
-                          an exception is thrown, then <a>abort the update</a>
-                          with that exception.
+                          <a>Check and canonicalize amount</a>
+                          <var>item</var>.<a data-lt=
+                          "PaymentItem.amount">amount</a>. If an exception is
+                          thrown, then <a>abort the update</a> with that
+                          exception.
                         </li>
                       </ol>
                     </li>
@@ -2434,14 +2421,12 @@
                         <li>For each <var>option</var> in
                         <var>shippingOptions</var>:
                           <ol>
-                            <li>Let <var>amount</var> be
-                            <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.amount">amount</a>.
-                            </li>
                             <li>
-                              <a>Check and canonicalize <var>amount</var></a>.
-                              If an exception is thrown, then <a>abort the
-                              update</a> with that exception.
+                              <a>Check and canonicalize amount</a>
+                              <var>option</var>.<a data-lt=
+                              "PaymentShippingOption.amount">amount</a>. If an
+                              exception is thrown, then <a>abort the update</a>
+                              with that exception.
                             </li>
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
@@ -2483,15 +2468,12 @@
                             <li>If the <a>total</a> member of
                             <var>modifier</var> is present, then:
                               <ol>
-                                <li>Let <var>total</var> be
-                                <var>modifier</var>.<a>total</a>.<a data-lt=
-                                "PaymentItem.amount">amount</a>.
-                                </li>
                                 <li>
-                                  <a>Check and canonicalize
-                                  <var>total</var></a>. If an exception is
-                                  thrown, then <a>abort the update</a> with
-                                  that exception.
+                                  <a>Check and canonicalize total</a>
+                                  <var>modifier</var>.<a>total</a>.<a data-lt=
+                                  "PaymentItem.amount">amount</a>. If an
+                                  exception is thrown, then <a>abort the
+                                  update</a> with that exception.
                                 </li>
                               </ol>
                             </li>
@@ -2500,15 +2482,12 @@
                             <a>PaymentItem</a> <var>item</var> in
                             <var>modifier</var>.<a>additionalDisplayItems</a>:
                               <ol>
-                                <li>Let <var>amount</var> be
-                                <var>item</var>.<a data-lt=
-                                "PaymentItem.amount">amount</a>.
-                                </li>
                                 <li>
-                                  <a>Check and canonicalize
-                                  <var>amount</var></a>. If an exception is
-                                  thrown, then <a>abort the update</a> with
-                                  that exception.
+                                  <a>Check and canonicalize amount</a>
+                                  <var>item</var>.<a data-lt=
+                                  "PaymentItem.amount">amount</a>. If an
+                                  exception is thrown, then <a>abort the
+                                  update</a> with that exception.
                                 </li>
                               </ol>
                             </li>

--- a/index.html
+++ b/index.html
@@ -1321,9 +1321,9 @@
           <pre class="hljs">^-?[0-9]+(\.[0-9]+)?$</pre>
         </div>
         <p>
-          To <dfn data-lt="check and canonicalize amount">check and
-          canonicalize <var>amount</var> <a>PaymentCurrencyAmount</a></dfn>,
-          run the following steps:
+          To <dfn>check and canonicalize amount</dfn> given a
+          <a>PaymentCurrencyAmount</a> <var>amount</var>, run the following
+          steps:
         </p>
         <ol data-link-for="PaymentCurrencyAmount">
           <li>If <var>amount</var>.<a>currencySystem</a> is not
@@ -1339,11 +1339,9 @@
           <a>RangeError</a> exception and terminate this algorithm, optionally
           informing the developer that the currency is invalid.
           </li>
-          <li>Let <var>value</var> be <var>amount</var>.<a>value</a>.
-          </li>
-          <li>If <var>value</var> is not a <a>valid decimal monetary value</a>,
-          throw a <a>TypeError</a>, optionally informing the developer that the
-          currency is invalid.
+          <li>If <var>amount</var>.<a>value</a> is not a <a>valid decimal
+          monetary value</a>, throw a <a>TypeError</a>, optionally informing
+          the developer that the currency is invalid.
           </li>
           <li>Set <var>amount</var>.<a>currency</a> to the result of
           <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>
@@ -1351,13 +1349,13 @@
           </li>
         </ol>
         <p>
-          To <dfn data-lt="check and canonicalize total">check and canonicalize
-          <var>total</var> <a>PaymentCurrencyAmount</a></dfn>, run the
-          following steps:
+          To <dfn>check and canonicalize total</dfn> given a
+          <a>PaymentCurrencyAmount</a> <var>total</var>, run the following
+          steps:
         </p>
         <ol data-link-for="PaymentCurrencyAmount">
           <li>If <var>total</var>.<a>currencySystem</a> is not
-          <code>urn:iso:std:iso:4217</code>, terminate this algorithm.
+          "<code>urn:iso:std:iso:4217</code>", terminate this algorithm.
           </li>
           <li>
             <a>Check and canonicalize amount</a> <var>amount</var>. Rethrow any
@@ -3027,7 +3025,7 @@
           </ul>
         </dd>
         <dt>
-          ECMA-262 6th Edition, The ECMAScript 2015 Language Specification
+          ECMAScript
         </dt>
         <dd>
           The terms <dfn data-cite=

--- a/index.html
+++ b/index.html
@@ -431,34 +431,6 @@
         </pre>
       </section>
     </section>
-    <section>
-      <h2>
-        Definitions
-      </h2>
-      <p>
-        A <dfn data-cite="INFRA#javascript-string">JavaScript string</dfn> is a
-        <dfn>valid decimal monetary value</dfn> if it consists of the following
-        <dfn data-lt="code point" data-cite="INFRA#code-point">code
-        points</dfn> in the given order: [[!INFRA]]
-      </p>
-      <ol>
-        <li>Optionally, a single U+002D HYPHEN-MINUS (-), to indicate that the
-        amount is negative.
-        </li>
-        <li>One or more <a>code points</a> in the range U+0030 DIGIT ZERO (0)
-        to U+0039 DIGIT NINE (9).
-        </li>
-        <li>Optionally, a single U+002E FULL STOP (.) followed by one or more
-        <a>code points</a> in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT
-        NINE (9).
-        </li>
-      </ol>
-      <div class="note">
-        The following regular expression is an implementation of the above
-        definition.
-        <pre class="hljs">^-?[0-9]+(\.[0-9]+)?$</pre>
-      </div>
-    </section>
     <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
       <h2>
         <dfn>PaymentRequest</dfn> interface
@@ -565,18 +537,13 @@
           </li>
           <li data-link-for="PaymentDetailsInit">Process the total:
             <ol>
-              <li>If <var>details</var>.<a>total</a>.<a data-lt=
-              "PaymentItem.amount">amount</a>.<a data-lt=
-              "PaymentCurrencyAmount.value">value</a> is not a <a>valid decimal
-              monetary value</a>, then <a>throw</a> a <a>TypeError</a>;
-              optionally informing the developer that the value is invalid.
-              </li>
-              <li>If the first <a>code point</a> of
+              <li>Let <var>total</var> be
               <var>details</var>.<a>total</a>.<a data-lt=
-              "PaymentItem.amount">amount</a>.<a data-lt=
-              "PaymentCurrencyAmount.value">value</a> is U+002D HYPHEN-MINUS,
-              then <a>throw</a> a <a>TypeError</a>, optionally informing the
-              developer that the total can't be negative.
+              "PaymentItem.amount">amount</a>.
+              </li>
+              <li>
+                <a>Check and canonicalize <var>total</var></a>. Rethrow any
+                exceptions.
               </li>
             </ol>
           </li>
@@ -584,11 +551,12 @@
           present, then for each <var>item</var> in
           <var>details</var>.<a>displayItems</a>:
             <ol>
-              <li>If <var>item</var>.<a data-lt=
-              "PaymentItem.amount">amount</a>.<a data-lt=
-              "PaymentCurrencyAmount.value">value</a> is not a <a>valid decimal
-              monetary value</a>, then <a>throw</a> a <a>TypeError</a>,
-              optionally informing the developer that the value is invalid.
+              <li>Let <var>amount</var> be <var>item</var>.<a data-lt=
+              "PaymentItem.amount">amount</a>.
+              </li>
+              <li>
+                <a>Check and canonicalize <var>amount</var></a>. Rethrow any
+                exceptions.
               </li>
             </ol>
           </li>
@@ -610,11 +578,12 @@
                   </li>
                   <li>For each <var>option</var> in <var>options</var>:
                     <ol>
-                      <li>If
-                        <var>option</var>.<a>amount</a>.<a data-link-for="PaymentCurrencyAmount">value</a>
-                        is not a <a>valid decimal monetary value</a>, then
-                        <a>throw</a> a <a>TypeError</a>, optionally informing
-                        the developer that the value is invalid.
+                      <li>Let <var>amount</var> be
+                        <var>item</var>.<a data-lt="PaymentItem.amount">amount</a>.
+                      </li>
+                      <li>
+                        <a>Check and canonicalize <var>amount</var></a>.
+                        Rethrow any exceptions.
                       </li>
                       <li>If <var>seenIDs</var> contains
                       <var>option</var>.<a>id</a>, then set <var>options</var>
@@ -663,19 +632,13 @@
                       "PaymentDetailsModifier.total">total</a> member of <var>
                         modifier</var> is present, then:
                         <ol>
-                          <li>Let <var>value</var> be
+                          <li>Let <var>total</var> be
                           <var>modifier</var>.<a data-lt=
-                          "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>.<a data-lt="PaymentCurrencyAmount.value">value</a>.
+                          "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>
                           </li>
-                          <li>If <var>value</var> is not a <a>valid decimal
-                          monetary value</a>, then throw a <a>TypeError</a>,
-                          optionally informing the developer that the value is
-                          invalid.
-                          </li>
-                          <li>If the first <a>code point</a> of
-                          <var>value</var> is U+002D HYPHEN-MINUS, then throw a
-                          <a>TypeError</a>, optionally informing the developer
-                          that the value can't be negative.
+                          <li>
+                            <a>Check and canonicalize <var>total</var></a>.
+                            Rethrow any exceptions.
                           </li>
                         </ol>
                       </li>
@@ -685,15 +648,13 @@
                       <var>item</var> of <var>modifier</var>.<a data-lt=
                       "PaymentDetailsModifier.additionalDisplayItems">additionalDisplayItems</a>:
                         <ol>
-                          <li>Let <var>value</var> be
+                          <li>Let <var>amount</var> be
                           <var>item</var>.<a data-lt=
-                          "PaymentItem.amount">amount</a>.<a data-lt=
-                          "PaymentCurrencyAmount.value">value</a>.
+                          "PaymentItem.amount">amount</a>.
                           </li>
-                          <li>If <var>value</var> is not a <a>valid decimal
-                          monetary value</a>, then throw a <a>TypeError</a>,
-                          optionally informing the developer that the value is
-                          invalid.
+                          <li>
+                            <a>Check and canonicalize <var>amount</var></a>.
+                            Rethrow any exceptions.
                           </li>
                         </ol>
                       </li>
@@ -866,8 +827,8 @@
               <var>paymentMethod</var> tuple.
               </li>
               <li>Let <var>data</var> be the result of <a data-cite=
-              "!ECMA-262-2015#sec-json.parse">JSON-parsing</a> the second
-              element in <var>paymentMethod</var> tuple.
+              "!ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
+              in <var>paymentMethod</var> tuple.
               </li>
               <li>If required by the specification that defines the
               <var>identifer</var>, then <a data-cite=
@@ -1297,7 +1258,7 @@
             A URL that indicates the currency system that the <a>currency</a>
             identifier belongs to. By default, the value is
             <code>urn:iso:std:iso:4217</code> indicating that <a>currency</a>
-            is defined by [[ISO4217]] (for example, <code>USD</code> for US
+            is defined by [[!ISO4217]] (for example, <code>USD</code> for US
             Dollars).
           </dd>
         </dl>
@@ -1307,9 +1268,21 @@
           <dfn>currency</dfn>
         </dt>
         <dd>
-          A string containing a currency identifier. The value of
-          <a>currency</a> can be any string that is valid within the currency
-          system indicated by <a>currencySystem</a>.
+          <p>
+            A string containing a currency identifier. The value of
+            <a>currency</a> can be any string that is valid within the currency
+            system indicated by <a>currencySystem</a>.
+          </p>
+          <p>
+            When using [[!ISO4217]], all <a data-cite=
+            "!ecma-402#sec-iswellformedcurrencycode">well-formed</a> 3-letter
+            currency codes are allowed. Their canonical form is upper case.
+            However, the set of combinations of currency code for which
+            localized currency symbols are available is implementation
+            dependent. Where a localized currency symbol is not available, a
+            user agent SHOULD us the [[!ISO4217]] currency code SHOULD be used
+            for formatting.
+          </p>
         </dd>
         <dt>
           <dfn>value</dfn>
@@ -1321,12 +1294,85 @@
       <p>
         The following example shows how to represent US$55.00.
       </p>
-      <pre class="example">
-{
-  "currency": "USD",
-  "value" : "55.00"
-}
+      <pre class="example js">
+        {
+          "currency": "USD",
+          "value" : "55.00"
+        }
       </pre>
+      <section>
+        <h3>
+          Validity checkers
+        </h3>
+        <p>
+          A <dfn data-cite="INFRA#javascript-string">JavaScript string</dfn> is
+          a <dfn>valid decimal monetary value</dfn> if it consists of the
+          following <dfn data-lt="code point" data-cite="INFRA#code-point">code
+          points</dfn> in the given order: [[!INFRA]]
+        </p>
+        <ol>
+          <li>Optionally, a single U+002D HYPHEN-MINUS (-), to indicate that
+          the amount is negative.
+          </li>
+          <li>One or more <a>code points</a> in the range U+0030 DIGIT ZERO (0)
+          to U+0039 DIGIT NINE (9).
+          </li>
+          <li>Optionally, a single U+002E FULL STOP (.) followed by one or more
+          <a>code points</a> in the range U+0030 DIGIT ZERO (0) to U+0039 DIGIT
+          NINE (9).
+          </li>
+        </ol>
+        <div class="note">
+          The following regular expression is an implementation of the above
+          definition.
+          <pre class="hljs">^-?[0-9]+(\.[0-9]+)?$</pre>
+        </div>
+        <p>
+          To <dfn data-lt="check and canonicalize amount">check and
+          canonicalize <var>amount</var> <a>PaymentCurrencyAmount</a></dfn>,
+          run the following steps:
+        </p>
+        <ol data-link-for="PaymentCurrencyAmount">
+          <li>If <a>currencySystem</a> is not
+          <code>urn:iso:std:iso:4217</code>, terminate this algorithm.
+          </li>
+          <li>let <var>isValidCurrency</var> be the result of calling
+          <a data-cite=
+          "!ecma-402#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a>
+          abstract operation with <a>currency</a> as the argument.
+          </li>
+          <li>If <var>isValidCurrency</var> returns false, then throw a
+          <a>RangeError</a> exception and terminate this algorithm, optionally
+          informing the developer that the currency is invalid.
+          </li>
+          <li>Let <var>value</var> be <var>amount</var>'s <a>value</a>.
+          </li>
+          <li>If <var>value</var> is not a <a>valid decimal monetary value</a>,
+          throw a <a>TypeError</a>, optionally informing the developer that the
+          currency is invalid.
+          </li>
+          <li>Canonicalize <a>currency</a> by converting it to upper case.
+          </li>
+        </ol>
+        <p>
+          To <dfn data-lt="check and canonicalize total">check and canonicalize
+          <var>total</var> <a>PaymentCurrencyAmount</a></dfn>, run the
+          following steps:
+        </p>
+        <ol data-link-for="PaymentCurrencyAmount">
+          <li>If <a>currencySystem</a> is not
+          <code>urn:iso:std:iso:4217</code>, terminate this algorithm.
+          </li>
+          <li>
+            <a>Check and canonicalize <var>amount</var></a>. Rethrow any
+            exceptions.
+          </li>
+          <li>If the first <a>code point</a> of <var>value</var> is U+002D
+          HYPHEN-MINUS, then throw a <a>TypeError</a> optionally informing the
+          developer that a total can't be a negative number.
+          </li>
+        </ol>
+      </section>
     </section>
     <section>
       <h2>
@@ -2343,18 +2389,14 @@
                     <li data-link-for="PaymentDetailsUpdate">If the
                     <a>total</a> member of <var>details</var> is present, then:
                       <ol>
-                        <li>Let <var>value</var> be
+                        <li>Let <var>total</var> be
                         <var>details</var>.<a>total</a>.<a data-lt=
-                        "PaymentItem.amount">amount</a>.<a data-lt=
-                        "PaymentCurrencyAmount.value">value</a>.
+                        "PaymentItem.amount">amount</a>.
                         </li>
-                        <li>If <var>value</var> is not a <a>valid decimal
-                        monetary value</a>, then <a>abort the update</a> with a
-                        <a>TypeError</a>.
-                        </li>
-                        <li>If the first <a>code point</a> of <var>value</var>
-                        is U+002D HYPHEN-MINUS, then <a>abort the update</a>
-                        with a <a>TypeError</a>.
+                        <li>
+                          <a>Check and canonicalize <var>total</var></a>. If an
+                          exception is thrown, then <a>abort the update</a>
+                          with that exception.
                         </li>
                       </ol>
                     </li>
@@ -2362,11 +2404,13 @@
                     is present, then for each <var>item</var> in
                     <var>details</var>.<a>displayItems</a>:
                       <ol>
-                        <li>If <var>item</var>.<a data-lt=
-                        "PaymentItem.amount">amount</a>.<a data-lt=
-                        "PaymentCurrencyAmount.value">value</a> is not a
-                        <a>valid decimal monetary value</a>, then <a>abort the
-                        update</a> with a <a>TypeError</a>.
+                        <li>Let <var>amount</var> be
+                          <var>item</var>.<a data-lt="PaymentItem.amount">amount</a>.
+                        </li>
+                        <li>
+                          <a>Check and canonicalize <var>amount</var></a>. If
+                          an exception is thrown, then <a>abort the update</a>
+                          with that exception.
                         </li>
                       </ol>
                     </li>
@@ -2384,11 +2428,14 @@
                         <li>For each <var>option</var> in
                         <var>shippingOptions</var>:
                           <ol>
-                            <li>If <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.amount">amount</a>.<a data-lt="PaymentCurrencyAmount.value">value</a>
-                              is not a <a>valid decimal monetary value</a>,
-                              then <a>abort the update</a> with a
-                              <a>TypeError</a>.
+                            <li>Let <var>amount</var> be
+                            <var>option</var>.<a data-lt=
+                            "PaymentShippingOption.amount">amount</a>.
+                            </li>
+                            <li>
+                              <a>Check and canonicalize <var>amount</var></a>.
+                              If an exception is thrown, then <a>abort the
+                              update</a> with that exception.
                             </li>
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
@@ -2430,19 +2477,15 @@
                             <li>If the <a>total</a> member of
                             <var>modifier</var> is present, then:
                               <ol>
-                                <li>Let <var>value</var> be
+                                <li>Let <var>total</var> be
                                 <var>modifier</var>.<a>total</a>.<a data-lt=
-                                "PaymentItem.amount">amount</a>.<a data-lt=
-                                "PaymentCurrencyAmount.value">value</a>.
+                                "PaymentItem.amount">amount</a>.
                                 </li>
-                                <li>If <var>value</var> is not a <a>valid
-                                decimal monetary value</a>, then <a>abort the
-                                update</a> with a <a>TypeError</a>.
-                                </li>
-                                <li>If the first <a>code point</a> of
-                                <var>value</var> is U+002D HYPHEN-MINUS, then
-                                <a>abort the update</a> with a
-                                <a>TypeError</a>.
+                                <li>
+                                  <a>Check and canonicalize
+                                  <var>total</var></a>. If an exception is
+                                  thrown, then <a>abort the update</a> with
+                                  that exception.
                                 </li>
                               </ol>
                             </li>
@@ -2451,14 +2494,15 @@
                             <a>PaymentItem</a> <var>item</var> in
                             <var>modifier</var>.<a>additionalDisplayItems</a>:
                               <ol>
-                                <li>Let <var>amountValue</var> be
+                                <li>Let <var>amount</var> be
                                 <var>item</var>.<a data-lt=
-                                "PaymentItem.amount">amount</a>.<a data-lt=
-                                "PaymentCurrencyAmount.value">value</a>.
+                                "PaymentItem.amount">amount</a>.
                                 </li>
-                                <li>If <var>amountValue</var> is not a <a>valid
-                                decimal monetary value</a>, then <a>abort the
-                                update</a> with a <a>TypeError</a>.
+                                <li>
+                                  <a>Check and canonicalize
+                                  <var>amount</var></a>. If an exception is
+                                  thrown, then <a>abort the update</a> with
+                                  that exception.
                                 </li>
                               </ol>
                             </li>
@@ -3002,13 +3046,15 @@
         </dt>
         <dd>
           The terms <dfn data-cite=
-          "!ECMA-262-2015#sec-promise-objects">Promise</dfn>, <dfn data-cite=
-          "!ECMA-262-2015#sec-object-internal-methods-and-internal-slots">internal
+          "!ECMASCRIPT#sec-promise-objects">Promise</dfn>, <dfn data-cite=
+          "!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
           slot</dfn>, <code><dfn data-cite=
-          "!ECMA-262-2015#sec-native-error-types-used-in-this-standard-typeerror">
-          TypeError</dfn></code>, and <code><dfn data-cite=
-          "!ECMA-262-2015#sec-json.stringify">JSON.stringify</dfn></code> are
-          defined by [[!ECMA-262-2015]].
+          "!ECMASCRIPT#sec-native-error-types-used-in-this-standard-rangeerror">
+          RangeError</dfn></code>, <code><dfn data-cite=
+          "!ECMASCRIPT#sec-native-error-types-used-in-this-standard-typeerror">TypeError</dfn></code>,
+          and <code><dfn data-cite=
+          "!ECMASCRIPT#sec-json.stringify">JSON.stringify</dfn></code> are
+          defined by [[!ECMASCRIPT]].
           <p>
             The term <dfn data-lt=
             "JSON-serialized|JSON-serializing">JSON-serialize</dfn> applied to

--- a/index.html
+++ b/index.html
@@ -832,8 +832,8 @@
               <var>paymentMethod</var> tuple.
               </li>
               <li>Let <var>data</var> be the result of <a data-cite=
-              "!ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
-              in <var>paymentMethod</var> tuple.
+              "!ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second item in
+              the <var>paymentMethod</var> tuple.
               </li>
               <li>If required by the specification that defines the
               <var>identifer</var>, then <a data-cite=
@@ -1285,8 +1285,7 @@
             However, the set of combinations of currency code for which
             localized currency symbols are available is implementation
             dependent. Where a localized currency symbol is not available, a
-            user agent SHOULD us the [[!ISO4217]] currency code SHOULD be used
-            for formatting.
+            user agent SHOULD use U+00A4 (¤) for formatting.
           </p>
         </dd>
         <dt>
@@ -1316,8 +1315,8 @@
           points</dfn> in the given order: [[!INFRA]]
         </p>
         <ol>
-          <li>Optionally, a single U+002D HYPHEN-MINUS (-), to indicate that
-          the amount is negative.
+          <li>Optionally, a single U+002D (-), to indicate that the amount is
+          negative.
           </li>
           <li>One or more <a>code points</a> in the range U+0030 DIGIT ZERO (0)
           to U+0039 DIGIT NINE (9).
@@ -1338,25 +1337,28 @@
           run the following steps:
         </p>
         <ol data-link-for="PaymentCurrencyAmount">
-          <li>If <a>currencySystem</a> is not
-          <code>urn:iso:std:iso:4217</code>, terminate this algorithm.
+          <li>If <var>amount</var>.<a>currencySystem</a> is not
+          "<code>urn:iso:std:iso:4217</code>", terminate this algorithm.
           </li>
-          <li>let <var>isValidCurrency</var> be the result of calling
+          <li>Let <var>isValidCurrency</var> be the result of calling
           <a data-cite=
           "!ecma-402#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a>
-          abstract operation with <a>currency</a> as the argument.
+          abstract operation with <var>amount</var>.<a>currency</a> as the
+          argument.
           </li>
-          <li>If <var>isValidCurrency</var> returns false, then throw a
+          <li>If <var>isValidCurrency</var> is false, then throw a
           <a>RangeError</a> exception and terminate this algorithm, optionally
           informing the developer that the currency is invalid.
           </li>
-          <li>Let <var>value</var> be <var>amount</var>'s <a>value</a>.
+          <li>Let <var>value</var> be <var>amount</var>.<a>value</a>.
           </li>
           <li>If <var>value</var> is not a <a>valid decimal monetary value</a>,
           throw a <a>TypeError</a>, optionally informing the developer that the
           currency is invalid.
           </li>
-          <li>Canonicalize <a>currency</a> by converting it to upper case.
+          <li>Set <var>amount</var>.<a>currency</a> to the result of
+          <a data-cite="!infra#ascii-uppercase">ASCII uppercasing</a>
+          <var>amount</var>.<a>currency</a>.
           </li>
         </ol>
         <p>
@@ -1365,7 +1367,7 @@
           following steps:
         </p>
         <ol data-link-for="PaymentCurrencyAmount">
-          <li>If <a>currencySystem</a> is not
+          <li>If <var>total</var>.<a>currencySystem</a> is not
           <code>urn:iso:std:iso:4217</code>, terminate this algorithm.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -541,7 +541,8 @@
               <var>details</var>.<a>total</a>.<a data-lt=
               "PaymentItem.amount">amount</a>.
               </li>
-              <li>
+              <li data-tests=
+              "payment-request-ctor-currency-code-checks.https.html">
                 <a>Check and canonicalize <var>total</var></a>. Rethrow any
                 exceptions.
               </li>
@@ -554,7 +555,8 @@
               <li>Let <var>amount</var> be <var>item</var>.<a data-lt=
               "PaymentItem.amount">amount</a>.
               </li>
-              <li>
+              <li data-tests=
+              "payment-request-ctor-currency-code-checks.https.html">
                 <a>Check and canonicalize <var>amount</var></a>. Rethrow any
                 exceptions.
               </li>
@@ -581,7 +583,8 @@
                       <li>Let <var>amount</var> be
                         <var>item</var>.<a data-lt="PaymentItem.amount">amount</a>.
                       </li>
-                      <li>
+                      <li data-tests=
+                      "payment-request-ctor-currency-code-checks.https.html">
                         <a>Check and canonicalize <var>amount</var></a>.
                         Rethrow any exceptions.
                       </li>
@@ -636,7 +639,8 @@
                           <var>modifier</var>.<a data-lt=
                           "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>
                           </li>
-                          <li>
+                          <li data-tests=
+                          "payment-request-ctor-currency-code-checks.https.html">
                             <a>Check and canonicalize <var>total</var></a>.
                             Rethrow any exceptions.
                           </li>
@@ -652,7 +656,8 @@
                           <var>item</var>.<a data-lt=
                           "PaymentItem.amount">amount</a>.
                           </li>
-                          <li>
+                          <li data-tests=
+                          "payment-request-ctor-currency-code-checks.https.html">
                             <a>Check and canonicalize <var>amount</var></a>.
                             Rethrow any exceptions.
                           </li>


### PR DESCRIPTION
* Hooks into ECMAScript's Intl's `IsWellFormedCurrencyCode`.
* Internally changes currencies into canonical form (upper case).
* Groups checking and normalization algorithms for "is valid amount" and "is valid total" - reducing a fair bit of spec text. 
* Relocates "valid decimal monetary value" to `PaymentCurrencyAmount`.
* Cites [[ECMASCRIPT]], instead of obsolete [[ECMA-262-2015]].
* Hooks into [[Infra]] ASCII uppercasing algo, for canonical form.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-request/currency_codes.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/8f30b32...a67b9d6.html)