### PR TITLE
Validate PMIs, ignore duplicates

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,8 +566,6 @@
               then <a>throw</a> a <a>TypeError</a>, optionally informing the
               developer that at least one <a>payment method</a> is required.
               </li>
-              <li>Let <var>seenPMIs</var> be an empty list.
-              </li>
               <li>For each <var>paymentMethod</var> of <var>methodData</var>:
                 <ol>
                   <li data-tests=
@@ -581,19 +579,6 @@
                     exception and terminate this algorithm. Optionally, inform
                     the developer that the payment method identifier is
                     invalid.
-                  </li>
-                  <li>If <var>seenPMIs</var> contains
-                  <var>paymentMethod</var>.<a data-lt=
-                  "PaymentMethodData.supportedMethods">supportedMethods</a>,
-                  continue to the next <var>paymentMethod</var> of
-                  <var>methodData</var> (if any). Optionally, inform the
-                  developer that <var>paymentMethod</var>.<a data-lt=
-                  "PaymentMethodData.supportedMethods">supportedMethods</a> was
-                  already seen and <var>paymentMethod</var> will be ignored.
-                  </li>
-                  <li>Append <var>paymentMethod</var>.<a data-lt=
-                  "PaymentMethodData.supportedMethods">supportedMethods</a> to
-                  <var>seenPMI</var>.
                   </li>
                   <li>If the <a data-lt="PaymentMethodData.data">data</a>
                   member of <var>paymentMethod</var> is missing, let
@@ -2574,8 +2559,6 @@
                         <li>Let <var>serializedModifierData</var> be an empty
                         list.
                         </li>
-                        <li>Let <var>seenPMIs</var> be an empty list.
-                        </li>
                         <li>For each <a>PaymentDetailsModifier</a>
                         <var>modifier</var> in <var>modifiers</var>:
                           <ol data-link-for="PaymentDetailsModifier">
@@ -2626,20 +2609,6 @@
                             string. If <a>JSON-serializing</a> throws an
                             exception, then <a>abort the update</a> with that
                             exception.
-                            </li>
-                            <li>If <var>seenPMIs</var> contains
-                            <var>modifier</var>.<a data-lt=
-                            "PaymentDetailsModifier.supportedMethods">supportedMethods</a>,
-                            continue to the next <var>modifier</var> of
-                            <var>modifiers</var> (if any). Optionally, inform
-                            the developer that
-                              <var>modifier</var>.<a data-lt="PaymentDetailsModifier.supportedMethods">supportedMethods</a>
-                              was already seen and <var>modifier</var> will be
-                              ignored.
-                            </li>
-                            <li>Append <var>modifier</var>.<a data-lt=
-                            "PaymentDetailsModifier.supportedMethods">supportedMethods</a>
-                            to <var>seenPMI</var>.
                             </li>
                             <li>Add <var>serializedData</var> to
                             <var>serializedModifierData</var>.

--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
               then <a>throw</a> a <a>TypeError</a>, optionally informing the
               developer that at least one <a>payment method</a> is required.
               </li>
-              <li>Let <var>seenPMIs</var> be an emtpy list.
+              <li>Let <var>seenPMIs</var> be an empty list.
               </li>
               <li>For each <var>paymentMethod</var> of <var>methodData</var>:
                 <ol>
@@ -582,7 +582,7 @@
                     the developer that the payment method identifier is
                     invalid.
                   </li>
-                  <li>If <a>seenPMIs</a> contains
+                  <li>If <var>seenPMIs</var> contains
                   <var>paymentMethod</var>.<a data-lt=
                   "PaymentMethodData.supportedMethods">supportedMethods</a>,
                   continue to the next <var>paymentMethod</var> of
@@ -2627,7 +2627,7 @@
                             exception, then <a>abort the update</a> with that
                             exception.
                             </li>
-                            <li>If <a>seenPMIs</a> contains
+                            <li>If <var>seenPMIs</var> contains
                             <var>modifier</var>.<a data-lt=
                             "PaymentDetailsModifier.supportedMethods">supportedMethods</a>,
                             continue to the next <var>modifier</var> of

--- a/index.html
+++ b/index.html
@@ -2562,7 +2562,9 @@
                         <li>For each <a>PaymentDetailsModifier</a>
                         <var>modifier</var> in <var>modifiers</var>:
                           <ol data-link-for="PaymentDetailsModifier">
-                            <li>Run the steps to <a data-cite=
+                            <li data-tests=
+                            "updateWith-method-pmi-handling-manual.https.html">
+                            Run the steps to <a data-cite=
                             "payment-method-id#dfn-validate-a-payment-method-identifier">
                               validate a payment method identifier</a> with
                               <var>modifier</var>.<a data-lt=

