### PR TITLE
add redactList for PaymentAddress (Part 1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2097,7 +2097,7 @@
         </pre>
         <p>
           The <a>PaymentAddress</a> interface represents a <a>physical
-          address</a> on the Web.
+          address</a>.
         </p>
         <section>
           <h2>

--- a/index.html
+++ b/index.html
@@ -3239,7 +3239,7 @@
                 </p>
                 <p>
                   Unfortunately, even with the <var>redactList</var>, recipient
-                  anonymity is cannot be assured. This is because in some
+                  anonymity cannot be assured. This is because in some
                   countries postal codes are so fine-grained that they can
                   uniquely identify a recipient.
                 </p>

--- a/index.html
+++ b/index.html
@@ -3388,12 +3388,23 @@
           </li>
           <li>If the <a data-lt=
           "PaymentOptions.requestShipping">requestShipping</a> value of
-          <var>request</var>.<a>[[\options]]</a> is true, then <a>create a
-          <code>PaymentAddress</code> from user-provided input</a> passing the
-          empty list as the <var>redactList</var> and set the <a data-lt=
-          "PaymentResponse.shippingAddress">shippingAddress</a> attribute of
-          <var>response</var> to the resulting <a>PaymentAddress</a>.
-          Otherwise, set it to null.
+          <var>request</var>.<a>[[\options]]</a> is true, then:
+            <ol>
+              <li>Let <var>redactList</var> be the empty <a>list</a>.
+              </li>
+              <li>Let <var>shippingAddress</var> be the result of <a>create a
+              <code>PaymentAddress</code> from user-provided input</a> with
+              <var>redactList</var>.
+              </li>
+              <li>Set the <a data-lt=
+              "PaymentResponse.shippingAddress">shippingAddress</a> attribute
+              value of <var>response</var> to <var>shippingAddress</var>.
+              </li>
+              <li>Set the <a data-lt=
+              "PaymentResponse.shippingAddress">shippingAddress</a> attribute
+              value of <var>request</var> to <var>shippingAddress</var>.
+              </li>
+            </ol>
           </li>
           <li>If the <a data-lt=
           "PaymentOptions.requestShipping">requestShipping</a> value of

--- a/index.html
+++ b/index.html
@@ -1989,7 +1989,7 @@
         </dl>
       </section>
     </div>
-    <section data-dfn-for="PaymentAddress" data-link-for="PaymentAddress">
+    <section>
       <h2>
         Physical Addresses
       </h2>
@@ -2082,7 +2082,7 @@
           <dfn>PaymentAddress</dfn> interface
         </h2>
         <pre class="idl">
-          [SecureContext, Exposed=(Window), Constructor(optional AddressInit details)]
+          [SecureContext, Exposed=(Window)]
           interface PaymentAddress {
             [Default] object toJSON();
             readonly attribute DOMString city;
@@ -2105,11 +2105,15 @@
         </p>
         <section>
           <h2>
-            Constructor
+            Internal Constructor
           </h2>
+          <p class="note">
+            This constructor algorithm is used internally by the user agent.
+            It's not available to scripts.
+          </p>
           <p>
             The steps to <dfn data-lt=
-            "PaymentAddress.PaymentAddress()">construct a
+            "PaymentAddress.PaymentAddress()">internally construct a
             <code>PaymentAddress</code></dfn> with <a>AddressInit</a>
             <var>details</var> are given by the following algorithm:
           </p>
@@ -2711,7 +2715,7 @@
           provided.
           </li>
           <li>
-            <a data-lt="PaymentAddress.PaymentAddress()">Construct a new
+            <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a new
             <code>PaymentAddress</code></a> with <var>details</var> and return
             the result.
           </li>

--- a/index.html
+++ b/index.html
@@ -2125,8 +2125,8 @@
             </li>
             <li>If <var>details</var>["<a>country</a>"] is present:
               <ol>
-                <li>Set <var>country</var> the result of <a>strip leading
-                and trailing ASCII whitespace</a> from
+                <li>Set <var>country</var> the result of <a>strip leading and
+                trailing ASCII whitespace</a> from
                 <var>details</var>["<a>country</a>"] and performing
                 <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>.
                 </li>

--- a/index.html
+++ b/index.html
@@ -3226,6 +3226,25 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
+              <div class="note" title="Privacy of recipient information">
+                <p>
+                  The <var>redactList</var> optionally gives user agents the
+                  possibility to limit the amount of personal information about
+                  the recipient that the API shares with the merchant.
+                </p>
+                <p>
+                  For merchants, the resulting <a>PaymentAddress</a> object
+                  provides enough information to, for example, calculate
+                  shipping costs, but, in most cases, not enough information to
+                  physically locate and uniquely identify the recipient.
+                </p>
+                <p>
+                  Unfortunately, even with the <var>redactList</var>, recipient
+                  anonymity is cannot be assured. This is because in some
+                  countries postal codes are so fine-grained that they can
+                  uniquely identify a recipient.
+                </p>
+              </div>
               <li>Let <var>redactList</var> be the empty list. Optionally,
               append the following items to <var>redactList</var>: «
               "organization", "phone", "recipient", "addressLine" ».

--- a/index.html
+++ b/index.html
@@ -2062,9 +2062,7 @@
           <dfn>Recipient</dfn>
         </dt>
         <dd>
-          The name of the recipient or contact person. This member may, under
-          certain circumstances, contain multiline information. For example, it
-          might contain "care of" information.
+          The name of the recipient or contact person at this address.
         </dd>
         <dt>
           <dfn>Phone number</dfn>
@@ -2558,7 +2556,9 @@
             <dfn>recipient</dfn> member
           </dt>
           <dd>
-            A <a>recipient</a>.
+            A <a>recipient</a>. This member may, under certain circumstances,
+            contain multiline information. For example, it might contain "care
+            of" information.
           </dd>
           <dt>
             <dfn>phone</dfn> member

--- a/index.html
+++ b/index.html
@@ -2037,7 +2037,7 @@
           localities.
         </dd>
         <dt>
-          <dfn>Postal code</dfn>
+          <dfn data-lt="Postal codes">Postal code</dfn>
         </dt>
         <dd>
           The postal code or ZIP code, also known as PIN code in India.
@@ -2094,6 +2094,7 @@
             readonly attribute DOMString postalCode;
             readonly attribute DOMString recipient;
             readonly attribute DOMString region;
+            readonly attribute DOMString regionCode;
             readonly attribute DOMString sortingCode;
             readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
           };
@@ -2114,10 +2115,11 @@
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>address</var> be a new instance of
-            <a>PaymentAddress</a>.
-            </li>Set <var>address</var>.<a>[[\addressLine]]</a>to the empty
-            frozen array, and all other <a data-lt=
-            "PaymentAddress slots">internal slots</a>set to the empty string.
+            <a>PaymentAddress</a>.Set
+            <var>address</var>.<a>[[\addressLine]]</a>to the empty frozen
+            array, and all other <a data-lt="PaymentAddress slots">internal
+            slots</a>set to the empty string.
+            </li>
             <li>If <var>details</var> was not passed to the constructor, return
             <var>address</var> and terminate this algorithm.
             </li>
@@ -2127,11 +2129,25 @@
                 "!INFRA#ascii-uppercase">ASCII uppercasing</a>
                 <var>details</var>["<a>country</a>"].
                 </li>
-                <li>If <var>country</var> is not a valid [[!ISO3166]] alpha-2
+                <li>If <var>country</var> is not a valid [[!ISO3166-1]] alpha-2
                 code, throw a <a>RangeError</a> exception.
                 </li>
                 <li>Set <var>address</var>.<a>[[\country]]</a> to
                 <var>country</var>.
+                </li>
+              </ol>
+            </li>
+            <li>If <var>details</var>["<a>regionCode</a>"] is present:
+              <ol>
+                <li>Let <var>regionCode</var> be the result of <a data-cite=
+                "!INFRA#ascii-uppercase">ASCII uppercasing</a>
+                <var>details</var>["<a>regionCode</a>"].
+                </li>
+                <li>If <var>regionCode</var> is not a valid [[!ISO3166-2]]
+                subdivision code, throw a <a>RangeError</a> exception.
+                </li>
+                <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
+                <var>regionCode</var>.
                 </li>
               </ol>
             </li>
@@ -2231,7 +2247,8 @@
             <dfn>addressLine</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>address line</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s
             <a>[[\addressLine]]</a> internal slot.
           </p>
         </section>
@@ -2240,8 +2257,19 @@
             <dfn>region</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
-            <a>[[\region]]</a> internal slot.
+            Represents the <a>region</a> of the address. When getting, returns
+            the value of the <a>PaymentAddress</a>'s <a>[[\region]]</a>
+            internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>regionCode</dfn> attribute
+          </h2>
+          <p>
+            Represents the <a>region</a> of the address as an [[!ISO3166-2]]
+            code. When getting, returns the value of the
+            <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal slot.
           </p>
         </section>
         <section>
@@ -2249,8 +2277,9 @@
             <dfn>city</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
-            <a>[[\city]]</a> internal slot.
+            Represents the <a>city</a> of the address. When getting, returns
+            the value of the <a>PaymentAddress</a>'s <a>[[\city]]</a> internal
+            slot.
           </p>
         </section>
         <section>
@@ -2258,7 +2287,8 @@
             <dfn>dependentLocality</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>dependent locality</a> of the address. When
+            getting, returns the value of the <a>PaymentAddress</a>'s
             <a>[[\dependentLocality]]</a> internal slot.
           </p>
         </section>
@@ -2267,7 +2297,8 @@
             <dfn>postalCode</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>postal code</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s
             <a>[[\postalCode]]</a> internal slot.
           </p>
         </section>
@@ -2276,7 +2307,8 @@
             <dfn>sortingCode</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>sorting code</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s
             <a>[[\sortingCode]]</a> internal slot.
           </p>
         </section>
@@ -2285,7 +2317,8 @@
             <dfn>languageCode</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>language code</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s
             <a>[[\languageCode]]</a> internal slot.
           </p>
         </section>
@@ -2294,7 +2327,8 @@
             <dfn>organization</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>organization</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s
             <a>[[\organization]]</a> internal slot.
           </p>
         </section>
@@ -2303,7 +2337,8 @@
             <dfn>recipient</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
+            Represents the <a>recipient</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s
             <a>[[\recipient]]</a> internal slot.
           </p>
         </section>
@@ -2312,8 +2347,9 @@
             <dfn>phone</dfn> attribute
           </h2>
           <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
-            <a>[[\phone]]</a> internal slot.
+            Represents the <a>phone</a> of the address. When getting, returns
+            the value of the <a>PaymentAddress</a>'s <a>[[\phone]]</a> internal
+            slot.
           </p>
         </section>
         <section data-link-for="">
@@ -2335,7 +2371,7 @@
                 <dfn>[[\country]]</dfn>
               </td>
               <td>
-                A <a>country</a> as an [[!ISO3166]] alpha-2 code or the empty
+                A <a>country</a> as an [[!ISO3166-1]] alpha-2 code or the empty
                 string stored in its canonical uppercase form. For example,
                 "JP".
               </td>
@@ -2354,7 +2390,20 @@
                 <dfn>[[\region]]</dfn>
               </td>
               <td>
-                A <a>region</a> or the empty string.
+                A <a>region</a> as a country subdivision name or the empty
+                string, such as "Victoria", representing the state of Victoria
+                in Australia.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\regionCode]]</dfn>
+              </td>
+              <td>
+                A <a>region</a> as a [[!ISO3166-2]] subdivision code or the
+                empty string stored in its canonical uppercase form. For
+                example, "<code>PT-11</code>" represents the Lisbon district of
+                Portugal.
               </td>
             </tr>
             <tr>
@@ -2434,6 +2483,7 @@
             DOMString country;
             sequence&lt;DOMString&gt; addressLine;
             DOMString region;
+            DOMString regionCode;
             DOMString city;
             DOMString dependentLocality;
             DOMString postalCode;
@@ -2454,7 +2504,7 @@
             <dfn>country</dfn> member
           </dt>
           <dd>
-            A <a>country</a>.
+            An [[!ISO3166-1]] country code, representing the <a>country</a>.
           </dd>
           <dt>
             <dfn>addressLine</dfn> member
@@ -2467,6 +2517,12 @@
           </dt>
           <dd>
             A <a>region</a>.
+          </dd>
+          <dt>
+            <dfn>regionCode</dfn> member
+          </dt>
+          <dd>
+            An [[!ISO3166-2]] subdivision code representing the <a>region</a>.
           </dd>
           <dt>
             <dfn>city</dfn> member
@@ -2535,6 +2591,7 @@
             "postalCode",
             "recipient",
             "region",
+            "regionCode",
             "sortingCode"
           };
         </pre>
@@ -2543,9 +2600,9 @@
           "<dfn>country</dfn>", "<dfn>dependentLocality</dfn>",
           "<dfn>languageCode</dfn>", "<dfn>organization</dfn>",
           "<dfn>phone</dfn>", "<dfn>postalCode</dfn>", "<dfn>recipient</dfn>",
-          "<dfn>region</dfn>", and "<dfn>sortingCode</dfn>" enum values
-          correspond to attributes with the same identifiers in the
-          <a>PaymentAddress</a> interface.
+          "<dfn>region</dfn>", "<dfn>regionCode</dfn>" and
+          "<dfn>sortingCode</dfn>" enum values correspond to attributes with
+          the same identifiers in the <a>PaymentAddress</a> interface.
         </p>
       </section>
       <section>
@@ -2574,7 +2631,7 @@
           </li>
           <li>If "<a data-link-for="AddressField">country</a>" is not in <var>
             excludeList</var>, set <var>details</var>["<a>country</a>"] to the
-            user-provided country as an upper case [[!ISO3166]] alpha-2 code,
+            user-provided country as an upper case [[!ISO3166-1]] alpha-2 code,
             or to the empty string if none was provided.
           </li>
           <li>If "<a data-link-for="AddressField">phone</a>" is not in
@@ -2619,13 +2676,14 @@
           <var>details</var>["<a>postalCode</a>"].
             <div class="note" title="Privacy of Postal Codes">
               <p>
