### PR TITLE
Assure PaymentRequest.id is a UUID (closes #588)

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,8 +563,7 @@
               <li>If <var>details</var>.<a data-lt=
               "PaymentDetailsInit.id">id</a> is missing, add an <a data-lt=
               "PaymentDetailsInit.id">id</a> member to <var>details</var> and
-              set its value to string that uniquely identifies this payment
-              request. It is RECOMMENDED that the string be a <abbr title=
+              set its value to a <abbr title=
               "Universally Unique Identifier">UUID</abbr> [[!RFC4122]].
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -560,11 +560,12 @@
           </li>
           <li>Establish the request's id:
             <ol>
-              <li>If <var>details</var>.<a data-lt=
-              "PaymentDetailsInit.id">id</a> is missing, add an <a data-lt=
-              "PaymentDetailsInit.id">id</a> member to <var>details</var> and
-              set its value to a <abbr title=
-              "Universally Unique Identifier">UUID</abbr> [[!RFC4122]].
+              <li data-tests="payment-request-id-attribute.https.html">If <var>
+                details</var>.<a data-lt="PaymentDetailsInit.id">id</a> is
+                missing, add an <a data-lt="PaymentDetailsInit.id">id</a>
+                member to <var>details</var> and set its value to a
+                <abbr title="Universally Unique Identifier">UUID</abbr>
+                [[!RFC4122]].
               </li>
             </ol>
           </li>


### PR DESCRIPTION
Given that all UAs use a UUID for an .id, we make this a must.

* tests: https://github.com/w3c/web-platform-tests/pull/9061


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/665.html" title="Last updated on Jan 18, 2018, 1:13 AM GMT (8e6f75b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/665/fe1a3ca...8e6f75b.html" title="Last updated on Jan 18, 2018, 1:13 AM GMT (8e6f75b)">Diff</a>