### PR TITLE
Feat: adds PaymentItemType enum and PaymentItem.type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1885,7 +1885,7 @@
         <dt>
           <dfn>type</dfn> member
         </dt>
-        <dd>
+        <dd data-tests="PaymentItem/type_member.https.html">
           A <a>PaymentItemType</a> enum value or null. A user agent MAY use the
           value of <a>type</a> to assist in the presentation of
           <a>PaymentItem</a> by, for example, visually grouping types together

--- a/index.html
+++ b/index.html
@@ -1886,11 +1886,12 @@
           <dfn>type</dfn> member
         </dt>
         <dd data-tests="PaymentItem/type_member.https.html">
-          A <a>PaymentItemType</a> enum value. A user agent MAY use the value
-          of <a>type</a> to assist in the presentation of <a>PaymentItem</a>
-          by, for example, visually grouping types together or other otherwise
-          distinguishing them from other types (or from items that have no
-          associated type).
+          A <a>PaymentItemType</a> enum value, which a developer can use to
+          explicitly indicate that this member is of a particular type. A user
+          agent MAY use the value of <a>type</a> to assist in the presentation
+          of <a>PaymentItem</a> by, for example, visually grouping types
+          together or other otherwise distinguishing them from other types (or
+          from items that have no associated type).
         </dd>
       </dl>
     </section>
@@ -1913,8 +1914,8 @@
         </dt>
         <dd>
           Indicates that the corresponding <a>PaymentItem</a> represents a form
-          of tax (e.g., sales tax, goods and services tax, value added tax,
-          etc.).
+          of taxation. Examples include sales tax, goods and services tax,
+          value added tax, an so on.
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -1849,7 +1849,7 @@
           required DOMString label;
           required PaymentCurrencyAmount amount;
           boolean pending = false;
-          PaymentItemType type;
+          PaymentItemType? type;
         };
       </pre>
       <p>
@@ -1886,10 +1886,11 @@
           <dfn>type</dfn> member
         </dt>
         <dd>
-          A <a>PaymentItemType</a> enum value. A the value of <a>type</a> to
-          assist in the presentation of <a>PaymentItem</a> by, for example,
-          visually grouping types together or other otherwise distinguishing
-          them from other types (or from items that have no associated type).
+          A <a>PaymentItemType</a> enum value or null. A user agent MAY use the
+          value of <a>type</a> to assist in the presentation of
+          <a>PaymentItem</a> by, for example, visually grouping types together
+          or other otherwise distinguishing them from other types (or from
+          items that have no associated type).
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -124,6 +124,11 @@
             <a href="https://github.com/w3c/payment-request/issues/617">issue
             617</a>).
           </li>
+          <li data-link-for="PaymentItem">
+            <a>PaymentItem</a>'s <a>type</a> member and the
+            <a>PaymentItemType</a> enum (see <a href=
+            "https://github.com/w3c/payment-request/issues/163">issue 163</a>).
+          </li>
         </ul>
       </section>
     </section>
@@ -1849,6 +1854,7 @@
           required DOMString label;
           required PaymentCurrencyAmount amount;
           boolean pending = false;
+          // Note: type member is "at risk" of being removed!
           PaymentItemType type;
         };
       </pre>
@@ -1882,43 +1888,64 @@
           shipping option. <a>User agents</a> MAY indicate pending fields in
           the user interface for the payment request.
         </dd>
-        <dt>
-          <dfn>type</dfn> member
-        </dt>
-        <dd data-tests="PaymentItem/type_member.https.html">
-          A <a>PaymentItemType</a> enum value, which a developer can use to
-          explicitly indicate that this member is of a particular type. A user
-          agent MAY use the value of <a>type</a> to assist in the presentation
-          of <a>PaymentItem</a> by, for example, visually grouping types
-          together or other otherwise distinguishing them from other types (or
-          from items that have no associated type).
-        </dd>
       </dl>
+      <div class="issue atrisk">
+        <p>
+          This feature has been marked "<a>at risk</a>". Firefox plans to
+          experiment with this feature during the Candidate Recommendation
+          phase. If you'd like for this feature to remain in the specification,
+          please signal your support for it to remain in <a href=
+          "https://github.com/w3c/payment-request/issues/163">issue 163</a>.
+        </p>
+        <dl>
+          <dt>
+            <dfn>type</dfn> member
+          </dt>
+          <dd data-tests="PaymentItem/type_member.https.html">
+            A <a>PaymentItemType</a> enum value, which a developer can use to
+            explicitly indicate that this member is of a particular type. A
+            user agent MAY use the value of <a>type</a> to assist in the
+            presentation of <a>PaymentItem</a> by, for example, visually
+            grouping types together or other otherwise distinguishing them from
+            other types (or from items that have no associated type).
+          </dd>
+          <dd></dd>
+        </dl>
+      </div>
     </section>
-    <section data-dfn-for="PaymentItemType">
-      <h2>
-        <dfn>PaymentItemType</dfn> enum
-      </h2>
-      <pre class="idl">
-        enum PaymentItemType {
-          "tax"
-        };
-      </pre>
+    <div class="issue atrisk">
       <p>