-                <a>Postal codes</a> in certain countries can be so specific as to
-                uniquely identify an individual. This being a privacy concern,
-                some user agents only return the part of a postal code that they
-                deem sufficient for a merchant to calculate shipping costs. This
-                varies across countries and regions, and so the choice to redact
-                part, or all, of the postal code is left to the discretion of
-                implementers in the interest of protecting users' privacy.
+                <a>Postal codes</a> in certain countries can be so specific as
+                to uniquely identify an individual. This being a privacy
+                concern, some user agents only return the part of a postal code
+                that they deem sufficient for a merchant to calculate shipping
+                costs. This varies across countries and regions, and so the
+                choice to redact part, or all, of the postal code is left to
+                the discretion of implementers in the interest of protecting
+                users' privacy.
               </p>
             </div>
           </li>
@@ -2635,9 +2693,16 @@
           string if none was provided.
           </li>
           <li>If "<a data-link-for="AddressField">region</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>region</a>"] to
-          the user-provided region, or to the empty string if none was
-          provided.
+          <var>excludeList</var>:
+            <ol>
+              <li>Set <var>details</var>["<a>region</a>"] to the user-provided
+              region, or to the empty string if none was provided.
+              </li>
+              <li>If <var>details</var>["<a>region</a>"] maps to a
+              [[!ISO3166-2]] subdivision code, set
+              <var>details</var>["<a>regionCode</a>"] to that subdivision code.
+              </li>
+            </ol>
           </li>
           <li>If "<a data-link-for="AddressField">sortingCode</a>" is not in
           <var>excludeList</var>, set <var>details</var>["<a>sortingCode</a>"]

--- a/index.html
+++ b/index.html
@@ -2233,7 +2233,7 @@
               </aside>
             </li>
             <li>If "country" is not in <var>excludeList</var>, set
-            <var>details</var>.<a>[[\country]]</a> to the user-provided country
+            <var>details</var>.["<a>country</a>"] to the user-provided country
             as an upper case [[!ISO3166]] alpha-2 code, or to the empty string
             if none was provided.
             </li>

--- a/index.html
+++ b/index.html
@@ -2087,7 +2087,6 @@
             readonly attribute DOMString postalCode;
             readonly attribute DOMString recipient;
             readonly attribute DOMString region;
-            readonly attribute DOMString regionCode;
             readonly attribute DOMString sortingCode;
             readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
           };
@@ -2131,21 +2130,6 @@
                 </li>
                 <li>Set <var>address</var>.<a>[[\country]]</a> to
                 <var>country</var>.
-                </li>
-              </ol>
-            </li>
-            <li>If <var>details</var>["<a>regionCode</a>"] is present and not
-            the empty string:
-              <ol>
-                <li>Let <var>regionCode</var> be the result of <a data-cite=
-                "!INFRA#ascii-uppercase">ASCII uppercasing</a>
-                <var>details</var>["<a>regionCode</a>"].
-                </li>
-                <li>If <var>regionCode</var> is not a valid [[!ISO3166-2]]
-                subdivision code, throw a <a>RangeError</a> exception.
-                </li>
-                <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
-                <var>regionCode</var>.
                 </li>
               </ol>
             </li>
@@ -2250,16 +2234,6 @@
             Represents the <a>region</a> of the address. When getting, returns
             the value of the <a>PaymentAddress</a>'s <a>[[\region]]</a>
             internal slot.
-          </p>
-        </section>
-        <section>
-          <h2>
-            <dfn>regionCode</dfn> attribute
-          </h2>
-          <p>
-            Represents the <a>region</a> of the address as an [[!ISO3166-2]]
-            code. When getting, returns the value of the
-            <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal slot.
           </p>
         </section>
         <section>
@@ -2387,17 +2361,6 @@
             </tr>
             <tr>
               <td>
-                <dfn>[[\regionCode]]</dfn>
-              </td>
-              <td>
-                A <a>region</a> represented as a [[!ISO3166-2]] subdivision
-                code or the empty string, stored in its canonical uppercase
-                form. For example, "<code>PT-11</code>" represents the Lisbon
-                district of Portugal.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 <dfn>[[\city]]</dfn>
               </td>
               <td>
@@ -2473,7 +2436,6 @@
             DOMString country;
             sequence&lt;DOMString&gt; addressLine;
             DOMString region;
-            DOMString regionCode;
             DOMString city;
             DOMString dependentLocality;
             DOMString postalCode;
@@ -2507,13 +2469,6 @@
           </dt>
           <dd>
             A <a>region</a>.
-          </dd>
-          <dt>
-            <dfn>regionCode</dfn> member
-          </dt>
-          <dd>
-            An <a>region</a>, represented as an [[!ISO3166-2]] subdivision
-            code.
           </dd>
           <dt>
             <dfn>city</dfn> member
@@ -2654,10 +2609,6 @@
             <ol>
               <li>Set <var>details</var>["<a>region</a>"] to the user-provided
               region, or to the empty string if none was provided.
-              </li>
-              <li>If <var>details</var>["<a>region</a>"] maps to a
-              [[!ISO3166-2]] subdivision code, set
-              <var>details</var>["<a>regionCode</a>"] to that subdivision code.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -2531,14 +2531,14 @@
         <p>
           The steps to <dfn>create a <code>PaymentAddress</code> from
           user-provided input</dfn> are given by the following algorithm. The
-          algorithm takes a <a>list</a> <var>excludeList</var>, for which user
+          algorithm takes a <a>list</a> <var>redactList</var>, for which user
           input will not be gathered.
         </p>
         <ol data-link-for="AddressInit">
           <li>Let <var>details</var> be an object with no members that will
           serve as a <a>AddressInit</a> dictionary.
           </li>
-          <li>If "addressLine" is not in <var>excludeList</var>, set
+          <li>If "addressLine" is not in <var>redactList</var>, set
           <var>details</var>["<a>addressLine</a>"] to the result of splitting
           the user-provided address line into a <a data-cite=
           "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
@@ -2548,12 +2548,12 @@
               scope of this specification.
             </aside>
           </li>
-          <li>If "country" is not in <var>excludeList</var>, set
+          <li>If "country" is not in <var>redactList</var>, set
           <var>details</var>["<a>country</a>"] to the user-provided country as
           an upper case [[!ISO3166-1]] alpha-2 code, or to the empty string if
           none was provided.
           </li>
-          <li>If "phone" is not in <var>excludeList</var>, set
+          <li>If "phone" is not in <var>redactList</var>, set
           <var>details</var>["<a>phone</a>"] to the user-provided phone number,
           or to the empty string if none was provided.
             <aside class="note" title="Privacy of phone number">
@@ -2566,25 +2566,25 @@
               </p>
             </aside>
           </li>
-          <li>If "languageCode" is not in <var>excludeList</var>, set
+          <li>If "languageCode" is not in <var>redactList</var>, set
           <var>details</var>["<a>languageCode</a>"] to a <a data-cite=
           "!BCP47#section-4.5">canonicalized language tag</a>, or to the empty
           string if none was provided.
             <div class="issue" data-number="608"></div>
           </li>
-          <li>If "city" is not in <var>excludeList</var>, set
+          <li>If "city" is not in <var>redactList</var>, set
           <var>details</var>["<a>city</a>"] to the user-provided city, or to
           the empty string if none was provided.
           </li>
-          <li>If "dependentLocality" is not in <var>excludeList</var>, set
-          <var>details</var>["<a>dependentLocality</a>"] to the user-provided
-          dependent locality, or to the empty string if none was provided.
+          <li>If "dependentLocality" is not in <var>redactList</var>, set <var>
+            details</var>["<a>dependentLocality</a>"] to the user-provided
+            dependent locality, or to the empty string if none was provided.
           </li>
-          <li>If "organization" is not in <var>excludeList</var>, set
+          <li>If "organization" is not in <var>redactList</var>, set
           <var>details</var>["<a>organization</a>"] to the user-provided
           recipient organization, or to the empty string if none was provided.
           </li>
-          <li>If "postalCode" is not in <var>excludeList</var>, set
+          <li>If "postalCode" is not in <var>redactList</var>, set
           <var>details</var>["<a>postalCode</a>"] to the user-provided postal
           code, or to the empty string if none was provided. Optionally, redact
           part of <var>details</var>["<a>postalCode</a>"].
@@ -2601,18 +2601,18 @@
               </p>
             </div>
           </li>
-          <li>If "recipient" is not in <var>excludeList</var>, set
+          <li>If "recipient" is not in <var>redactList</var>, set
           <var>details</var>["<a>recipient</a>"] to the user-provided recipient
           of the transaction, or to the empty string if none was provided.
           </li>
-          <li>If "region" is not in <var>excludeList</var>:
+          <li>If "region" is not in <var>redactList</var>:
             <ol>
               <li>Set <var>details</var>["<a>region</a>"] to the user-provided
               region, or to the empty string if none was provided.
               </li>
             </ol>
           </li>
-          <li>If "sortingCode" is not in <var>excludeList</var>, set
+          <li>If "sortingCode" is not in <var>redactList</var>, set
           <var>details</var>["<a>sortingCode</a>"] to the user-provided sorting
           code, or to the empty string if none was provided.
           </li>
@@ -3210,8 +3210,8 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li>Let <var>excludeList</var> be the empty list. Optionally,
-              append the following items to <var>excludeList</var>: «
+              <li>Let <var>redactList</var> be the empty list. Optionally,
+              append the following items to <var>redactList</var>: «
               "organization", "phone", "recipient", "addressLine" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
@@ -3355,7 +3355,7 @@
           "PaymentOptions.requestShipping">requestShipping</a> value of
           <var>request</var>.<a>[[\options]]</a> is true, then <a>create a
           <code>PaymentAddress</code> from user-provided input</a> passing the
-          empty list as the <var>excludeList</var> and set the <a data-lt=
+          empty list as the <var>redactList</var> and set the <a data-lt=
           "PaymentResponse.shippingAddress">shippingAddress</a> attribute of
           <var>response</var> to the resulting <a>PaymentAddress</a>.
           Otherwise, set it to null.

--- a/index.html
+++ b/index.html
@@ -1996,6 +1996,10 @@
       <p>
         A <dfn>physical address</dfn> is composed of the following concepts.
       </p>
+      <p class="note">
+        Developers wanting to represent a <a>physical address</a> can use the
+        <a>PaymentAddress</a> interface.
+      </p>
       <dl data-sort="">
         <dt>
           <dfn>Country</dfn>
@@ -2053,13 +2057,13 @@
           address for display.
         </dd>
         <dt>
-          <dfn>organization</dfn>
+          <dfn>Organization</dfn>
         </dt>
         <dd>
           The organization, firm, company, or institution at this address.
         </dd>
         <dt>
-          <dfn>recipient</dfn>
+          <dfn>Recipient</dfn>
         </dt>
         <dd>
           The name of the recipient or contact person. This member may, under
@@ -2067,7 +2071,7 @@
           might contain "care of" information.
         </dd>
         <dt>
-          <dfn>phone number</dfn>
+          <dfn>Phone number</dfn>
         </dt>
         <dd>
           The phone number of the recipient or contact person at this address.
@@ -2078,20 +2082,20 @@
           <dfn>PaymentAddress</dfn> interface
         </h2>
         <pre class="idl">
-          [SecureContext, Exposed=(Window,Worker), Constructor(optional AddressInit details)]
+          [SecureContext, Exposed=(Window), Constructor(optional AddressInit details)]
           interface PaymentAddress {
             [Default] object toJSON();
-            readonly attribute DOMString country;
-            readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
-            readonly attribute DOMString region;
             readonly attribute DOMString city;
+            readonly attribute DOMString country;
             readonly attribute DOMString dependentLocality;
-            readonly attribute DOMString postalCode;
-            readonly attribute DOMString sortingCode;
             readonly attribute DOMString languageCode;
             readonly attribute DOMString organization;
-            readonly attribute DOMString recipient;
             readonly attribute DOMString phone;
+            readonly attribute DOMString postalCode;
+            readonly attribute DOMString recipient;
+            readonly attribute DOMString region;
+            readonly attribute DOMString sortingCode;
+            readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
           };
         </pre>
         <p>
@@ -2103,10 +2107,10 @@
             Constructor
           </h2>
           <p>
-            The steps to <dfn data-lt="PaymentAddress.PaymentAddress()"
-            data-no-default="">construct a <code>PymentAddress</code></dfn>
-            with <a>AddressInit</a> <var>details</var> are given by the
-            following algorithm:
+            The steps to <dfn data-lt=
+            "PaymentAddress.PaymentAddress()">construct a
+            <code>PaymentAddress</code></dfn> with <a>AddressInit</a>
+            <var>details</var> are given by the following algorithm:
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>address</var> be a new instance of
@@ -2130,46 +2134,18 @@
                 </li>
               </ol>
             </li>
-            <li>If <var>details</var>["<a>addressLine</a>"] is present:
-              <ol>
-                <li>Push each item of <var>details</var>["<a>addressLine</a>"]
-                in order into <var>address</var>.<a>[[\addressLine]]</a>.
-                </li>
-              </ol>
-            </li>
-            <li>Freeze <var>details</var>["<a>addressLine</a>"].
-            </li>
-            <li>If <var>details</var>["<a>region</a>"] is present, set
-            <var>address</var>.<a>[[\region]]</a> to the result of trimming
-            <var>details</var>["<a>region</a>"]
-            </li>
             <li>If <var>details</var>["<a>phone</a>"] is present:
               <ol>
-                <li>Check if <var>details</var>["<a>phone</a>"] is a
+                <li>If <var>details</var>["<a>phone</a>"] is not a
                 <a>structurally valid phone number</a>, throw a
                 <a>RangeError</a>.
                 </li>
-                <li>Set <var>address</var>.<a>[[\phone]]</a> to the result of
-                <a>canonicalize a phone number</a>
-                <var>details</var>["<a>phone</a>"].
+                <li>
+                  <a>Canonicalize a phone number</a>
+                  <var>details</var>["<a>phone</a>"] and set
+                  <var>address</var>.<a>[[\phone]]</a> to the result.
                 </li>
               </ol>
