### PR TITLE
Throw on dup shippingOptions ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -2550,7 +2550,9 @@
                               exception is thrown, then <a>abort the update</a>
                               with that exception.
                             </li>
-                            <li>If <var>seenIDs</var> contains
+                            <li data-tests=
+                            "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
+                            If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.id">id</a>, then <a>abort
                             the update</a> with a <a>TypeError</a>.

--- a/index.html
+++ b/index.html
@@ -2554,8 +2554,8 @@
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.id">id</a>, then <a>abort
-                            the update</a> with a "<a>ConstraintError</a>"
-                            <a>DOMException</a>.
+                            the update</a> with a "<a>ConstraintError</a>" <a>
+                              DOMException</a>.
                             </li>
                             <li>Otherwise, append
                               <var>option</var>.<a data-lt="PaymentShippingOption.id">id</a>
@@ -2704,10 +2704,11 @@
                     <li>If <var>request</var>.<a>[[\options]]</a>.<a data-lt=
                     "PaymentOptions.requestShipping">requestShipping</a> is
                     true, and the <a data-lt=
-                    "PaymentDetailsUpdate.error">error</a> is present, the user
-                    agent SHOULD request that the user selected an alternative
-                    shipping address, or be given the option abort the payment
-                    request. The user agent SHOULD display the <a data-lt=
+                    "PaymentDetailsUpdate.error">error</a> member of
+                    <var>details</var> is present, the user agent SHOULD
+                    request that the user selected an alternative shipping
+                    address, or be given the option abort the payment request.
+                    The user agent SHOULD display the <a data-lt=
                     "PaymentDetailsUpdate.error">error</a> member of
                     <var>details</var> to give more information about why the
                     address can't be used to complete the transaction.

--- a/index.html
+++ b/index.html
@@ -648,9 +648,8 @@
                       </li>
                       <li>If <var>seenIDs</var> contains
                       <var>option</var>.<a>id</a>, then throw a
-                      "<a>TypeError</a>" <a>DOMException</a>. Optionally,
-                      inform the developer that shipping option IDs must be
-                      unique.
+                      <a>TypeError</a>. Optionally, inform the developer that
+                      shipping option IDs must be unique.
                       </li>
                       <li>Otherwise, append <var>option</var>.<a>id</a> to
                       <var>seenIDs</var>.
@@ -2554,8 +2553,7 @@
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.id">id</a>, then <a>abort
-                            the update</a> with a "<a>TypeError</a>"
-                            <a>DOMException</a>.
+                            the update</a> with a <a>TypeError</a>.
                             </li>
                             <li>Otherwise, append
                               <var>option</var>.<a data-lt="PaymentShippingOption.id">id</a>

--- a/index.html
+++ b/index.html
@@ -3251,7 +3251,7 @@
       </p>
       <p>
         User agents MAY impose implementation-specific limits on otherwise
-        unTypeError inputs, e.g., to prevent denial of service attacks, to
+        unconstrained inputs, e.g., to prevent denial of service attacks, to
         guard against running out of memory, or to work around
         platform-specific limitations. When an input exceeds
         implementation-specific limit, the user agent MUST throw, or, in the

--- a/index.html
+++ b/index.html
@@ -2554,8 +2554,8 @@
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.id">id</a>, then <a>abort
-                            the update</a> with a "<a>TypeError</a>" <a>
-                              DOMException</a>.
+                            the update</a> with a "<a>TypeError</a>"
+                            <a>DOMException</a>.
                             </li>
                             <li>Otherwise, append
                               <var>option</var>.<a data-lt="PaymentShippingOption.id">id</a>

--- a/index.html
+++ b/index.html
@@ -2554,8 +2554,8 @@
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.id">id</a>, then <a>abort
-                            the update</a> with a "ConstraintError"
-                            DOMException.
+                            the update</a> with a "<a>ConstraintError</a>"
+                            <a>DOMException</a>.
                             </li>
                             <li>Otherwise, append
                               <var>option</var>.<a data-lt="PaymentShippingOption.id">id</a>

--- a/index.html
+++ b/index.html
@@ -647,10 +647,12 @@
                         exceptions.
                       </li>
                       <li>If <var>seenIDs</var> contains
