### PR TITLE
define PaymentRequest.shippingType attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -1061,7 +1061,7 @@
         <h2>
           <dfn>shippingType</dfn> attribute
         </h2>
-        <p>
+        <p data-tests="payment-request-shippingType-attribute.https.html">
           A <a>PaymentRequest</a>'s <a>shippingType</a> attribute is the type
           of shipping used to fulfill the transaction. Its value is either a
           <a>PaymentShippingType</a> enum value, or null if none is provided by

--- a/index.html
+++ b/index.html
@@ -515,8 +515,10 @@
           <var>details</var>, and the payment <var>options</var>.
         </p>
         <p>
-          The <a>PaymentRequest(methodData, details, options)</a> constructor
-          MUST act as follows:
+          The <code><dfn data-lt=
+          "PaymentRequest.PaymentRequest()">PaymentRequest(<var>methodData</var>,
+          <var>details</var>, <var>options</var>)</dfn></code> constructor MUST
+          act as follows:
         </p>
         <ol data-link-for="PaymentDetailsBase" class="algorithm">
           <li>If the <a>current settings object</a>'s <a data-cite=
@@ -1053,6 +1055,20 @@
           populated when the user provides a shipping address. It is null by
           default. When a user provides a shipping address, the <a>shipping
           address changed algorithm</a> runs.
+        </p>
+      </section>
+      <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
+        <h2>
+          <dfn>shippingType</dfn> attribute
+        </h2>
+        <p>
+          A <a>PaymentRequest</a>'s <a>shippingType</a> attribute is the type
+          of shipping used to fulfill the transaction. Its value is either a
+          <a>PaymentShippingType</a> enum value, or null if none is provided by
+          the developer during <a data-lt=
+          "PaymentRequest.PaymentRequest()">construction</a> (see
+          <a>PaymentOptions</a>'s <a data-lt=
+          "PaymentOptions.shippingType">shippingType</a> member).
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">


### PR DESCRIPTION
* closes #472 

Bonus: kills last two ReSpec warnings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-request/shippingType.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/8f30b32...e0f421a.html)