-            </li>
-            <li>If <var>details</var>["<a>city</a>"] is present, set
-            <var>address</var>.<a>[[\city]]</a> to the result of trimming <var>
-              details</var>["<a>city</a>"].
-            </li>
-            <li>If <var>details</var>["<a>dependentLocality</a>"] is present,
-            set <var>address</var>.<a>[[\dependentLocality]]</a> to the result
-            of trimming <var>details</var>["<a>dependentLocality</a>"].
-            </li>
-            <li>If <var>details</var>["<a>postalCode</a>"] is present, set
-            <var>address</var>.<a>[[\postalCode]]</a> to the result of trimming
-            <var>details</var>["<a>postalCode</a>"].
-            </li>
-            <li>If <var>details</var>["<a>sortingCode</a>"] is present, set
-            <var>address</var>.<a>[[\sortingCode]]</a> to the result of
-            trimming <var>details</var>["<a>sortingCode</a>"].
             </li>
             <li>If <var>details</var>["<a>languageCode</a>"] is present:
               <ol>
@@ -2183,13 +2159,49 @@
                 </li>
               </ol>
             </li>
-            <li>If <var>details</var>["<a>organization</a>"] is present, set
-            <var>address</var>.<a>[[\organization]]</a> to the result of
-            trimming <var>details</var>["<a>organization</a>"].
+            <li>If <var>details</var>["<a>addressLine</a>"] is present, set
+            <var>address</var>.<a>[[\addressLine]]</a> to a new frozen array
+            created from <var>details</var>.["<a>addressLine</a>"].
             </li>
