### PR TITLE
show() must be triggered by user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,7 +1095,7 @@
           return a promise rejected with a "<a>NotAllowedError</a>"
           <a>DOMException</a>, at its discretion.
         </p>
-        <p data-tests="payment-request-canmakepayment-method.https.html">
+        <p data-tests="payment-request-canmakepayment-method-manual.https.html">
           The <a>canMakePayment()</a> method MUST act as follows:
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -834,7 +834,7 @@
             <a>DOMException</a>.
           </p>
         </div>
-        <p data-tests="payment-request-show-method.https.html">
+        <p data-tests="payment-request-show-method-manual.https.html">
           The <code><a data-lt="show()">show(detailsPromise)</a></code> method
           MUST act as follows:
         </p>

--- a/index.html
+++ b/index.html
@@ -834,7 +834,7 @@
             <a>DOMException</a>.
           </p>
         </div>
-        <p data-tests="payment-request-show-method-manual.https.html">
+        <p data-tests="payment-request-show-method.https.html, payment-request-show-method-manual.https.html">
           The <code><a data-lt="show()">show(detailsPromise)</a></code> method
           MUST act as follows:
         </p>

--- a/index.html
+++ b/index.html
@@ -839,6 +839,10 @@
           MUST act as follows:
         </p>
         <ol class="algorithm">
+          <li>If the method was not <a>triggered by user activation</a>, return
+          a promise rejected with a "<a>SecurityError</a>" <a>DOMException</a>
+          and terminate this algorithm.
+          </li>
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
           which the method is called.
           </li>
@@ -856,19 +860,9 @@
               Optionally, if the <a>user agent</a> wishes to disallow the call
               to <a>show()</a> to protect the user, then return a promise
               rejected with a "<a>SecurityError</a>" <a>DOMException</a>. For
-              example, the <a>user agent</a> may require the call to be
-              <a>triggered by user activation</a>, or may limit the rate at
-              which a page can call <a>show()</a>.
-            </p>
-            <p class="note">
-              During the Candidate Recommendation phase, implementations are
-              expected to experiment in this area. Developers using this API
-              should investigate and anticipate such experiments and understand
-              under what circumstances a "<a>SecurityError</a>"
-              <a>DOMException</a> might occur. If interoperable behavior
-              emerges amongst user agents, then that behavior will be
-              standardized here before progressing the specification along the
-              W3C Recommendation Track.
+              example, the <a>user agent</a> may limit the rate at which a page
+              can call <a>show()</a>, as described in the <a href=
+              "#privacy">privacy considerations</a> section.
             </p>
           </li>
           <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>"

--- a/index.html
+++ b/index.html
@@ -834,7 +834,8 @@
             <a>DOMException</a>.
           </p>
         </div>
-        <p data-tests="payment-request-show-method.https.html, payment-request-show-method-manual.https.html">
+        <p data-tests=
+        "payment-request-show-method.https.html, payment-request-show-method-manual.https.html">
           The <code><a data-lt="show()">show(detailsPromise)</a></code> method
           MUST act as follows:
         </p>
@@ -1095,7 +1096,8 @@
           return a promise rejected with a "<a>NotAllowedError</a>"
           <a>DOMException</a>, at its discretion.
         </p>
-        <p data-tests="payment-request-canmakepayment-method-manual.https.html">
+        <p data-tests=
+        "payment-request-canmakepayment-method-manual.https.html">
           The <a>canMakePayment()</a> method MUST act as follows:
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1040,7 +1040,7 @@
             request</a>.
           </p>
         </div>
-        <p data-tests="payment-request-abort-method.https.html">
+        <p data-tests="payment-request-abort-method-manual.https.html">
           The <a>abort()</a> method MUST act as follows:
         </p>
         <ol class="algorithm">


### PR DESCRIPTION
closes #651

The following tasks have been completed:

 * [X] [web platform tests](https://github.com/w3c/web-platform-tests/pull/9990)
 * [x] [MDN Docs added](https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show) 

Implementation commitment:

 * [x] Safari (already in WebKit)
 * [x] [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=817807)
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1442078)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/655.html" title="Last updated on Mar 14, 2018, 12:43 AM GMT (a9cc8ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/655/463d25c...a9cc8ba.html" title="Last updated on Mar 14, 2018, 12:43 AM GMT (a9cc8ba)">Diff</a>