### PR TITLE
Suggested emphasis of privacy protections

### DIFF
--- a/index.html
+++ b/index.html
@@ -3320,6 +3320,11 @@
           The <a>user agent</a> MUST NOT share information about the user with
           a developer (e.g., the shipping address) without user consent.
         </p>
+        <p>
+          The <a>user agent</a> MUST NOT share sales information beyond the payment
+          scope with a payment processor, such as what is being paid for and the shipping 
+          details.
+        </p>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
Closes #626

Perhaps my mistake, but I missed exactly how details of the the purchase (beyond payment scope) were protected from being sent to the payment processor.

@marcoscaceres helped make it clearer https://twitter.com/mrmarkrichards/status/909707142076227584 and suggested I raise a request here.

It'd be great to to ensure it is very clear that purchase item details, same as shipping details, shouldn't be shared with third parties (only the site you are paying would know).

Hopefully, this will reduce the likes of me querying it again. I think the wording suggested achieves the goal, but I'm not used to contributing to specs so feel free to criticise.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/markalanrichards/payment-request/patch-1.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-request/7e4a2ca...markalanrichards:e321197.html)