-            <li>If <var>details</var>["<a>recipient</a>"] is present, set <var>
-              address</var>.<a>[[\recipient]]</a> to the result of trimming
-              <var>details</var>["<a>recipient</a>"].
+            <li>If <var>details</var>["<a>region</a>"] is present, <a>strip
+            leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>region</a>"] and set
+            <var>address</var>.<a>[[\region]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>city</a>"] is present, <a>strip
+            leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>city</a>"] and set
+            <var>address</var>.<a>[[\city]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>dependentLocality</a>"] is present,
+            <a>strip leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>dependentLocality</a>"] and set
+            <var>address</var>.<a>[[\dependentLocality]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>postalCode</a>"] is present, <a>strip
+            leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>postalCode</a>"] and set
+            <var>address</var>.<a>[[\postalCode]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>sortingCode</a>"] is present,
+            <a>strip leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>sortingCode</a>"] and set
+            <var>address</var>.<a>[[\sortingCode]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>sortingCode</a>"] is present,
+            <a>strip leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>sortingCode</a>"] and set
+            <var>address</var>.<a>[[\sortingCode]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>organization</a>"] is present,
+            <a>strip leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>organization</a>"] and set
+            <var>address</var>.<a>[[\organization]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>recipient</a>"] is present, <a>strip
+            leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>recipient</a>"] and set
+            <var>address</var>.<a>[[\recipient]]</a> to the result.
             </li>
             <li>Return <var>address</var>.
             </li>
@@ -2197,34 +2209,38 @@
         </section>
         <section>
           <h2>
-            Creating a <code>PaymentAddress</code>
+            Creating a <code>PaymentAddress</code> from user-provided input
           </h2>
           <p>
-            The steps to <dfn>create a payment address from user-provided
-            input</dfn> are given by the following algorithm.
+            The steps to <dfn>create a <code>PaymentAddress</code> from
+            user-provided input</dfn> are given by the following algorithm. The
+            algorithm takes a <a>list</a> <var>excludeList</var>, which
+            includes zero or more members identifier for which user input is
+            not gathered.
           </p>
-          <ol data-link-for="PaymentAddress">
-            <li>Let <var>address</var> be a new instance of
-            <a>PaymentAddress</a>.
+          <ol data-link-for="AddressInit">
+            <li>Let <var>details</var> be an object with no members that will
+            serve as a <a>AddressInit</a> dictionary.
             </li>
-            <li>Set <var>address</var>.<a>[[\addressLine]]</a> to the result of
+            <li>If "addressLine" is not in <var>excludeList</var>, set
+            <var>details</var>.<a>["addressLine"]</a> to the result of
             splitting the user-provided address line into a <a data-cite=
             "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
-            provided, set it to the empty <a data-cite=
-            "!WEBIDL#dfn-frozen-array-type">frozen array</a>.
+            provided, set it to the empty <a>list</a>.
               <aside class="note">
                 How to split an address line is locale dependent and beyond the
                 scope of this specification.
               </aside>
             </li>
-            <li>Set <var>address</var>.<a>[[\country]]</a> to the user-provided
-            country as an upper case [[!ISO3166]] alpha-2 code, or to the empty
-            string if none was provided.
+            <li>If "country" is not in <var>excludeList</var>, set
+            <var>details</var>.<a>[[\country]]</a> to the user-provided country
+            as an upper case [[!ISO3166]] alpha-2 code, or to the empty string
+            if none was provided.
             </li>
-            <li>Set the <var>address</var>.<a>[[\phone]]</a> to the
-            user-provided phone number for this shipping address, optionally
-            formatted to adhere to [[!E.164]], or to the empty string if none
-            was provided.
+            <li>If "phone" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>phone</a>"] to the user-provided phone
+            number for this shipping address, optionally formatted to adhere to
+            [[!E.164]], or to the empty string if none was provided.
               <aside class="note" title="Privacy of phone number">
                 <p>
                   To maintain user's privacy, implementers need to be mindful
@@ -2235,38 +2251,47 @@
                 </p>
               </aside>
             </li>
-            <li>Set <var>address</var>.<a>[[\languageCode]]</a> to a
-            <a data-cite="!BCP47#section-4.5">canonicalized language tag</a>,
-            or to the empty string if none was provided.
+            <li>If "languageCode" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>languageCode</a>"] to a <a data-cite=
+            "!BCP47#section-4.5">canonicalized language tag</a>, or to the
+            empty string if none was provided.
               <div class="issue" data-number="608"></div>
             </li>
-            <li>Set <var>address</var>.<a>[[\city]]</a> to the user-provided
-            city, or to the empty string if none was provided.
+            <li>If "city" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>city</a>"] to the user-provided city, or to
+            the empty string if none was provided.
             </li>
-            <li>Set <var>address</var>.<a>[[\dependentLocality]]</a> to the
+            <li>If "dependentLocality" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>dependentLocality</a>"] to the
             user-provided dependent locality, or to the empty string if none
             was provided.
             </li>
-            <li>Set <var>address</var>.<a>[[\organization]]</a> to the
-            user-provided recipient organization, or to the empty string if
-            none was provided.
-            </li>
-            <li>Set <var>address</var>.<a>[[\postalCode]]</a> to the
-            user-provided postal code, or to the empty string if none was
+            <li>If "organization" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>organization</a>"] to the user-provided
+            recipient organization, or to the empty string if none was
             provided.
             </li>
-            <li>Set <var>address</var>.<a>[[\recipient]]</a> to the
-            user-provided recipient of the transaction, or to the empty string
-            if none was provided.
+            <li>If "postalCode" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>postalCode</a>"] to the user-provided
+            postal code, or to the empty string if none was provided.
             </li>
-            <li>Set <var>address</var>.<a>[[\region]]</a> to the user-provided
-            region, or to the empty string if none was provided.
-            </li>
-            <li>Set <var>address</var>.<a>[[\sortingCode]]</a> to the
-            user-provided sorting code, or to the empty string if none was
+            <li>If "recipient" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>recipient</a>"] to the user-provided
+            recipient of the transaction, or to the empty string if none was
             provided.
             </li>
-            <li>Return <var>address</var>.
+            <li>If "region" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>region</a>"] to the user-provided region,
+            or to the empty string if none was provided.
+            </li>
+            <li>If "sortingCode" is not in <var>excludeList</var>, set
+            <var>details</var>.["<a>sortingCode</a>"] to the user-provided
+            sorting code, or to the empty string if none was provided.
+            </li>
+            <li>
+              <a data-lt="PaymentAddress.PaymentAddress()">Construct a new
+              <code>PaymentAddress</code></a> with <var>details</var> and
+              return the result.
             </li>
           </ol>
         </section>
@@ -2397,7 +2422,8 @@
               </td>
               <td>
                 A <a>country</a> as an [[!ISO3166]] alpha-2 code or the empty
-                string. The canonical form is upper case. For example, "JP".
+                string stored in its canonical uppercase form. For example,
+                "JP".
               </td>
             </tr>
             <tr>
@@ -2602,7 +2628,7 @@
             </li>
             <li>Strip and collapse ASCII whitespace in <var>tel</var>.
             </li>
-            <li>If the length is greater 15, return false.
+            <li>If <var>tel</var>'s the length is greater 15, return false.
             </li>
             <li>If the first code point is not U+002B PLUS SIGN, return false.
             </li>
@@ -3210,8 +3236,12 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
+              <li>Let excludeList be the list « "organization", "phoneNumber",
+              "recipient", "" »
+              </li>
               <li>Let <var>address</var> be the result of running the steps to
-              <a>create a payment address from user-provided input</a>.
+              <a>create a <code>PaymentAddress</code> from user-provided
+              input</a>.
               </li>
               <li>Set the <a data-lt=
               "PaymentRequest.shippingAddress">shippingAddress</a> attribute on
@@ -3801,7 +3831,15 @@
       <p>
         This specification relies on several other underlying specifications.
       </p>
-      <dl>
+      <dl data-sort="">
+        <dt>
+          Infra
+        </dt>
+        <dd>
+          The [[!INFRA] specification defines how to <dfn data-cite=
+          "!INFRA#strip-leading-and-trailing-ascii-whitespace">strip leading
+          and trailing ascii whitespace</dfn>.
+        </dd>
         <dt>
           Payment Method Identifiers
         </dt>

--- a/index.html
+++ b/index.html
@@ -3271,8 +3271,9 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li>Let <var>excludeList</var> be the list « "organization",
-              "phoneNumber", "recipient" ».
+              <li data-link-for="AddressField">Let <var>excludeList</var> be
+              the list « "<a>organization</a>", "<a>phoneNumber</a>",
+              "<a>recipient</a>", "<a>addressLine</a>" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided

--- a/index.html
+++ b/index.html
@@ -3388,7 +3388,9 @@
           </li>
           <li>If the <a data-lt=
           "PaymentOptions.requestShipping">requestShipping</a> value of
-          <var>request</var>.<a>[[\options]]</a> is true, then:
+          <var>request</var>.<a>[[\options]]</a> is false, then set the
+          <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
+          attribute value of <var>response</var> to null. Otherwise:
             <ol>
               <li>Let <var>redactList</var> be the empty <a>list</a>.
               </li>

--- a/index.html
+++ b/index.html
@@ -2214,16 +2214,15 @@
           <p>
             The steps to <dfn>create a <code>PaymentAddress</code> from
             user-provided input</dfn> are given by the following algorithm. The
-            algorithm takes a <a>list</a> <var>excludeList</var>, which
-            includes zero or more members identifier for which user input is
-            not gathered.
+            algorithm takes a <a>AddressField</a> <a>list</a>
+            <var>excludeList</var>, for which user input is not gathered.
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>details</var> be an object with no members that will
             serve as a <a>AddressInit</a> dictionary.
             </li>
             <li>If "addressLine" is not in <var>excludeList</var>, set
-            <var>details</var>.<a>["addressLine"]</a> to the result of
+            <var>details</var>.["<a>addressLine</a>"] to the result of
             splitting the user-provided address line into a <a data-cite=
             "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
             provided, set it to the empty <a>list</a>.
@@ -2511,7 +2510,7 @@
           </table>
         </section>
       </section>
-      <section>
+      <section data-dfn-for="AddressInit" data-link-for="AddressInit">
         <h2>
           <dfn>AddressInit</dfn> dictionary
         </h2>
@@ -2604,6 +2603,35 @@
             A <a>phone number</a>.
           </dd>
         </dl>
+      </section>
+      <section data-dfn-for="AddressField" data-link-for="AddressField">
+        <h2>
+          <dfn>AddressField</dfn> enum
+        </h2>
+        <pre class="idl">
+          enum AddressField {
+            "addressLine",
+            "city",
+            "country",
+            "dependentLocality",
+            "languageCode",
+            "organization",
+            "phone",
+            "postalCode",
+            "recipient",
+            "region",
+            "sortingCode"
+          };
+        </pre>
+        <p>
+          The "<dfn>addressLine</dfn>", "<dfn>city</dfn>",
+          "<dfn>country</dfn>", "<dfn>dependentLocality</dfn>",
+          "<dfn>languageCode</dfn>", "<dfn>organization</dfn>",
+          "<dfn>phone</dfn>", "<dfn>postalCode</dfn>", "<dfn>recipient</dfn>",
+          "<dfn>region</dfn>", and "<dfn>sortingCode</dfn>" enum values
+          correspond to attributes with the same identifiers in the
+          <a>PaymentAddress</a> interface.
+        </p>
       </section>
       <section>
         <h2>
@@ -3238,8 +3266,8 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li>Let excludeList be the list « "organization", "phoneNumber",
-              "recipient", "" »
+              <li>Let <var>excludeList</var> be the list « "organization",
+              "phoneNumber", "recipient" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided
@@ -3840,7 +3868,8 @@
         <dd>
           The [[!INFRA] specification defines how to <dfn data-cite=
           "!INFRA#strip-leading-and-trailing-ascii-whitespace">strip leading
-          and trailing ascii whitespace</dfn>.
+          and trailing ascii whitespace</dfn>. It also defines the concpet of a
+          <dfn data-cite="!INFRA#list">list</dfn>.
         </dd>
         <dt>
           Payment Method Identifiers

--- a/index.html
+++ b/index.html
@@ -2099,10 +2099,12 @@
           <h2>
             Internal Constructor
           </h2>
-          <p class="note">
-            This constructor algorithm is used internally by the user agent.
-            It's not available to scripts.
-          </p>
+          <div class="issue" data-number="653">
+            Currently, this constructor algorithm is only used internally by a
+            user agent. It is not available to scripts. However, discussions
+            are underway in the working group to make this into a public
+            constructor.
+          </div>
           <p>
             The steps to <dfn data-lt=
             "PaymentAddress.PaymentAddress()">internally construct a
@@ -2111,10 +2113,11 @@
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>address</var> be a new instance of
-            <a>PaymentAddress</a>.Set
-            <var>address</var>.<a>[[\addressLine]]</a>to the empty frozen
-            array, and all other <a data-lt="PaymentAddress slots">internal
-            slots</a>set to the empty string.
+            <a>PaymentAddress</a>.
+            </li>
+            <li>Set <var>address</var>.<a>[[\addressLine]]</a> to the empty
+            frozen array, and all other <a data-lt=
+            "PaymentAddress slots">internal slots</a> set to the empty string.
             </li>
             <li>If <var>details</var> was not passed to the constructor, return
             <var>address</var> and terminate this algorithm.
@@ -2211,16 +2214,17 @@
           <h2>
             <dfn>country</dfn> attribute
           </h2>
-          <p>
-            When getting, returns the value of the <a>PaymentAddress</a>'s
-            <a>[[\country]]</a> internal slot.
+          <p data-link-for="">
+            Represents the <a>country</a> of the address. When getting, returns
+            the value of the <a>PaymentAddress</a>'s <a>[[\country]]</a>
+            internal slot.
           </p>
         </section>
         <section>
           <h2>
             <dfn>addressLine</dfn> attribute
           </h2>
-          <p>
+          <p data-link-for="">
             Represents the <a>address line</a> of the address. When getting,
             returns the value of the <a>PaymentAddress</a>'s
             <a>[[\addressLine]]</a> internal slot.
@@ -2230,7 +2234,7 @@
           <h2>
             <dfn>region</dfn> attribute
           </h2>
-          <p>
+          <p data-link-for="">
             Represents the <a>region</a> of the address. When getting, returns
             the value of the <a>PaymentAddress</a>'s <a>[[\region]]</a>
             internal slot.
@@ -2240,7 +2244,7 @@
           <h2>
             <dfn>city</dfn> attribute
           </h2>
-          <p>
+          <p data-link-for="">
             Represents the <a>city</a> of the address. When getting, returns
             the value of the <a>PaymentAddress</a>'s <a>[[\city]]</a> internal
             slot.
@@ -2290,7 +2294,7 @@
           <h2>
             <dfn>organization</dfn> attribute
           </h2>
-          <p>
+          <p data-link-for="">
             Represents the <a>organization</a> of the address. When getting,
             returns the value of the <a>PaymentAddress</a>'s
             <a>[[\organization]]</a> internal slot.
@@ -2300,7 +2304,7 @@
           <h2>
             <dfn>recipient</dfn> attribute
           </h2>
-          <p>
+          <p data-link-for="">
             Represents the <a>recipient</a> of the address. When getting,
             returns the value of the <a>PaymentAddress</a>'s
             <a>[[\recipient]]</a> internal slot.
@@ -2311,9 +2315,9 @@
             <dfn>phone</dfn> attribute
           </h2>
           <p>
-            Represents the <a>phone</a> of the address. When getting, returns
-            the value of the <a>PaymentAddress</a>'s <a>[[\phone]]</a> internal
-            slot.
+            Represents the <a>phone number</a> of the address. When getting,
+            returns the value of the <a>PaymentAddress</a>'s <a>[[\phone]]</a>
+            internal slot.
           </p>
         </section>
         <section data-link-for="">
@@ -2456,13 +2460,13 @@
             <dfn>country</dfn> member
           </dt>
           <dd>
-            An <a>country</a>, represented as a a [[!ISO3166-1]] country code.
+            An <a>country</a>, represented as a [[!ISO3166-1]] country code.
           </dd>
           <dt>
             <dfn>addressLine</dfn> member
           </dt>
           <dd>
-            An <a>address line</a>, represented as sequence.
+            An <a>address line</a>, represented as a sequence.
           </dd>
           <dt>
             <dfn>region</dfn> member
@@ -2535,8 +2539,8 @@
           input will not be gathered.
         </p>
         <ol data-link-for="AddressInit">
-          <li>Let <var>details</var> be an object with no members that will
-          serve as a <a>AddressInit</a> dictionary.
+          <li>Let <var>details</var> be an <a>AddressInit</a> dictionary with
+          no members present.
           </li>
           <li>If "addressLine" is not in <var>redactList</var>, set
           <var>details</var>["<a>addressLine</a>"] to the result of splitting
@@ -3216,7 +3220,7 @@
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided
-              input</a>.
+              input</a> with <var>redactList</var>.
               </li>
               <li>Set the <a data-lt=
               "PaymentRequest.shippingAddress">shippingAddress</a> attribute on

--- a/index.html
+++ b/index.html
@@ -2125,7 +2125,7 @@
             </li>
             <li>If <var>details</var>["<a>country</a>"] is present:
               <ol>
-                <li>Set <var>country</var> the result of <a>stripping leading
+                <li>Set <var>country</var> the result of <a>strip leading
                 and trailing ASCII whitespace</a> from
                 <var>details</var>["<a>country</a>"] and performing
                 <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>.

--- a/index.html
+++ b/index.html
@@ -2449,7 +2449,7 @@
           "PaymentAddress.PaymentAddress()">constructing</a> a
           <a>PaymentAddress</a>. Its members are as follows.
         </p>
-        <dl data-dfn-for="AddressInit" data-sort="ascending">
+        <dl data-dfn-for="AddressInit" data-link-for="" data-sort="ascending">
           <dt>
             <dfn>country</dfn> member
           </dt>
@@ -2490,7 +2490,7 @@
             <dfn>sortingCode</dfn> member
           </dt>
           <dd>
-            A <a>sorting code</a>
+            A <a>sorting code</a>.
           </dd>
           <dt>
             <dfn>languageCode</dfn> member
@@ -2579,7 +2579,8 @@
           </li>
           <li>If "<a data-link-for="AddressField">phone</a>" is not in
           <var>excludeList</var>, set <var>details</var>["<a>phone</a>"] to the
-          user-provided <a>structurally valid phone number</a>, or to the empty
+          user-provided <a>structurally valid phone number</a> in <a data-lt=
+          "canonicalize a phone number">canonical form</a>, or to the empty
           string if none was provided.
             <aside class="note" title="Privacy of phone number">
               <p>
@@ -2614,7 +2615,19 @@
           <li>If "<a data-link-for="AddressField">postalCode</a>" is not in
           <var>excludeList</var>, set <var>details</var>["<a>postalCode</a>"]
           to the user-provided postal code, or to the empty string if none was
-          provided.
+          provided. Optionally, redact part of
+          <var>details</var>["<a>postalCode</a>"].
+            <div class="note" title="Privacy of Postal Codes">
+              <p>
+                <a>Postal codes</a> in certain countries can be so specific as to
+                uniquely identify an individual. This being a privacy concern,
+                some user agents only return the part of a postal code that they
+                deem sufficient for a merchant to calculate shipping costs. This
+                varies across countries and regions, and so the choice to redact
+                part, or all, of the postal code is left to the discretion of
+                implementers in the interest of protecting users' privacy.
+              </p>
+            </div>
           </li>
           <li>If "<a data-link-for="AddressField">recipient</a>" is not in
           <var>excludeList</var>, set <var>details</var>["<a>recipient</a>"] to
@@ -3272,7 +3285,7 @@
             run the following steps:
             <ol>
               <li data-link-for="AddressField">Let <var>excludeList</var> be
-              the list « "<a>organization</a>", "<a>phoneNumber</a>",
+              the list « "<a>organization</a>", "<a>phone</a>",
               "<a>recipient</a>", "<a>addressLine</a>" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
@@ -3414,11 +3427,12 @@
           </li>
           <li>If the <a data-lt=
           "PaymentOptions.requestShipping">requestShipping</a> value of
-          <var>request</var>.<a>[[\options]]</a> is true, then set the
-          <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
-          attribute of <var>response</var> to the value of the <a data-lt=
-          "PaymentRequest.shippingAddress">shippingAddress</a> attribute of
-          <var>request</var>. Otherwise, set it to null.
+          <var>request</var>.<a>[[\options]]</a> is true, then <a>create a
+          <code>PaymentAddress</code> from user-provided input</a> passing the
+          empty list as the <var>excludeList</var> and set the <a data-lt=
+          "PaymentResponse.shippingAddress">shippingAddress</a> attribute of
+          <var>response</var> to the resulting <a>PaymentAddress</a>.
+          Otherwise, set it to null.
           </li>
           <li>If the <a data-lt=
           "PaymentOptions.requestShipping">requestShipping</a> value of
@@ -3446,11 +3460,9 @@
           "PaymentOptions.requestPayerPhone">requestPayerPhone</a> value of
           <var>request</var>.<a>[[\options]]</a> is true, then set the
           <a data-lt="PaymentResponse.payerPhone">payerPhone</a> attribute of
-          <var>response</var> to the payer's phone number provided by the user,
-          or to null if none was provided. When setting the <a data-lt=
-          "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
-          SHOULD format the phone number to adhere to [[!E.164]]. Otherwise,
-          set it to null.
+          <var>response</var> to a <a>structurally valid phone number</a> in
+          <a data-lt="canonicalize a phone number">canonical form</a> provided
+          by the user, or to null if none was provided.
           </li>
           <li>Set <var>response</var>.<a>[[\completeCalled]]</a> to false.
           </li>

--- a/index.html
+++ b/index.html
@@ -2576,36 +2576,6 @@
           </dd>
         </dl>
       </section>
-      <section data-dfn-for="AddressField" data-link-for="AddressField">
-        <h2>
-          <dfn>AddressField</dfn> enum
-        </h2>
-        <pre class="idl">
-          enum AddressField {
-            "addressLine",
-            "city",
-            "country",
-            "dependentLocality",
-            "languageCode",
-            "organization",
-            "phone",
-            "postalCode",
-            "recipient",
-            "region",
-            "regionCode",
-            "sortingCode"
-          };
-        </pre>
-        <p>
-          The "<dfn>addressLine</dfn>", "<dfn>city</dfn>",
-          "<dfn>country</dfn>", "<dfn>dependentLocality</dfn>",
-          "<dfn>languageCode</dfn>", "<dfn>organization</dfn>",
-          "<dfn>phone</dfn>", "<dfn>postalCode</dfn>", "<dfn>recipient</dfn>",
-          "<dfn>region</dfn>", "<dfn>regionCode</dfn>" and
-          "<dfn>sortingCode</dfn>" enum values correspond to attributes with
-          the same identifiers in the <a>PaymentAddress</a> interface.
-        </p>
-      </section>
       <section>
         <h2>
           Creating a <code>PaymentAddress</code> from user-provided input
@@ -2613,31 +2583,31 @@
         <p>
           The steps to <dfn>create a <code>PaymentAddress</code> from
           user-provided input</dfn> are given by the following algorithm. The
-          algorithm takes a <a>AddressField</a> <a>list</a>
-          <var>excludeList</var>, for which user input will not be gathered.
+          algorithm takes a <a>list</a> <var>excludeList</var>, for which user
+          input will not be gathered.
         </p>
         <ol data-link-for="AddressInit">
           <li>Let <var>details</var> be an object with no members that will
           serve as a <a>AddressInit</a> dictionary.
           </li>
-          <li>If "<a data-link-for="AddressField">addressLine</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>addressLine</a>"]
-          to the result of splitting the user-provided address line into a
-          <a data-cite="!WEBIDL#dfn-frozen-array-type">frozen array</a>. If
-          none was provided, set it to the empty <a>list</a>.
+          <li>If "addressLine" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>addressLine</a>"] to the result of splitting
+          the user-provided address line into a <a data-cite=
+          "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
+          provided, set it to the empty <a>list</a>.
             <aside class="note">
               How to split an address line is locale dependent and beyond the
               scope of this specification.
             </aside>
           </li>
-          <li>If "<a data-link-for="AddressField">country</a>" is not in <var>
-            excludeList</var>, set <var>details</var>["<a>country</a>"] to the
-            user-provided country as an upper case [[!ISO3166-1]] alpha-2 code,
-            or to the empty string if none was provided.
+          <li>If "country" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>country</a>"] to the user-provided country as
+          an upper case [[!ISO3166-1]] alpha-2 code, or to the empty string if
+          none was provided.
           </li>
-          <li>If "<a data-link-for="AddressField">phone</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>phone</a>"] to the
-          user-provided <a>structurally valid phone number</a> in <a data-lt=
+          <li>If "phone" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>phone</a>"] to the user-provided
+          <a>structurally valid phone number</a> in <a data-lt=
           "canonicalize a phone number">canonical form</a>, or to the empty
           string if none was provided.
             <aside class="note" title="Privacy of phone number">
@@ -2650,31 +2620,28 @@
               </p>
             </aside>
           </li>
-          <li>If "<a data-link-for="AddressField">languageCode</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>languageCode</a>"]
-          to a <a data-cite="!BCP47#section-4.5">canonicalized language
-          tag</a>, or to the empty string if none was provided.
+          <li>If "languageCode" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>languageCode</a>"] to a <a data-cite=
+          "!BCP47#section-4.5">canonicalized language tag</a>, or to the empty
+          string if none was provided.
             <div class="issue" data-number="608"></div>
           </li>
-          <li>If "<a data-link-for="AddressField">city</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>city</a>"] to the
-          user-provided city, or to the empty string if none was provided.
+          <li>If "city" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>city</a>"] to the user-provided city, or to
+          the empty string if none was provided.
           </li>
-          <li>If "<a data-link-for="AddressField">dependentLocality</a>" is not
-          in <var>excludeList</var>, set
+          <li>If "dependentLocality" is not in <var>excludeList</var>, set
           <var>details</var>["<a>dependentLocality</a>"] to the user-provided
           dependent locality, or to the empty string if none was provided.
           </li>
-          <li>If "<a data-link-for="AddressField">organization</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>organization</a>"]
-          to the user-provided recipient organization, or to the empty string
-          if none was provided.
+          <li>If "organization" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>organization</a>"] to the user-provided
+          recipient organization, or to the empty string if none was provided.
           </li>
-          <li>If "<a data-link-for="AddressField">postalCode</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>postalCode</a>"]
-          to the user-provided postal code, or to the empty string if none was
-          provided. Optionally, redact part of
-          <var>details</var>["<a>postalCode</a>"].
+          <li>If "postalCode" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>postalCode</a>"] to the user-provided postal
+          code, or to the empty string if none was provided. Optionally, redact
+          part of <var>details</var>["<a>postalCode</a>"].
             <div class="note" title="Privacy of Postal Codes">
               <p>
                 <a>Postal codes</a> in certain countries can be so specific as
@@ -2688,13 +2655,11 @@
               </p>
             </div>
           </li>
-          <li>If "<a data-link-for="AddressField">recipient</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>recipient</a>"] to
-          the user-provided recipient of the transaction, or to the empty
-          string if none was provided.
+          <li>If "recipient" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>recipient</a>"] to the user-provided recipient
+          of the transaction, or to the empty string if none was provided.
           </li>
-          <li>If "<a data-link-for="AddressField">region</a>" is not in
-          <var>excludeList</var>:
+          <li>If "region" is not in <var>excludeList</var>:
             <ol>
               <li>Set <var>details</var>["<a>region</a>"] to the user-provided
               region, or to the empty string if none was provided.
@@ -2705,10 +2670,9 @@
               </li>
             </ol>
           </li>
-          <li>If "<a data-link-for="AddressField">sortingCode</a>" is not in
-          <var>excludeList</var>, set <var>details</var>["<a>sortingCode</a>"]
-          to the user-provided sorting code, or to the empty string if none was
-          provided.
+          <li>If "sortingCode" is not in <var>excludeList</var>, set
+          <var>details</var>["<a>sortingCode</a>"] to the user-provided sorting
+          code, or to the empty string if none was provided.
           </li>
           <li>
             <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a
@@ -3350,10 +3314,9 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li data-link-for="AddressField">Let <var>excludeList</var> be
-              the empty list. Optionally, append the following items to
-              <var>excludeList</var>: « "<a>organization</a>", "<a>phone</a>",
-              "<a>recipient</a>", "<a>addressLine</a>" ».
+              <li>Let <var>excludeList</var> be the empty list. Optionally,
+              append the following items to <var>excludeList</var>: «
+              "organization", "phone", "recipient", "addressLine" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided

--- a/index.html
+++ b/index.html
@@ -2029,8 +2029,7 @@
         </dt>
         <dd>
           The dependent locality or sublocality within a city. For example,
-          used for neighborhoods, boroughs, districts, or UK dependent
-          localities.
+          neighborhoods, boroughs, districts, or UK dependent localities.
         </dd>
         <dt>
           <dfn data-lt="Postal codes">Postal code</dfn>
@@ -2495,13 +2494,13 @@
             <dfn>country</dfn> member
           </dt>
           <dd>
-            An [[!ISO3166-1]] country code, representing the <a>country</a>.
+            An <a>country</a>, represented as a a [[!ISO3166-1]] country code.
           </dd>
           <dt>
             <dfn>addressLine</dfn> member
           </dt>
           <dd>
-            A sequence representing the <a>address line</a>.
+            An <a>address line</a>, represented as sequence.
           </dd>
           <dt>
             <dfn>region</dfn> member
@@ -2513,7 +2512,8 @@
             <dfn>regionCode</dfn> member
           </dt>
           <dd>
-            An [[!ISO3166-2]] subdivision code representing the <a>region</a>.
+            An <a>region</a>, represented as an [[!ISO3166-2]] subdivision
+            code.
           </dd>
           <dt>
             <dfn>city</dfn> member
@@ -2543,8 +2543,8 @@
             <dfn>languageCode</dfn> member
           </dt>
           <dd>
-            A <a data-cite="!BCP47#section-2">language tag</a> representing the
-            <a>language code</a>.
+            A <a>language code</a>, represented as a <a data-cite=
+            "!BCP47#section-2">language tag</a>.
           </dd>
           <dt>
             <dfn>organization</dfn> member
@@ -2556,7 +2556,7 @@
             <dfn>recipient</dfn> member
           </dt>
           <dd>
-            A <a>recipient</a>. This member may, under certain circumstances,
+            A <a>recipient</a>. Under certain circumstances, this member may
             contain multiline information. For example, it might contain "care
             of" information.
           </dd>
@@ -2564,7 +2564,8 @@
             <dfn>phone</dfn> member
           </dt>
           <dd>
-            A <a>phone number</a>.
+            A <a>phone number</a>, optionally structured to adhere to
+            [[!E.164]].
           </dd>
         </dl>
       </section>

--- a/index.html
+++ b/index.html
@@ -2108,8 +2108,9 @@
           <p>
             The steps to <dfn data-lt=
             "PaymentAddress.PaymentAddress()">internally construct a
-            <code>PaymentAddress</code></dfn> with <a>AddressInit</a>
-            <var>details</var> are given by the following algorithm:
+            <code>PaymentAddress</code></dfn> with an optional
+            <a>AddressInit</a> <var>details</var> are given by the following
+            algorithm:
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>address</var> be a new instance of
@@ -2119,8 +2120,8 @@
             frozen array, and all other <a data-lt=
             "PaymentAddress slots">internal slots</a> set to the empty string.
             </li>
-            <li>If <var>details</var> was not passed to the constructor, return
-            <var>address</var> and terminate this algorithm.
+            <li>If <var>details</var> was not passed, return
+            <var>address</var>.
             </li>
             <li>If <var>details</var>["<a>country</a>"] is present:
               <ol>

--- a/index.html
+++ b/index.html
@@ -1991,322 +1991,637 @@
     </div>
     <section data-dfn-for="PaymentAddress" data-link-for="PaymentAddress">
       <h2>
-        <dfn>PaymentAddress</dfn> interface
+        Physical Addresses
       </h2>
-      <pre class="idl">
-        [SecureContext, Exposed=Window]
-        interface PaymentAddress {
-          [Default] object toJSON();
-          readonly attribute DOMString country;
-          readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
-          readonly attribute DOMString region;
-          readonly attribute DOMString city;
-          readonly attribute DOMString dependentLocality;
-          readonly attribute DOMString postalCode;
-          readonly attribute DOMString sortingCode;
-          readonly attribute DOMString languageCode;
-          readonly attribute DOMString organization;
-          readonly attribute DOMString recipient;
-          readonly attribute DOMString phone;
-        };
-      </pre>
-      <section>
+      <p>
+        A <dfn>physical address</dfn> is composed of the following concepts.
+      </p>
+      <dl data-sort="">
+        <dt>
+          <dfn>Country</dfn>
+        </dt>
+        <dd>
+          The country corresponding to this address.
+        </dd>
+        <dt>
+          <dfn>Address line</dfn>
+        </dt>
+        <dd>
+          The most specific part of the address. It can include, for example, a
+          street name, a house number, apartment number, a rural delivery
+          route, descriptive instructions, or a post office box number.
+        </dd>
+        <dt>
+          <dfn>Region</dfn>
+        </dt>
+        <dd>
+          The top level administrative subdivision of the country. For example,
+          this can be a state, a province, an oblast, or a prefecture.
+        </dd>
+        <dt>
+          <dfn>City</dfn>
+        </dt>
+        <dd>
+          The city/town portion of the address.
+        </dd>
+        <dt>
+          <dfn>Dependent locality</dfn>
+        </dt>
+        <dd>
+          The dependent locality or sublocality within a city. For example,
+          used for neighborhoods, boroughs, districts, or UK dependent
+          localities.
+        </dd>
+        <dt>
+          <dfn>Postal code</dfn>
+        </dt>
+        <dd>
+          The postal code or ZIP code, also known as PIN code in India.
+        </dd>
+        <dt>
+          <dfn>Sorting code</dfn>
+        </dt>
+        <dd>
+          The sorting code as used in, for example, France.
+        </dd>
+        <dt>
+          <dfn>Language code</dfn>
+        </dt>
+        <dd>
+          The language in which the address is provided. It's used to determine
+          the field separators and the order of fields when formatting the
+          address for display.
+        </dd>
+        <dt>
+          <dfn>organization</dfn>
+        </dt>
+        <dd>
+          The organization, firm, company, or institution at this address.
+        </dd>
+        <dt>
+          <dfn>recipient</dfn>
+        </dt>
+        <dd>
+          The name of the recipient or contact person. This member may, under
+          certain circumstances, contain multiline information. For example, it
+          might contain "care of" information.
+        </dd>
+        <dt>
+          <dfn>phone number</dfn>
+        </dt>
+        <dd>
+          The phone number of the recipient or contact person at this address.
+        </dd>
+      </dl>
+      <section data-dfn-for="PaymentAddress" data-link-for="PaymentAddress">
         <h2>
-          Creating a <code>PaymentAddress</code>
+          <dfn>PaymentAddress</dfn> interface
         </h2>
+        <pre class="idl">
+          [SecureContext, Exposed=(Window,Worker), Constructor(optional AddressInit details)]
+          interface PaymentAddress {
+            [Default] object toJSON();
+            readonly attribute DOMString country;
+            readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
+            readonly attribute DOMString region;
+            readonly attribute DOMString city;
+            readonly attribute DOMString dependentLocality;
+            readonly attribute DOMString postalCode;
+            readonly attribute DOMString sortingCode;
+            readonly attribute DOMString languageCode;
+            readonly attribute DOMString organization;
+            readonly attribute DOMString recipient;
+            readonly attribute DOMString phone;
+          };
+        </pre>
         <p>
-          The steps to <dfn>create a payment address</dfn> from user-provided
-          input are given by the following algorithm.
+          The <a>PaymentAddress</a> interface represents a <a>physical
+          address</a> on the Web.
         </p>
-        <ol data-link-for="PaymentAddress">
-          <li>Let <var>address</var> be a new instance of
-          <a>PaymentAddress</a>.
-          </li>
-          <li>Set <var>address</var>.<a>[[\addressLine]]</a> to the result of
-          splitting the user-provided address line into a <a data-cite=
-          "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
-          provided, set it to the empty <a data-cite=
-          "!WEBIDL#dfn-frozen-array-type">frozen array</a>.
-            <aside class="note">
-              How to split an address line is locale dependent and beyond the
-              scope of this specification.
-            </aside>
-          </li>
-          <li>Set <var>address</var>.<a>[[\country]]</a> to the user-provided
-          country as an upper case [[!ISO3166]] alpha-2 code, or to the empty
-          string if none was provided.
-          </li>
-          <li>Set the <var>address</var>.<a>[[\phone]]</a> to the user-provided
-          phone number for this shipping address, optionally formatted to
-          adhere to [[!E.164]], or to the empty string if none was provided.
-            <aside class="note" title="Privacy of phone number">
-              <p>
-                To maintain user's privacy, implementers need to be mindful
-                that a shipping address's associated phone number might be
-                different or the same from that of the end-user's. As such,
-                implementers need to take care to not provide the end user's
-                phone number to the merchant without the end user's consent.
-              </p>
-            </aside>
-          </li>
-          <li>Set <var>address</var>.<a>[[\languageCode]]</a> to a
+        <section>
+          <h2>
+            Constructor
+          </h2>
+          <p>
+            The steps to <dfn data-lt="PaymentAddress.PaymentAddress()"
+            data-no-default="">construct a <code>PymentAddress</code></dfn>
+            with <a>AddressInit</a> <var>details</var> are given by the
+            following algorithm:
+          </p>
+          <ol data-link-for="AddressInit">
+            <li>Let <var>address</var> be a new instance of
+            <a>PaymentAddress</a> with <a>[[\addressLine]]</a> set to an empty
+            <code><a data-cite=
+            "!WEBIDL#idl-sequence">sequence</a>&lt;<a data-cite=
+            "WEBIDL#idl-DOMString">DOMString</a>&gt;</code>, and all other
+            internal slots set to the empty string.
+            </li>
+            <li>If <var>details</var> was not passed to the constructor, return
+            <var>address</var> and terminate this algorithm.
+            </li>
+            <li>If <var>details</var>["<a>country</a>"] is present:
+              <ol>
+                <li>Let <var>country</var> be the result of <a data-cite=
+                "!INFRA#ascii-uppercase">ASCII uppercasing</a>
+                <var>details</var>["<a>country</a>"].
+                </li>
+                <li>If <var>country</var> is not a valid [[!ISO3166]] alpha-2
+                code, throw a <a>RangeError</a>.
+                </li>
+              </ol>
+            </li>
+            <li>If <var>details</var>["<a>addressLine</a>"] is present:
+              <ol>
+                <li>Push each item of <var>details</var>["<a>addressLine</a>"]
+                in order into <var>address</var>.<a>[[\addressLine]]</a>.
+                </li>
+              </ol>
+            </li>
+            <li>Freeze <var>details</var>["<a>addressLine</a>"].
+            </li>
+            <li>If <var>details</var>["<a>region</a>"] is present, set
+            <var>address</var>.<a>[[\region]]</a> to the result of trimming
+            <var>details</var>["<a>region</a>"]
+            </li>
+            <li>If <var>details</var>["<a>phone</a>"] is present:
+              <ol>
+                <li>Check if <var>details</var>["<a>phone</a>"] is a
+                <a>structurally valid phone number</a>, throw a
+                <a>RangeError</a>.
+                </li>
+                <li>Set <var>address</var>.<a>[[\phone]]</a> to the result of
+                <a>canonicalize a phone number</a>
+                <var>details</var>["<a>phone</a>"].
+                </li>
+              </ol>
+            </li>
+            <li>If <var>details</var>["<a>city</a>"] is present, set
+            <var>address</var>.<a>[[\city]]</a> to the result of trimming <var>
+              details</var>["<a>city</a>"].
+            </li>
+            <li>If <var>details</var>["<a>dependentLocality</a>"] is present,
+            set <var>address</var>.<a>[[\dependentLocality]]</a> to the result
+            of trimming <var>details</var>["<a>dependentLocality</a>"].
+            </li>
+            <li>If <var>details</var>["<a>postalCode</a>"] is present, set
+            <var>address</var>.<a>[[\postalCode]]</a> to the result of trimming
+            <var>details</var>["<a>postalCode</a>"].
+            </li>
+            <li>If <var>details</var>["<a>sortingCode</a>"] is present, set
+            <var>address</var>.<a>[[\sortingCode]]</a> to the result of
+            trimming <var>details</var>["<a>sortingCode</a>"].
+            </li>
+            <li>If <var>details</var>["<a>languageCode</a>"] is present:
+              <ol>
+                <li>If <a data-cite=
+                "ecma-402#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a>(<var>details</var>["<a>languageCode</a>"])
+                is false, throw a <a>RangeError</a> exception.
+                </li>
+                <li>Set <var>address</var>.<a>[[\languageCode]]</a> to
+                <a data-cite=
+                "ecma-402#sec-canonicalizelanguagetag">CanonicalizeLanguageTag</a>(<var>details</var>["<a>languageCode</a>"]).
+                </li>
+              </ol>
+            </li>
+            <li>If <var>details</var>["<a>organization</a>"] is present, set
+            <var>address</var>.<a>[[\organization]]</a> to the result of
+            trimming <var>details</var>["<a>organization</a>"].
+            </li>
+            <li>If <var>details</var>["<a>recipient</a>"] is present, set <var>
+              address</var>.<a>[[\recipient]]</a> to the result of trimming
+              <var>details</var>["<a>recipient</a>"].
+            </li>
+            <li>Return <var>address</var>.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h2>
+            Creating a <code>PaymentAddress</code>
+          </h2>
+          <p>
+            The steps to <dfn>create a payment address from user-provided
+            input</dfn> are given by the following algorithm.
+          </p>
+          <ol data-link-for="PaymentAddress">
+            <li>Let <var>address</var> be a new instance of
+            <a>PaymentAddress</a>.
+            </li>
+            <li>Set <var>address</var>.<a>[[\addressLine]]</a> to the result of
+            splitting the user-provided address line into a <a data-cite=
+            "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
+            provided, set it to the empty <a data-cite=
+            "!WEBIDL#dfn-frozen-array-type">frozen array</a>.
+              <aside class="note">
+                How to split an address line is locale dependent and beyond the
+                scope of this specification.
+              </aside>
+            </li>
+            <li>Set <var>address</var>.<a>[[\country]]</a> to the user-provided
+            country as an upper case [[!ISO3166]] alpha-2 code, or to the empty
+            string if none was provided.
+            </li>
+            <li>Set the <var>address</var>.<a>[[\phone]]</a> to the
+            user-provided phone number for this shipping address, optionally
+            formatted to adhere to [[!E.164]], or to the empty string if none
+            was provided.
+              <aside class="note" title="Privacy of phone number">
+                <p>
+                  To maintain user's privacy, implementers need to be mindful
+                  that a shipping address's associated phone number might be
+                  different or the same from that of the end-user's. As such,
+                  implementers need to take care to not provide the end user's
+                  phone number to the merchant without the end user's consent.
+                </p>
+              </aside>
+            </li>
+            <li>Set <var>address</var>.<a>[[\languageCode]]</a> to a
             <a data-cite="!BCP47#section-4.5">canonicalized language tag</a>,
             or to the empty string if none was provided.
-            <div class="issue" data-number="608"></div>
-          </li>
-          <li>Set <var>address</var>.<a>[[\city]]</a> to the user-provided
-          city, or to the empty string if none was provided.
-          </li>
-          <li>Set <var>address</var>.<a>[[\dependentLocality]]</a> to the
-          user-provided dependent locality, or to the empty string if none was
-          provided.
-          </li>
-          <li>Set <var>address</var>.<a>[[\organization]]</a> to the
-          user-provided recipient organization, or to the empty string if none
-          was provided.
-          </li>
-          <li>Set <var>address</var>.<a>[[\postalCode]]</a> to the
-          user-provided postal code, or to the empty string if none was
-          provided.
-          </li>
-          <li>Set <var>address</var>.<a>[[\recipient]]</a> to the user-provided
-          recipient of the transaction, or to the empty string if none was
-          provided.
-          </li>
-          <li>Set <var>address</var>.<a>[[\region]]</a> to the user-provided
-          region, or to the empty string if none was provided.
-          </li>
-          <li>Set <var>address</var>.<a>[[\sortingCode]]</a> to the
-          user-provided sorting code, or to the empty string if none was
-          provided.
-          </li>
-          <li>Return <var>address</var>.
-          </li>
-        </ol>
+              <div class="issue" data-number="608"></div>
+            </li>
+            <li>Set <var>address</var>.<a>[[\city]]</a> to the user-provided
+            city, or to the empty string if none was provided.
+            </li>
+            <li>Set <var>address</var>.<a>[[\dependentLocality]]</a> to the
+            user-provided dependent locality, or to the empty string if none
+            was provided.
+            </li>
+            <li>Set <var>address</var>.<a>[[\organization]]</a> to the
+            user-provided recipient organization, or to the empty string if
+            none was provided.
+            </li>
+            <li>Set <var>address</var>.<a>[[\postalCode]]</a> to the
+            user-provided postal code, or to the empty string if none was
+            provided.
+            </li>
+            <li>Set <var>address</var>.<a>[[\recipient]]</a> to the
+            user-provided recipient of the transaction, or to the empty string
+            if none was provided.
+            </li>
+            <li>Set <var>address</var>.<a>[[\region]]</a> to the user-provided
+            region, or to the empty string if none was provided.
+            </li>
+            <li>Set <var>address</var>.<a>[[\sortingCode]]</a> to the
+            user-provided sorting code, or to the empty string if none was
+            provided.
+            </li>
+            <li>Return <var>address</var>.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h2>
+            <dfn>toJSON()</dfn> method
+          </h2>
+          <p>
+            When called, runs [[!WEBIDL]]'s <a data-cite=
+            "WEBIDL#default-tojson-operation">default toJSON operation</a>.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>country</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\country]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>addressLine</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\addressLine]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>region</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\region]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>city</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\city]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>dependentLocality</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\dependentLocality]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>postalCode</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\postalCode]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>sortingCode</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\sortingCode]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>languageCode</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\languageCode]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>organization</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\organization]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>recipient</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\recipient]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>phone</dfn> attribute
+          </h2>
+          <p>
+            When getting, returns the value of the <a>PaymentAddress</a>'s
+            <a>[[\phone]]</a> internal slot.
+          </p>
+        </section>
+        <section data-link-for="">
+          <h2>
+            Internal slots
+          </h2>
+          <table>
+            <tr>
+              <th>
+                Internal slot
+              </th>
+              <th>
+                Description (<em>non-normative</em>)
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\country]]</dfn>
+              </td>
+              <td>
+                A <a>country</a> as an [[!ISO3166]] alpha-2 code or the empty
+                string. The canonical form is upper case. For example, "JP".
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\addressLine]]</dfn>
+              </td>
+              <td>
+                A frozen array, possibly of zero length, representing an
+                <a>address line</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\region]]</dfn>
+              </td>
+              <td>
+                A <a>region</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\city]]</dfn>
+              </td>
+              <td>
+                A <a>city</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\dependentLocality]]</dfn>
+              </td>
+              <td>
+                A <a>dependent locality</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\postalCode]]</dfn>
+              </td>
+              <td>
+                A <a>postal code</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\sortingCode]]</dfn>
+              </td>
+              <td>
+                A <a>sorting code</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\languageCode]]</dfn>
+              </td>
+              <td>
+                A <a data-cite="!BCP47#section-2">language tag</a> representing
+                the <a>language code</a>, or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\organization]]</dfn>
+              </td>
+              <td>
+                An <a>organization</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\recipient]]</dfn>
+              </td>
+              <td>
+                A <a>recipient</a> or the empty string.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\phone]]</dfn>
+              </td>
+              <td>
+                A <a>phone number</a> or the empty string.
+              </td>
+            </tr>
+          </table>
+        </section>
       </section>
       <section>
         <h2>