-                      <var>option</var>.<a>id</a>, then set <var>options</var>
-                      to an empty sequence and break.
+                      <var>option</var>.<a>id</a>, then throw a
+                      "<a>ConstraintError</a>" <a>DOMException</a>. Optionally,
+                      inform the developer that shipping option IDs must be
+                      unique.
                       </li>
-                      <li>Append <var>option</var>.<a>id</a> to
+                      <li>Otherwise, append <var>option</var>.<a>id</a> to
                       <var>seenIDs</var>.
                       </li>
                     </ol>
@@ -1512,11 +1514,6 @@
           <dd>
             A sequence containing the different shipping options for the user
             to choose from.
-            <p>
-              If the sequence is empty, then this indicates that the merchant
-              cannot ship to the current <a data-lt=
-              "PaymentRequest.shippingAddress">shippingAddress</a>.
-            </p>
             <p>
               If an item in the sequence has the <a data-lt=
               "PaymentShippingOption.selected">selected</a> member set to true,
@@ -2556,12 +2553,13 @@
                             </li>
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.id">id</a>, then set
-                            <var>options</var> to an empty sequence and break.
+                            "PaymentShippingOption.id">id</a>, then <a>abort
+                            the update</a> with a "ConstraintError"
+                            DOMException.
                             </li>
-                            <li>Append <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.id">id</a> to
-                            <var>seenIDs</var>.
+                            <li>Otherwise, append
+                              <var>option</var>.<a data-lt="PaymentShippingOption.id">id</a>
+                              to <var>seenIDs</var>.
                             </li>
                           </ol>
                         </li>
@@ -2705,20 +2703,14 @@
                     </li>
                     <li>If <var>request</var>.<a>[[\options]]</a>.<a data-lt=
                     "PaymentOptions.requestShipping">requestShipping</a> is
-                    true, and
-                    <var>request</var>.<a>[[\details]]</a>.<a>shippingOptions</a>
-                    is empty, then the developer has signified that there are
-                    no valid shipping options for the currently-chosen shipping
-                    address (given by <var>request</var>'s <a data-lt=
-                    "PaymentRequest.shippingAddress">shippingAddress</a>). In
-                    this case, the user agent SHOULD display an error
-                    indicating this, and MAY indicate that the currently-chosen
-                    shipping address is invalid in some way. The user agent
-                    SHOULD use the <a data-lt=
+                    true, and the <a data-lt=
+                    "PaymentDetailsUpdate.error">error</a> is present, the user
+                    agent SHOULD request that the user selected an alternative
+                    shipping address, or be given the option abort the payment
+                    request. The user agent SHOULD display the <a data-lt=
                     "PaymentDetailsUpdate.error">error</a> member of
-                    <var>details</var>, if it is present, to give more
-                    information about why there are no valid shipping options
-                    for that address.
+                    <var>details</var> to give more information about why the
+                    address can't be used to complete the transaction.
                     </li>
                   </ol>
                 </li>
@@ -3229,6 +3221,8 @@
             following <a>DOMException</a> types from [[!WEBIDL]] are used:
             "<code><dfn data-cite=
             "!WEBIDL#aborterror">AbortError</dfn></code>",
+            "<code><dfn data-cite=
+            "!WEBIDL#constrainterror">ConstraintError</dfn></code>",
             "<code><dfn data-cite=
             "!WEBIDL#invalidstateerror">InvalidStateError</dfn></code>",
             "<code><dfn data-cite=

--- a/index.html
+++ b/index.html
@@ -2703,15 +2703,20 @@
                     </li>
                     <li>If <var>request</var>.<a>[[\options]]</a>.<a data-lt=
                     "PaymentOptions.requestShipping">requestShipping</a> is
-                    true, and the <a data-lt=
+                    true, and
+                    <var>request</var>.<a>[[\details]]</a>.<a>shippingOptions</a>
+                    is empty, then the developer has signified that there are
+                    no valid shipping options for the currently-chosen shipping
+                    address (given by <var>request</var>'s <a data-lt=
+                    "PaymentRequest.shippingAddress">shippingAddress</a>). In
+                    this case, the user agent SHOULD display an error
+                    indicating this, and MAY indicate that the currently-chosen
+                    shipping address is invalid in some way. The user agent
+                    SHOULD use the <a data-lt=
                     "PaymentDetailsUpdate.error">error</a> member of
