### PR TITLE
Add section on Payment Handler Matching

### DIFF
--- a/index.html
+++ b/index.html
@@ -2953,6 +2953,19 @@
           <a>payment methods</a> support this.
         </p>
       </section>
+      <section>
+        <h2>
+          Payment Handler Matching
+        </h2>
+        <p>
+          For security reasons, a user agent may limit matching
+	  (in <a>show()</a> and <a>canMakePayment()</a>) to
+	  <a>payment handlers</a> from the same origin as a
+	  URL <a>payment method identifier</a>. User agents may
+	  also use information provided by a <a>payment method</a> owner
+	  to match <a>payment handlers</a> from other origins.
+	</p>
+      </section>
     </section>
     <section id="privacy">
       <h2>

--- a/index.html
+++ b/index.html
@@ -2957,14 +2957,14 @@
         <h2>
           Payment Handler Matching
         </h2>
-        <p>
-          For security reasons, a user agent may limit matching
-	  (in <a>show()</a> and <a>canMakePayment()</a>) to
-	  <a>payment handlers</a> from the same origin as a
-	  URL <a>payment method identifier</a>. User agents may
-	  also use information provided by a <a>payment method</a> owner
-	  to match <a>payment handlers</a> from other origins.
-	</p>
+        <p data-link-for="PaymentRequest">
+          For security reasons, a user agent can limit matching (in
+          <a>show()</a> and <a>canMakePayment()</a>) to <a>payment handlers</a>
+          from the same <a data-cite="rfc6454#section-3.2">origin</a> as a URL
+          <a>payment method identifier</a>. User agents can also use
+          information provided by a <a>payment method</a> owner to match
+          <a>payment handlers</a> from other origins.
+        </p>
       </section>
     </section>
     <section id="privacy">


### PR DESCRIPTION
Based on WG discussion today [1], this pull request endeavors (in a non-normative section) to:

 * Raise awareness that for security reasons a user agent might not include a payment handler from an origin other than the origin of a URL PMI. 
 * Raise awareness that user agents may also increase the set of matching payment handlers based on payment method owner information.

This pull request is not more specific than that in order to make it easier to include this text in the CR draft. If there were support for being more explicit, I would be glad to mention two ways
that we are working on where payment method owners delegate authority: W3C-defined
payment method specs and Payment Method Manifest.

At this point, I have this algorithm in mind when looking at the question of matching
payment handlers from origins other then the origin of a PMI URL.

 * If the user agent does not find a payment method manifest, then it should not include
   payment handlers from origins other than the origin of the PMI URI.

 * If the user agent does find a payment method manifest, but it is broken in any way,
    then the user agent should not include payment handlers from origins other than 
    the origin of the PMI URI.

 * Otherwise, the user agent authorizes payment handlers from other origins 
    according to the payment method manifest spec.

@rsolomakhin has written a Payment Handler API pull request [2] that addresses 
the origin / payment method manifest consideration for Web-based payment apps. 
However, that algo might reasonably apply to native mobile apps. Thus, it feels 
to me like it belongs in PR API, but I am not proposing that it be included at this time
due to CR timing considerations.

Ian

[1] https://www.w3.org/2017/08/10-wpwg-minutes
[2] https://github.com/w3c/payment-handler/pull/197


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-request/payment_app_sec.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/7438373...902eba1.html)