-          <dfn>toJSON()</dfn> method
+          <dfn>AddressInit</dfn> dictionary
         </h2>
+        <pre class="idl">
+          dictionary AddressInit {
+            DOMString country;
+            sequence&lt;DOMString&gt; addressLine;
+            DOMString region;
+            DOMString city;
+            DOMString dependentLocality;
+            DOMString postalCode;
+            DOMString sortingCode;
+            DOMString languageCode;
+            DOMString organization;
+            DOMString recipient;
+            DOMString phone;
+          };
+        </pre>
         <p>
-          When called, runs [[!WEBIDL]]'s <a data-cite=
-          "WEBIDL#default-tojson-operation">default toJSON operation</a>.
+          A <a>AddressInit</a> is passed when <a data-lt=
+          "PaymentAddress.PaymentAddress()">constructing</a> a
+          <a>PaymentAddress</a>. Its members are as follows.
         </p>
+        <dl data-dfn-for="AddressInit" data-sort="ascending">
+          <dt>
+            <dfn>country</dfn> member
+          </dt>
+          <dd>
+            A <a>country</a>.
+          </dd>
+          <dt>
+            <dfn>addressLine</dfn> member
+          </dt>
+          <dd>
+            A sequence representing the <a>address line</a>.
+          </dd>
+          <dt>
+            <dfn>region</dfn> member
+          </dt>
+          <dd>
+            A <a>region</a>.
+          </dd>
+          <dt>
+            <dfn>city</dfn> member
+          </dt>
+          <dd>
+            A <a>city</a>.
+          </dd>
+          <dt>
+            <dfn>dependentLocality</dfn> member
+          </dt>
+          <dd>
+            A <a>dependent locality</a>.
+          </dd>
+          <dt>
+            <dfn>postalCode</dfn> member
+          </dt>
+          <dd>
+            A <a>postal code</a>.
+          </dd>
+          <dt>
+            <dfn>sortingCode</dfn> member
+          </dt>
+          <dd>
+            A <a>sorting code</a>
+          </dd>
+          <dt>
+            <dfn>languageCode</dfn> member
+          </dt>
+          <dd>
+            A <a data-cite="!BCP47#section-2">language tag</a> representing the
+            <a>language code</a>.
+          </dd>
+          <dt>
+            <dfn>organization</dfn> member
+          </dt>
+          <dd>
+            An <a>organization</a>.
+          </dd>
+          <dt>
+            <dfn>recipient</dfn> member
+          </dt>
+          <dd>
+            A <a>recipient</a>.
+          </dd>
+          <dt>
+            <dfn>phone</dfn> member
+          </dt>
+          <dd>
+            A <a>phone number</a>.
+          </dd>
+        </dl>
       </section>
       <section>
         <h2>