-                    <var>details</var> is present, then the user agent SHOULD
-                    request that the user selected an alternative shipping
-                    address, or be given the option abort the payment request.
-                    The user agent SHOULD display the <a data-lt=
-                    "PaymentDetailsUpdate.error">error</a> member of
-                    <var>details</var> to give more information about why the
-                    address can't be used to complete the transaction.
+                    <var>details</var>, if it is present, to give more
+                    information about why there are no valid shipping options
+                    for that address.
                     </li>
                   </ol>
                 </li>

--- a/index.html
+++ b/index.html
@@ -648,7 +648,7 @@
                       </li>
                       <li>If <var>seenIDs</var> contains
                       <var>option</var>.<a>id</a>, then throw a
-                      "<a>ConstraintError</a>" <a>DOMException</a>. Optionally,
+                      "<a>TypeError</a>" <a>DOMException</a>. Optionally,
                       inform the developer that shipping option IDs must be
                       unique.
                       </li>
@@ -2554,7 +2554,7 @@
                             <li>If <var>seenIDs</var> contains
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.id">id</a>, then <a>abort
-                            the update</a> with a "<a>ConstraintError</a>" <a>
+                            the update</a> with a "<a>TypeError</a>" <a>
                               DOMException</a>.
                             </li>
                             <li>Otherwise, append
@@ -3223,8 +3223,6 @@
             "<code><dfn data-cite=
             "!WEBIDL#aborterror">AbortError</dfn></code>",
             "<code><dfn data-cite=
-            "!WEBIDL#constrainterror">ConstraintError</dfn></code>",
-            "<code><dfn data-cite=
             "!WEBIDL#invalidstateerror">InvalidStateError</dfn></code>",
             "<code><dfn data-cite=
             "!WEBIDL#notallowederror">NotAllowedError</dfn></code>",
@@ -3253,7 +3251,7 @@
       </p>
       <p>
         User agents MAY impose implementation-specific limits on otherwise
-        unconstrained inputs, e.g., to prevent denial of service attacks, to
+        unTypeError inputs, e.g., to prevent denial of service attacks, to
         guard against running out of memory, or to work around
         platform-specific limitations. When an input exceeds
         implementation-specific limit, the user agent MUST throw, or, in the

--- a/index.html
+++ b/index.html
@@ -2705,7 +2705,7 @@
                     "PaymentOptions.requestShipping">requestShipping</a> is
                     true, and the <a data-lt=
                     "PaymentDetailsUpdate.error">error</a> member of
-                    <var>details</var> is present, the user agent SHOULD
+                    <var>details</var> is present, then the user agent SHOULD
                     request that the user selected an alternative shipping
                     address, or be given the option abort the payment request.
                     The user agent SHOULD display the <a data-lt=

--- a/index.html
+++ b/index.html
@@ -656,9 +656,7 @@
                       </li>
                     </ol>
                   </li>
-                  <li>For each <var>option</var> in <var>options</var> (which
-                  may have been reset to the empty sequence in the previous
-                  step):
+                  <li>For each <var>option</var> in <var>options</var>:
                     <ol>
                       <li>If <var>option</var>.<a>selected</a> is true, then
                       set <var>selectedShippingOption</var> to
@@ -2564,8 +2562,7 @@
                           </ol>
                         </li>
                         <li>For each <var>option</var> in
-                        <var>shippingOptions</var> (which may have been reset
-                        to the empty sequence in the previous step):
+                        <var>shippingOptions</var>:
                           <ol>
                             <li>If <var>option</var>.<a data-lt=
                             "PaymentShippingOption.selected">selected</a> is


### PR DESCRIPTION
* throws on duplicate shipping options ids (closes #594)

Required tests:
 * [x] constructor throws https://github.com/w3c/web-platform-tests/pull/7217
 * [x] updateWith() aborts with TypeError https://github.com/w3c/web-platform-tests/pull/7218


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-request/throw_on_dup_ids.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/658f807...93b7d31.html)