### PR TITLE
Only select shippingOption if asked to (closes #609)

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,7 +623,9 @@
           </li>
           <li>Let <var>selectedShippingOption</var> be null.
           </li>
-          <li>Process shipping options:
+          <li>If the <a data-lt=
+          "PaymentOptions.requestShipping">requestShipping</a> member of <var>
+            options</var> is present and set to true, process shipping options:
             <ol>
               <li>Let <var>options</var> be an empty <code><a data-cite=
               "!WEBIDL#idl-sequence">sequence</a></code>&lt;<a>PaymentShippingOption</a>&gt;.


### PR DESCRIPTION
Test: https://github.com/w3c/web-platform-tests/pull/7239


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-request/null_shipping_option.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/58c6867...231a79a.html)