-          <dfn>country</dfn> attribute
+          Phone-related algorithms
         </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\country]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>addressLine</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\addressLine]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>region</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\region]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>city</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\city]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>dependentLocality</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\dependentLocality]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>postalCode</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\postalCode]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>sortingCode</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\sortingCode]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>languageCode</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\languageCode]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>organization</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\organization]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>recipient</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\recipient]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <dfn>phone</dfn> attribute
-        </h2>
-        <p>
-          When getting, returns the value of the <a>PaymentAddress</a>'s
-          <a>[[\phone]]</a> internal slot.
-        </p>
-      </section>
-      <section>
-        <h2>
-          Internal slots
-        </h2>
-        <table>
-          <tr>
-            <th>
-              Internal slot
-            </th>
-            <th>
-              Description (<em>non-normative</em>)
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\country]]</dfn>
-            </td>
-            <td>
-              An [[!ISO3166]] alpha-2 code. The canonical form is upper case.
-              For example, "JP".
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\addressLine]]</dfn>
-            </td>
-            <td>
-              The most specific part of the address. It can include, for
-              example, a street name, a house number, apartment number, a rural
-              delivery route, descriptive instructions, or a post office box
-              number.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\region]]</dfn>
-            </td>
-            <td>
-              The top level administrative subdivision of the country. For
-              example, this can be a state, a province, an oblast, or a
-              prefecture.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\city]]</dfn>
-            </td>
-            <td>
-              The city/town portion of the address.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\dependentLocality]]</dfn>
-            </td>
-            <td>
-              The dependent locality or sublocality within a city. For example,
-              used for neighborhoods, boroughs, districts, or UK dependent
-              localities.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\postalCode]]</dfn>
-            </td>
-            <td>
-              The postal code or ZIP code, also known as PIN code in India.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\sortingCode]]</dfn>
-            </td>
-            <td>
-              The sorting code as used in, for example, France.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\languageCode]]</dfn>
-            </td>
-            <td>
-              The [[!BCP47]] language tag for the address, in <a data-cite=
-              "BCP47#section-4.5">canonical form</a>. It's used to determine
-              the field separators and the order of fields when formatting the
-              address for display.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\organization]]</dfn>
-            </td>
-            <td>
-              The organization, firm, company, or institution at this address.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\recipient]]</dfn>
-            </td>
-            <td>
-              The name of the recipient or contact person. This member may,
-              under certain circumstances, contain multiline information. For
-              example, it might contain "care of" information.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>[[\phone]]</dfn>
-            </td>
-            <td>
-              The phone number of the recipient or contact person.
-            </td>
-          </tr>
-        </table>
+        <section>
+          <h3>
+            Structurally valid phone numbers
+          </h3>
+          <p>
+            The steps to check if a <a data-cite=
+            "WEBIDL#idl-DOMString">DOMString</a> <var>tel</var> is
+            <dfn>structurally valid phone number</dfn> is given by the
+            following algorithm.
+          </p>
+          <p class="note">
+            The algorithm checks that a phone number conforms to [[!E.164]].
+          </p>
+          <ol class="algorithm">
+            <li>If <var>tel</var> contains U+000A LINE FEED (LF) or U+000D
+            CARRIAGE RETURN (CR) characters, return false.
+            </li>
+            <li>Strip and collapse ASCII whitespace in <var>tel</var>.
+            </li>
+            <li>If the length is greater 15, return false.
+            </li>
+            <li>If the first code point is not U+002B PLUS SIGN, return false.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h3>
+            Canonicalize a phone number
+          </h3>
+          <p>
+            The steps to <dfn>canonicalize a phone number</dfn> given a
+            <a data-cite="WEBIDL#idl-DOMString">DOMString</a> <var>tel</var> is
+            given by the following algorithm.
+          </p>
+          <ol class="algorithm">
+            <li>TBW...
+            </li>
+          </ol>
+        </section>
       </section>
     </section>
     <section data-dfn-for="PaymentShippingOption">
@@ -2896,7 +3211,7 @@
             run the following steps:
             <ol>
               <li>Let <var>address</var> be the result of running the steps to
-              <a>create a payment address</a>.
+              <a>create a payment address from user-provided input</a>.
               </li>
               <li>Set the <a data-lt=
               "PaymentRequest.shippingAddress">shippingAddress</a> attribute on

--- a/index.html
+++ b/index.html
@@ -1996,10 +1996,6 @@
       <p>
         A <dfn>physical address</dfn> is composed of the following concepts.
       </p>
-      <p class="note">
-        Developers wanting to represent a <a>physical address</a> can use the
-        <a>PaymentAddress</a> interface.
-      </p>
       <dl data-sort="">
         <dt>
           <dfn>Country</dfn>

--- a/index.html
+++ b/index.html
@@ -2715,9 +2715,9 @@
           provided.
           </li>
           <li>