-        The <a>PaymentItemType</a> serves to categorize a <a>PaymentItem</a>
-        into particular types.
+        This feature has been marked "<a>at risk</a>". Firefox plans to
+        experiment with this feature during the Candidate Recommendation phase.
+        If you'd like for this feature to remain in the specification, please
+        signal your support for it to remain in <a href=
+        "https://github.com/w3c/payment-request/issues/163">issue 163</a>.
       </p>
-      <dl>
-        <dt>
-          "<dfn>tax</dfn>"
-        </dt>
-        <dd>
-          Indicates that the corresponding <a>PaymentItem</a> represents a form
-          of taxation. Examples include sales tax, goods and services tax,
-          value added tax, an so on.
-        </dd>
-      </dl>
-    </section>
+      <section data-dfn-for="PaymentItemType">
+        <h2>
+          <dfn>PaymentItemType</dfn> enum
+        </h2>
+        <pre class="idl">
+          enum PaymentItemType {
+            "tax"
+          };
+        </pre>
+        <p>
+          The <a>PaymentItemType</a> serves to categorize a <a>PaymentItem</a>
+          into particular types.
+        </p>
+        <dl>
+          <dt>
+            "<dfn>tax</dfn>"
+          </dt>
+          <dd>
+            Indicates that the corresponding <a>PaymentItem</a> represents a form
+            of taxation. Examples include sales tax, goods and services tax,
+            value added tax, an so on.
+          </dd>
+        </dl>
+      </section>
+    </div>
     <section data-dfn-for="PaymentAddress" data-link-for="PaymentAddress">
       <h2>
         <dfn>PaymentAddress</dfn> interface

--- a/index.html
+++ b/index.html
@@ -281,6 +281,7 @@
               {
                 label: "Sales Tax",
                 amount: { currency: "USD", value: "5.00" },
+                type: "tax"
               },
             ],
             total: {
@@ -1848,6 +1849,7 @@
           required DOMString label;
           required PaymentCurrencyAmount amount;
           boolean pending = false;
+          PaymentItemType type;
         };
       </pre>
       <p>
@@ -1879,6 +1881,39 @@
           tax amounts that depend upon selection of shipping address or
           shipping option. <a>User agents</a> MAY indicate pending fields in
           the user interface for the payment request.
+        </dd>
+        <dt>
+          <dfn>type</dfn> member
+        </dt>
+        <dd>
+          A <a>PaymentItemType</a> enum value. A the value of <a>type</a> to
+          assist in the presentation of <a>PaymentItem</a> by, for example,
+          visually grouping types together or other otherwise distinguishing
+          them from other types (or from items that have no associated type).
+        </dd>
+      </dl>
+    </section>
+    <section data-dfn-for="PaymentItemType">
+      <h2>
+        <dfn>PaymentItemType</dfn> enum
+      </h2>
+      <pre class="idl">
+        enum PaymentItemType {
+          "tax"
+        };
+      </pre>
+      <p>
+        The <a>PaymentItemType</a> serves to categorize a <a>PaymentItem</a>
+        into particular types.
+      </p>
+      <dl>
+        <dt>
+          "<dfn>tax</dfn>"
+        </dt>
+        <dd>
+          Indicates that the corresponding <a>PaymentItem</a> represents a form
+          of tax (e.g., sales tax, goods and services tax, value added tax,
+          etc.).
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -1849,7 +1849,7 @@
           required DOMString label;
           required PaymentCurrencyAmount amount;
           boolean pending = false;
-          PaymentItemType? type;
+          PaymentItemType type;
         };
       </pre>
       <p>
@@ -1886,11 +1886,11 @@
           <dfn>type</dfn> member
         </dt>
         <dd data-tests="PaymentItem/type_member.https.html">
-          A <a>PaymentItemType</a> enum value or null. A user agent MAY use the
-          value of <a>type</a> to assist in the presentation of
-          <a>PaymentItem</a> by, for example, visually grouping types together
-          or other otherwise distinguishing them from other types (or from
-          items that have no associated type).
+          A <a>PaymentItemType</a> enum value. A user agent MAY use the value
+          of <a>type</a> to assist in the presentation of <a>PaymentItem</a>
+          by, for example, visually grouping types together or other otherwise
+          distinguishing them from other types (or from items that have no
+          associated type).
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
* Tests: https://github.com/w3c/web-platform-tests/pull/9099
* dev docs: 

Adds optional "type" member `PaymentItem` and introduces `PaymentItemType` enum. 

I'm thinking we should introduce "discount" or similar when we add coupon support.  

@domenic, I'm wondering if there would be any advantage to having a default value for the `type` member (e.g., "other")? Thought I'd ask just in case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/666.html" title="Last updated on Feb 21, 2018, 11:31 PM GMT (a5dbf13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/666/678a110...a5dbf13.html" title="Last updated on Feb 21, 2018, 11:31 PM GMT (a5dbf13)">Diff</a>