--- a/index.html
+++ b/index.html
@@ -566,8 +566,33 @@
               then <a>throw</a> a <a>TypeError</a>, optionally informing the
               developer that at least one <a>payment method</a> is required.
               </li>
+              <li>Let <var>seenPMIs</var> be an emtpy list.
+              </li>
               <li>For each <var>paymentMethod</var> of <var>methodData</var>:
                 <ol>
+                  <li>Run the steps to <a data-cite=
+                  "payment-method-id#dfn-validate-a-payment-method-identifier">
+                    validate a payment method identifier</a> with
+                    <var>paymentMethod</var>.<a data-lt=
+                    "PaymentMethodData.supportedMethods">supportedMethods</a>.
+                    If it returns false, then throw a <a>RangeError</a>
+                    exception and terminate this algorithm. Optionally, inform
+                    the developer that the payment method identifier is
+                    invalid.
+                  </li>
+                  <li>If <a>seenPMIs</a> contains
+                  <var>paymentMethod</var>.<a data-lt=
+                  "PaymentMethodData.supportedMethods">supportedMethods</a>,
+                  continue to the next <var>paymentMethod</var> of
+                  <var>methodData</var> (if any). Optionally, inform the
+                  developer that <var>paymentMethod</var>.<a data-lt=
+                  "PaymentMethodData.supportedMethods">supportedMethods</a> was
+                  already seen and <var>paymentMethod</var> will be ignored.
+                  </li>
+                  <li>Append <var>paymentMethod</var>.<a data-lt=
+                  "PaymentMethodData.supportedMethods">supportedMethods</a> to
+                  <var>seenPMI</var>.
+                  </li>
                   <li>If the <a data-lt="PaymentMethodData.data">data</a>
                   member of <var>paymentMethod</var> is missing, let
                   <var>serializedData</var> be null. Otherwise, let
@@ -2547,9 +2572,21 @@
                         <li>Let <var>serializedModifierData</var> be an empty
                         list.
                         </li>
+                        <li>Let <var>seenPMIs</var> be an empty list.
+                        </li>
                         <li>For each <a>PaymentDetailsModifier</a>
                         <var>modifier</var> in <var>modifiers</var>:
                           <ol data-link-for="PaymentDetailsModifier">
+                            <li>Run the steps to <a data-cite=
+                            "payment-method-id#dfn-validate-a-payment-method-identifier">
+                              validate a payment method identifier</a> with
+                              <var>modifier</var>.<a data-lt=
+                              "PaymentDetailsModifier.supportedMethods">supportedMethods</a>.
+                              If it returns false, then <a>abort the update</a>
+                              with a <a>RangeError</a> exception. Optional,
+                              inform the developer that the payment method
+                              identifier is invalid.
+                            </li>
                             <li>If the <a>total</a> member of
                             <var>modifier</var> is present, then:
                               <ol>
@@ -2587,6 +2624,20 @@
                             string. If <a>JSON-serializing</a> throws an
                             exception, then <a>abort the update</a> with that
                             exception.
+                            </li>
+                            <li>If <a>seenPMIs</a> contains
+                            <var>modifier</var>.<a data-lt=
+                            "PaymentDetailsModifier.supportedMethods">supportedMethods</a>,
+                            continue to the next <var>modifier</var> of
+                            <var>modifiers</var> (if any). Optionally, inform
+                            the developer that
+                              <var>modifier</var>.<a data-lt="PaymentDetailsModifier.supportedMethods">supportedMethods</a>
+                              was already seen and <var>modifier</var> will be
+                              ignored.
+                            </li>
+                            <li>Append <var>modifier</var>.<a data-lt=
+                            "PaymentDetailsModifier.supportedMethods">supportedMethods</a>
+                            to <var>seenPMI</var>.
                             </li>
                             <li>Add <var>serializedData</var> to
                             <var>serializedModifierData</var>.

--- a/index.html
+++ b/index.html
@@ -570,7 +570,9 @@
               </li>
               <li>For each <var>paymentMethod</var> of <var>methodData</var>:
                 <ol>
-                  <li>Run the steps to <a data-cite=
+                  <li data-tests=
+                  "payment-request-ctor-pmi-handling.https.html">Run the steps
+                  to <a data-cite=
                   "payment-method-id#dfn-validate-a-payment-method-identifier">
                     validate a payment method identifier</a> with
                     <var>paymentMethod</var>.<a data-lt=


### PR DESCRIPTION
* Validate supportedMethods (closes #464)
* Defines behavior for duplicate PMIs in constructor and updateWith() (closes #309)

* [x]  ctor PMI check tests: https://github.com/w3c/web-platform-tests/pull/6816
* [x]  updateWith() PMI validity tests: https://github.com/w3c/web-platform-tests/pull/7021


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-request/validate_and_ignore.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/76bd629...efde8c3.html)