-            <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a new
-            <code>PaymentAddress</code></a> with <var>details</var> and return
-            the result.
+            <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a
+            new <code>PaymentAddress</code></a> with <var>details</var> and
+            return the result.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -2114,12 +2114,10 @@
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>address</var> be a new instance of
-            <a>PaymentAddress</a> with <a>[[\addressLine]]</a> set to an empty
-            <code><a data-cite=
-            "!WEBIDL#idl-sequence">sequence</a>&lt;<a data-cite=
-            "WEBIDL#idl-DOMString">DOMString</a>&gt;</code>, and all other
-            internal slots set to the empty string.
-            </li>
+            <a>PaymentAddress</a>.
+            </li>Set <var>address</var>.<a>[[\addressLine]]</a>to the empty
+            frozen array, and all other <a data-lt=
+            "PaymentAddress slots">internal slots</a>set to the empty string.
             <li>If <var>details</var> was not passed to the constructor, return
             <var>address</var> and terminate this algorithm.
             </li>
@@ -2218,7 +2216,7 @@
             The steps to <dfn>create a <code>PaymentAddress</code> from
             user-provided input</dfn> are given by the following algorithm. The
             algorithm takes a <a>AddressField</a> <a>list</a>
-            <var>excludeList</var>, for which user input is not gathered.
+            <var>excludeList</var>, for which user input will not be gathered.
           </p>
           <ol data-link-for="AddressInit">
             <li>Let <var>details</var> be an object with no members that will
@@ -2414,7 +2412,8 @@
         </section>
         <section data-link-for="">
           <h2>
-            Internal slots
+            <dfn data-lt="PaymentAddress slots" data-no-default="">Internal
+            slots</dfn>
           </h2>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -2626,7 +2626,9 @@
             <li>If <var>tel</var> contains U+000A LINE FEED (LF) or U+000D
             CARRIAGE RETURN (CR) characters, return false.
             </li>
-            <li>Strip and collapse ASCII whitespace in <var>tel</var>.
+            <li>
+              <a data-cite="!INFRA#strip-and-collapse-ascii-whitespace">Strip
+              and collapse ASCII whitespace</a> in <var>tel</var>.
             </li>
             <li>If <var>tel</var>'s the length is greater 15, return false.
             </li>

--- a/index.html
+++ b/index.html
@@ -3355,7 +3355,8 @@
             run the following steps:
             <ol>
               <li data-link-for="AddressField">Let <var>excludeList</var> be
-              the list « "<a>organization</a>", "<a>phone</a>",
+              the empty list. Optionally, append the following items to
+              <var>excludeList</var>: « "<a>organization</a>", "<a>phone</a>",
               "<a>recipient</a>", "<a>addressLine</a>" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to

--- a/index.html
+++ b/index.html
@@ -2001,7 +2001,7 @@
           <dfn>Country</dfn>
         </dt>
         <dd>
-          The country corresponding to this address.
+          The country corresponding to the address.
         </dd>
         <dt>
           <dfn>Address line</dfn>
@@ -2056,19 +2056,19 @@
           <dfn>Organization</dfn>
         </dt>
         <dd>
-          The organization, firm, company, or institution at this address.
+          The organization, firm, company, or institution at the address.
         </dd>
         <dt>
           <dfn>Recipient</dfn>
         </dt>
         <dd>
-          The name of the recipient or contact person at this address.
+          The name of the recipient or contact person at the address.
         </dd>
         <dt>
           <dfn>Phone number</dfn>
         </dt>
         <dd>
-          The phone number of the recipient or contact person at this address.
+          The phone number of the recipient or contact person at the address.
         </dd>
       </dl>
       <section data-dfn-for="PaymentAddress" data-link-for="PaymentAddress">

--- a/index.html
+++ b/index.html
@@ -1991,7 +1991,7 @@
     </div>
     <section>
       <h2>
-        Physical Addresses
+        Physical addresses
       </h2>
       <p>
         A <dfn>physical address</dfn> is composed of the following concepts.
@@ -2097,7 +2097,7 @@
         </p>
         <section>
           <h2>
-            Internal Constructor
+            Internal constructor
           </h2>
           <div class="issue" data-number="653">
             Currently, this constructor algorithm is only used internally by a
@@ -2150,16 +2150,16 @@
                 </li>
               </ol>
             </li>
-            <li>Let <var>cleanAddressLines</var> be an emtpy list.
+            <li>Let <var>cleanAddressLines</var> be an empty list.
             </li>
             <li>If <var>details</var>["<a>addressLine</a>"] is present, then
             for each <var>item</var> in
             <var>details</var>["<a>addressLine</a>"]:
               <ol>
                 <li>
-                  <a>strip leading and trailing ASCII whitespace</a> from
+                  <a>Strip leading and trailing ASCII whitespace</a> from
                   <var>item</var> and append the result into
-                  <var>cleanAddressLines</var>
+                  <var>cleanAddressLines</var>.
                 </li>
               </ol>
             </li>
@@ -2354,8 +2354,8 @@
                 <dfn>[[\country]]</dfn>
               </td>
               <td>
-                A <a>country</a> as an [[!ISO3166-1]] alpha-2 code or the empty
-                string stored in its canonical uppercase form. For example,
+                A <a>country</a> as an [[!ISO3166-1]] alpha-2 code stored in
+                its canonical uppercase form or the empty string. For example,
                 "JP".
               </td>
             </tr>
@@ -2559,8 +2559,7 @@
           </li>
           <li>If "addressLine" is not in <var>redactList</var>, set
           <var>details</var>["<a>addressLine</a>"] to the result of splitting
-          the user-provided address line into a <a data-cite=
-          "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
+          the user-provided address line into a <a>list</a>. If none was
           provided, set it to the empty <a>list</a>.
             <aside class="note">
               How to split an address line is locale dependent and beyond the
@@ -3245,9 +3244,9 @@
                   uniquely identify a recipient.
                 </p>
               </div>
-              <li>Let <var>redactList</var> be the empty list. Optionally,
-              append the following items to <var>redactList</var>: «
-              "organization", "phone", "recipient", "addressLine" ».
+              <li>Let <var>redactList</var> be the empty list. Optionally, set
+              <var>redactList</var> to « "organization", "phone", "recipient",
+              "addressLine" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided

--- a/index.html
+++ b/index.html
@@ -2210,100 +2210,6 @@
         </section>
         <section>
           <h2>
-            Creating a <code>PaymentAddress</code> from user-provided input
-          </h2>
-          <p>
-            The steps to <dfn>create a <code>PaymentAddress</code> from
-            user-provided input</dfn> are given by the following algorithm. The
-            algorithm takes a <a>AddressField</a> <a>list</a>
-            <var>excludeList</var>, for which user input will not be gathered.
-          </p>
-          <ol data-link-for="AddressInit">
-            <li>Let <var>details</var> be an object with no members that will
-            serve as a <a>AddressInit</a> dictionary.
-            </li>
-            <li>If "<a data-link-for="AddressField">addressLine</a>" is not in
-            <var>excludeList</var>, set
-            <var>details</var>["<a>addressLine</a>"] to the result of splitting
-            the user-provided address line into a <a data-cite=
-            "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
-            provided, set it to the empty <a>list</a>.
-              <aside class="note">
-                How to split an address line is locale dependent and beyond the
-                scope of this specification.
-              </aside>
-            </li>
-            <li>If "<a data-link-for="AddressField">country</a>" is not in
-            <var>excludeList</var>, set <var>details</var>["<a>country</a>"] to
-            the user-provided country as an upper case [[!ISO3166]] alpha-2
-            code, or to the empty string if none was provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">phone</a>" is not in <var>
-              excludeList</var>, set <var>details</var>["<a>phone</a>"] to the
-              user-provided <a>structurally valid phone number</a>, or to the
-              empty string if none was provided.
-              <aside class="note" title="Privacy of phone number">
-                <p>
-                  To maintain user's privacy, implementers need to be mindful
-                  that a shipping address's associated phone number might be
-                  different or the same from that of the end-user's. As such,
-                  implementers need to take care to not provide the end user's
-                  phone number to the merchant without the end user's consent.
-                </p>
-              </aside>
-            </li>
-            <li>If "<a data-link-for="AddressField">languageCode</a>" is not in
-            <var>excludeList</var>, set
-            <var>details</var>["<a>languageCode</a>"] to a <a data-cite=
-            "!BCP47#section-4.5">canonicalized language tag</a>, or to the
-            empty string if none was provided.
-              <div class="issue" data-number="608"></div>
-            </li>
-            <li>If "<a data-link-for="AddressField">city</a>" is not in
-            <var>excludeList</var>, set <var>details</var>["<a>city</a>"] to
-            the user-provided city, or to the empty string if none was
-            provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">dependentLocality</a>" is
-            not in <var>excludeList</var>, set
-            <var>details</var>["<a>dependentLocality</a>"] to the user-provided
-            dependent locality, or to the empty string if none was provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">organization</a>" is not in
-            <var>excludeList</var>, set
-            <var>details</var>["<a>organization</a>"] to the user-provided
-            recipient organization, or to the empty string if none was
-            provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">postalCode</a>" is not in
-            <var>excludeList</var>, set <var>details</var>["<a>postalCode</a>"]
-            to the user-provided postal code, or to the empty string if none
-            was provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">recipient</a>" is not in
-            <var>excludeList</var>, set <var>details</var>["<a>recipient</a>"]
-            to the user-provided recipient of the transaction, or to the empty
-            string if none was provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">region</a>" is not in <var>
-              excludeList</var>, set <var>details</var>["<a>region</a>"] to the
-              user-provided region, or to the empty string if none was
-              provided.
-            </li>
-            <li>If "<a data-link-for="AddressField">sortingCode</a>" is not in
-            <var>excludeList</var>, set
-            <var>details</var>["<a>sortingCode</a>"] to the user-provided
-            sorting code, or to the empty string if none was provided.
-            </li>
-            <li>
-              <a data-lt="PaymentAddress.PaymentAddress()">Construct a new
-              <code>PaymentAddress</code></a> with <var>details</var> and
-              return the result.
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h2>
             <dfn>toJSON()</dfn> method
           </h2>
           <p>
@@ -2641,6 +2547,96 @@
           correspond to attributes with the same identifiers in the
           <a>PaymentAddress</a> interface.
         </p>
+      </section>
+      <section>
+        <h2>
+          Creating a <code>PaymentAddress</code> from user-provided input
+        </h2>
+        <p>
+          The steps to <dfn>create a <code>PaymentAddress</code> from
+          user-provided input</dfn> are given by the following algorithm. The
+          algorithm takes a <a>AddressField</a> <a>list</a>
+          <var>excludeList</var>, for which user input will not be gathered.
+        </p>
+        <ol data-link-for="AddressInit">
+          <li>Let <var>details</var> be an object with no members that will
+          serve as a <a>AddressInit</a> dictionary.
+          </li>
+          <li>If "<a data-link-for="AddressField">addressLine</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>addressLine</a>"]
+          to the result of splitting the user-provided address line into a
+          <a data-cite="!WEBIDL#dfn-frozen-array-type">frozen array</a>. If
+          none was provided, set it to the empty <a>list</a>.
+            <aside class="note">
+              How to split an address line is locale dependent and beyond the
+              scope of this specification.
+            </aside>
+          </li>
+          <li>If "<a data-link-for="AddressField">country</a>" is not in <var>
+            excludeList</var>, set <var>details</var>["<a>country</a>"] to the
+            user-provided country as an upper case [[!ISO3166]] alpha-2 code,
+            or to the empty string if none was provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">phone</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>phone</a>"] to the
+          user-provided <a>structurally valid phone number</a>, or to the empty
+          string if none was provided.
+            <aside class="note" title="Privacy of phone number">
+              <p>
+                To maintain user's privacy, implementers need to be mindful
+                that a shipping address's associated phone number might be
+                different or the same from that of the end-user's. As such,
+                implementers need to take care to not provide the end user's
+                phone number to the merchant without the end user's consent.
+              </p>
+            </aside>
+          </li>
+          <li>If "<a data-link-for="AddressField">languageCode</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>languageCode</a>"]
+          to a <a data-cite="!BCP47#section-4.5">canonicalized language
+          tag</a>, or to the empty string if none was provided.
+            <div class="issue" data-number="608"></div>
+          </li>
+          <li>If "<a data-link-for="AddressField">city</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>city</a>"] to the
+          user-provided city, or to the empty string if none was provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">dependentLocality</a>" is not
+          in <var>excludeList</var>, set
+          <var>details</var>["<a>dependentLocality</a>"] to the user-provided
+          dependent locality, or to the empty string if none was provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">organization</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>organization</a>"]
+          to the user-provided recipient organization, or to the empty string
+          if none was provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">postalCode</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>postalCode</a>"]
+          to the user-provided postal code, or to the empty string if none was
+          provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">recipient</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>recipient</a>"] to
+          the user-provided recipient of the transaction, or to the empty
+          string if none was provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">region</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>region</a>"] to
+          the user-provided region, or to the empty string if none was
+          provided.
+          </li>
+          <li>If "<a data-link-for="AddressField">sortingCode</a>" is not in
+          <var>excludeList</var>, set <var>details</var>["<a>sortingCode</a>"]
+          to the user-provided sorting code, or to the empty string if none was
+          provided.
+          </li>
+          <li>
+            <a data-lt="PaymentAddress.PaymentAddress()">Construct a new
+            <code>PaymentAddress</code></a> with <var>details</var> and return
+            the result.
+          </li>
+        </ol>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -2118,16 +2118,17 @@
             </li>
             <li>Set <var>address</var>.<a>[[\addressLine]]</a> to the empty
             frozen array, and all other <a data-lt=
-            "PaymentAddress slots">internal slots</a> set to the empty string.
+            "PaymentAddress slots">internal slots</a> to the empty string.
             </li>
             <li>If <var>details</var> was not passed, return
             <var>address</var>.
             </li>
             <li>If <var>details</var>["<a>country</a>"] is present:
               <ol>
-                <li>Let <var>country</var> be the result of <a data-cite=
-                "!INFRA#ascii-uppercase">ASCII uppercasing</a>
-                <var>details</var>["<a>country</a>"].
+                <li>Set <var>country</var> the result of <a>stripping leading
+                and trailing ASCII whitespace</a> from
+                <var>details</var>["<a>country</a>"] and performing
+                <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>.
                 </li>
                 <li>If <var>country</var> is not a valid [[!ISO3166-1]] alpha-2
                 code, throw a <a>RangeError</a> exception.
@@ -2149,9 +2150,22 @@
                 </li>
               </ol>
             </li>
-            <li>If <var>details</var>["<a>addressLine</a>"] is present, set
-            <var>address</var>.<a>[[\addressLine]]</a> to a new frozen array
-            created from <var>details</var>["<a>addressLine</a>"].
+            <li>Let <var>cleanAddressLines</var> be an emtpy list.
+            </li>
+            <li>If <var>details</var>["<a>addressLine</a>"] is present, then
+            for each <var>item</var> in
+            <var>details</var>["<a>addressLine</a>"]:
+              <ol>
+                <li>
+                  <a>strip leading and trailing ASCII whitespace</a> from
+                  <var>item</var> and append the result into
+                  <var>cleanAddressLines</var>
+                </li>
+              </ol>
+            </li>
+            <li>
+              <var>Set address</var>.<a>[[\addressLine]]</a> to a new frozen
+              array created from <var>cleanAddressLines</var>.
             </li>
             <li>If <var>details</var>["<a>region</a>"] is present, <a>strip
             leading and trailing ASCII whitespace</a> from
@@ -2610,12 +2624,9 @@
           <var>details</var>["<a>recipient</a>"] to the user-provided recipient
           of the transaction, or to the empty string if none was provided.
           </li>
-          <li>If "region" is not in <var>redactList</var>:
-            <ol>
-              <li>Set <var>details</var>["<a>region</a>"] to the user-provided
-              region, or to the empty string if none was provided.
-              </li>
-            </ol>
+          <li>If "region" is not in <var>redactList</var>, set
+          <var>details</var>["<a>region</a>"] to the user-provided region, or
+          to the empty string if none was provided.
           </li>
           <li>If "sortingCode" is not in <var>redactList</var>, set
           <var>details</var>["<a>sortingCode</a>"] to the user-provided sorting

--- a/index.html
+++ b/index.html
@@ -2242,9 +2242,8 @@
             </li>
             <li>If "<a data-link-for="AddressField">phone</a>" is not in <var>
               excludeList</var>, set <var>details</var>["<a>phone</a>"] to the
-              user-provided phone number for this shipping address, optionally
-              formatted to adhere to [[!E.164]], or to the empty string if none
-              was provided.
+              user-provided <a>structurally valid phone number</a>, or to the
+              empty string if none was provided.
               <aside class="note" title="Privacy of phone number">
                 <p>
                   To maintain user's privacy, implementers need to be mindful

--- a/index.html
+++ b/index.html
@@ -2130,7 +2130,10 @@
                 <var>details</var>["<a>country</a>"].
                 </li>
                 <li>If <var>country</var> is not a valid [[!ISO3166]] alpha-2
-                code, throw a <a>RangeError</a>.
+                code, throw a <a>RangeError</a> exception.
+                </li>
+                <li>Set <var>address</var>.<a>[[\country]]</a> to
+                <var>country</var>.
                 </li>
               </ol>
             </li>
@@ -2138,7 +2141,7 @@
               <ol>
                 <li>If <var>details</var>["<a>phone</a>"] is not a
                 <a>structurally valid phone number</a>, throw a
-                <a>RangeError</a>.
+                <a>RangeError</a> exception.
                 </li>
                 <li>
                   <a>Canonicalize a phone number</a>
@@ -2161,7 +2164,7 @@
             </li>
             <li>If <var>details</var>["<a>addressLine</a>"] is present, set
             <var>address</var>.<a>[[\addressLine]]</a> to a new frozen array
-            created from <var>details</var>.["<a>addressLine</a>"].
+            created from <var>details</var>["<a>addressLine</a>"].
             </li>
             <li>If <var>details</var>["<a>region</a>"] is present, <a>strip
             leading and trailing ASCII whitespace</a> from
@@ -2221,9 +2224,10 @@
             <li>Let <var>details</var> be an object with no members that will
             serve as a <a>AddressInit</a> dictionary.
             </li>
-            <li>If "addressLine" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>addressLine</a>"] to the result of
-            splitting the user-provided address line into a <a data-cite=
+            <li>If "<a data-link-for="AddressField">addressLine</a>" is not in
+            <var>excludeList</var>, set
+            <var>details</var>["<a>addressLine</a>"] to the result of splitting
+            the user-provided address line into a <a data-cite=
             "!WEBIDL#dfn-frozen-array-type">frozen array</a>. If none was
             provided, set it to the empty <a>list</a>.
               <aside class="note">
@@ -2231,15 +2235,16 @@
                 scope of this specification.
               </aside>
             </li>
-            <li>If "country" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>country</a>"] to the user-provided country
-            as an upper case [[!ISO3166]] alpha-2 code, or to the empty string
-            if none was provided.
+            <li>If "<a data-link-for="AddressField">country</a>" is not in
+            <var>excludeList</var>, set <var>details</var>["<a>country</a>"] to
+            the user-provided country as an upper case [[!ISO3166]] alpha-2
+            code, or to the empty string if none was provided.
             </li>
-            <li>If "phone" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>phone</a>"] to the user-provided phone
-            number for this shipping address, optionally formatted to adhere to
-            [[!E.164]], or to the empty string if none was provided.
+            <li>If "<a data-link-for="AddressField">phone</a>" is not in <var>
+              excludeList</var>, set <var>details</var>["<a>phone</a>"] to the
+              user-provided phone number for this shipping address, optionally
+              formatted to adhere to [[!E.164]], or to the empty string if none
+              was provided.
               <aside class="note" title="Privacy of phone number">
                 <p>
                   To maintain user's privacy, implementers need to be mindful
@@ -2250,41 +2255,47 @@
                 </p>
               </aside>
             </li>
-            <li>If "languageCode" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>languageCode</a>"] to a <a data-cite=
+            <li>If "<a data-link-for="AddressField">languageCode</a>" is not in
+            <var>excludeList</var>, set
+            <var>details</var>["<a>languageCode</a>"] to a <a data-cite=
             "!BCP47#section-4.5">canonicalized language tag</a>, or to the
             empty string if none was provided.
               <div class="issue" data-number="608"></div>
             </li>
-            <li>If "city" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>city</a>"] to the user-provided city, or to
-            the empty string if none was provided.
+            <li>If "<a data-link-for="AddressField">city</a>" is not in
+            <var>excludeList</var>, set <var>details</var>["<a>city</a>"] to
+            the user-provided city, or to the empty string if none was
+            provided.
             </li>
-            <li>If "dependentLocality" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>dependentLocality</a>"] to the
-            user-provided dependent locality, or to the empty string if none
-            was provided.
+            <li>If "<a data-link-for="AddressField">dependentLocality</a>" is
+            not in <var>excludeList</var>, set
+            <var>details</var>["<a>dependentLocality</a>"] to the user-provided
+            dependent locality, or to the empty string if none was provided.
             </li>
-            <li>If "organization" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>organization</a>"] to the user-provided
+            <li>If "<a data-link-for="AddressField">organization</a>" is not in
+            <var>excludeList</var>, set
+            <var>details</var>["<a>organization</a>"] to the user-provided
             recipient organization, or to the empty string if none was
             provided.
             </li>
-            <li>If "postalCode" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>postalCode</a>"] to the user-provided
-            postal code, or to the empty string if none was provided.
+            <li>If "<a data-link-for="AddressField">postalCode</a>" is not in
+            <var>excludeList</var>, set <var>details</var>["<a>postalCode</a>"]
+            to the user-provided postal code, or to the empty string if none
+            was provided.
             </li>
-            <li>If "recipient" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>recipient</a>"] to the user-provided
-            recipient of the transaction, or to the empty string if none was
-            provided.
+            <li>If "<a data-link-for="AddressField">recipient</a>" is not in
+            <var>excludeList</var>, set <var>details</var>["<a>recipient</a>"]
+            to the user-provided recipient of the transaction, or to the empty
+            string if none was provided.
             </li>
-            <li>If "region" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>region</a>"] to the user-provided region,
-            or to the empty string if none was provided.
+            <li>If "<a data-link-for="AddressField">region</a>" is not in <var>
+              excludeList</var>, set <var>details</var>["<a>region</a>"] to the
+              user-provided region, or to the empty string if none was
+              provided.
             </li>
-            <li>If "sortingCode" is not in <var>excludeList</var>, set
-            <var>details</var>.["<a>sortingCode</a>"] to the user-provided
+            <li>If "<a data-link-for="AddressField">sortingCode</a>" is not in
+            <var>excludeList</var>, set
+            <var>details</var>["<a>sortingCode</a>"] to the user-provided
             sorting code, or to the empty string if none was provided.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -2152,19 +2152,6 @@
                 </li>
               </ol>
             </li>
-            <li>If <var>details</var>["<a>phone</a>"] is present:
-              <ol>
-                <li>If <var>details</var>["<a>phone</a>"] is not a
-                <a>structurally valid phone number</a>, throw a
-                <a>RangeError</a> exception.
-                </li>
-                <li>
-                  <a>Canonicalize a phone number</a>
-                  <var>details</var>["<a>phone</a>"] and set
-                  <var>address</var>.<a>[[\phone]]</a> to the result.
-                </li>
-              </ol>
-            </li>
             <li>If <var>details</var>["<a>languageCode</a>"] is present:
               <ol>
                 <li>If <a data-cite=
@@ -2220,6 +2207,11 @@
             leading and trailing ASCII whitespace</a> from
             <var>details</var>["<a>recipient</a>"] and set
             <var>address</var>.<a>[[\recipient]]</a> to the result.
+            </li>
+            <li>If <var>details</var>["<a>phone</a>"] is present, <a>strip
+            leading and trailing ASCII whitespace</a> from
+            <var>details</var>["<a>phone</a>"] and set
+            <var>address</var>.<a>[[\phone]]</a> to the result.
             </li>
             <li>Return <var>address</var>.
             </li>
@@ -2606,10 +2598,8 @@
           none was provided.
           </li>
           <li>If "phone" is not in <var>excludeList</var>, set
-          <var>details</var>["<a>phone</a>"] to the user-provided
-          <a>structurally valid phone number</a> in <a data-lt=
-          "canonicalize a phone number">canonical form</a>, or to the empty
-          string if none was provided.
+          <var>details</var>["<a>phone</a>"] to the user-provided phone number,
+          or to the empty string if none was provided.
             <aside class="note" title="Privacy of phone number">
               <p>
                 To maintain user's privacy, implementers need to be mindful
@@ -2680,52 +2670,6 @@
             return the result.
           </li>
         </ol>
-      </section>
-      <section>
-        <h2>
-          Phone-related algorithms
-        </h2>
-        <section>
-          <h3>
-            Structurally valid phone numbers
-          </h3>
-          <p>
-            The steps to check if a <a data-cite=
-            "WEBIDL#idl-DOMString">DOMString</a> <var>tel</var> is
-            <dfn>structurally valid phone number</dfn> is given by the
-            following algorithm.
-          </p>
-          <p class="note">
-            The algorithm checks that a phone number conforms to [[!E.164]].
-          </p>
-          <ol class="algorithm">
-            <li>If <var>tel</var> contains U+000A LINE FEED (LF) or U+000D
-            CARRIAGE RETURN (CR) characters, return false.
-            </li>
-            <li>
-              <a data-cite="!INFRA#strip-and-collapse-ascii-whitespace">Strip
-              and collapse ASCII whitespace</a> in <var>tel</var>.
-            </li>
-            <li>If <var>tel</var>'s the length is greater 15, return false.
-            </li>
-            <li>If the first code point is not U+002B PLUS SIGN, return false.
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h3>
-            Canonicalize a phone number
-          </h3>
-          <p>
-            The steps to <dfn>canonicalize a phone number</dfn> given a
-            <a data-cite="WEBIDL#idl-DOMString">DOMString</a> <var>tel</var> is
-            given by the following algorithm.
-          </p>
-          <ol class="algorithm">
-            <li>TBW...
-            </li>
-          </ol>
-        </section>
       </section>
     </section>
     <section data-dfn-for="PaymentShippingOption">
@@ -3490,9 +3434,10 @@
           "PaymentOptions.requestPayerPhone">requestPayerPhone</a> value of
           <var>request</var>.<a>[[\options]]</a> is true, then set the
           <a data-lt="PaymentResponse.payerPhone">payerPhone</a> attribute of
-          <var>response</var> to a <a>structurally valid phone number</a> in
-          <a data-lt="canonicalize a phone number">canonical form</a> provided
-          by the user, or to null if none was provided.
+          <var>response</var> to the payer's phone number provided by the user,
+          or to null if none was provided. When setting the <a data-lt=
+          "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
+          SHOULD format the phone number to adhere to [[!E.164]].
           </li>
           <li>Set <var>response</var>.<a>[[\completeCalled]]</a> to false.
           </li>

--- a/index.html
+++ b/index.html
@@ -2137,7 +2137,8 @@
                 </li>
               </ol>
             </li>
-            <li>If <var>details</var>["<a>regionCode</a>"] is present:
+            <li>If <var>details</var>["<a>regionCode</a>"] is present and not
+            the empty string:
               <ol>
                 <li>Let <var>regionCode</var> be the result of <a data-cite=
                 "!INFRA#ascii-uppercase">ASCII uppercasing</a>
@@ -2400,10 +2401,10 @@
                 <dfn>[[\regionCode]]</dfn>
               </td>
               <td>
-                A <a>region</a> as a [[!ISO3166-2]] subdivision code or the
-                empty string stored in its canonical uppercase form. For
-                example, "<code>PT-11</code>" represents the Lisbon district of
-                Portugal.
+                A <a>region</a> represented as a [[!ISO3166-2]] subdivision
+                code or the empty string, stored in its canonical uppercase
+                form. For example, "<code>PT-11</code>" represents the Lisbon
+                district of Portugal.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
closes w3c/payment-request#648 w3c/payment-request#643 w3c/payment-request#676 w3c/payment-request#692

The following tasks have been completed:

 * [X] [MDN Docs added](https://developer.mozilla.org/en-US/docs/Web/Events/shippingaddresschange) 

Implementation commitment:

 * [x] Safari (implemented in ApplePay - redacts)
 * [ ] [Chrome](https://crbug.com/821771) - planning.
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1435155)  - redacts.
 * Edge - keeping current behavior (no redact)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/654.html" title="Last updated on Mar 15, 2018, 3:46 AM GMT (e21719c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/654/f34f6b7...e21719c.html" title="Last updated on Mar 15, 2018, 3:46 AM GMT (e21719c)">Diff</a>