### PR TITLE
Editorial: define update a PaymentRequest's details algo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2700,317 +2700,11 @@
             <var>detailsPromise</var> to indicate that the payment request is
             valid again.
             </li>
-            <li>
-              <p>
-                Return from the method and perform the remaining steps <a>in
-                parallel</a>.
-              </p>
-              <p>
-                The remaining steps are conditional on the
-                <var>detailsPromise</var> settling. If
-                <var>detailsPromise</var> never settles then the payment
-                request is blocked. Users SHOULD always be able to cancel a
-                payment request. Implementations MAY choose to implement a
-                timeout for pending updates if <var>detailsPromise</var>
-                doesn't settle in a reasonable amount of time. If an
-                implementation chooses to implement a timeout, they must
-                execute the steps listed below in the "upon rejection" path.
-                Such a timeout is a fatal error for the payment request.
-              </p>
-            </li>
-            <li>
-              <a>Upon rejection</a> of <var>detailsPromise</var>:
-              <ol>
-                <li>
-                  <a>Abort the update</a> with an "<a>AbortError</a>"
-                  <a>DOMException</a>.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <a>Upon fulfillment</a> of <var>detailsPromise</var> with value
-              <var>value</var>:
-              <ol data-link-for="PaymentDetailsBase">
-                <li>Let <var>details</var> be the result of <a data-cite=
-                "!WEBIDL#es-dictionary">converting</a> <var>value</var> to a
-                <a>PaymentDetailsUpdate</a> dictionary. If this <a>throws</a>
-                an exception, <a>abort the update</a> with the thrown
-                exception.
-                </li>
-                <li>Let <var>serializedModifierData</var> be an empty list.
-                </li>
-                <li>Let <var>selectedShippingOption</var> be null.
-                </li>
-                <li>Let <var>shippingOptions</var> be an empty
-                <code><a data-cite=
-                "!WEBIDL#idl-sequence">sequence</a></code>&lt;<a>PaymentShippingOption</a>&gt;.
-                </li>
-                <li>Validate and canonicalize the details:
-                  <ol>
-                    <li data-link-for="PaymentDetailsUpdate">If the
-                    <a>total</a> member of <var>details</var> is present, then:
-                      <ol>
-                        <li>
-                          <a>Check and canonicalize total</a>
-                          <var>details</var>.<a>total</a>.<a data-lt=
-                          "PaymentItem.amount">amount</a>. If an exception is
-                          thrown, then <a>abort the update</a> with that
-                          exception.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If the <a>displayItems</a> member of <var>details</var>
-                    is present, then for each <var>item</var> in
-                    <var>details</var>.<a>displayItems</a>:
-                      <ol>
-                        <li>
-                          <a>Check and canonicalize amount</a>
-                          <var>item</var>.<a data-lt=
-                          "PaymentItem.amount">amount</a>. If an exception is
-                          thrown, then <a>abort the update</a> with that
-                          exception.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If the <a>shippingOptions</a> member of
-                    <var>details</var> is present, and
-                    <var>request</var>.<a>[[\options]]</a>.<a data-lt=
-                    "PaymentOptions.requestShipping">requestShipping</a> is
-                    true, then:
-                      <ol>
-                        <li>Set <var>shippingOptions</var> to
-                        <var>details</var>.<a>shippingOptions</a>.
-                        </li>
-                        <li>Let <var>seenIDs</var> be an empty list.
-                        </li>
-                        <li>For each <var>option</var> in
-                        <var>shippingOptions</var>:
-                          <ol>
-                            <li>
-                              <a>Check and canonicalize amount</a>
-                              <var>option</var>.<a data-lt=
-                              "PaymentShippingOption.amount">amount</a>. If an
-                              exception is thrown, then <a>abort the update</a>
-                              with that exception.
-                            </li>
-                            <li data-tests=
-                            "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
-                            If <var>seenIDs</var> contains
-                            <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.id">id</a>, then <a>abort
-                            the update</a> with a <a>TypeError</a>.
-                            </li>
-                            <li>Otherwise, append
-                              <var>option</var>.<a data-lt="PaymentShippingOption.id">id</a>
-                              to <var>seenIDs</var>.
-                            </li>
-                          </ol>
-                        </li>
-                        <li>For each <var>option</var> in
-                        <var>shippingOptions</var>:
-                          <ol>
-                            <li>If <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.selected">selected</a> is
-                            true, then set <var>selectedShippingOption</var> to
-                            <var>option</var>.<a data-lt=
-                            "PaymentShippingOption.id">id</a>.
-                            </li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If the <a>modifiers</a> member of <var>details</var> is
-                    present, then:
-                      <ol>
-                        <li>Let <var>modifiers</var> be the sequence
-                        <var>details</var>.<a>modifiers</a>.
-                        </li>
-                        <li>Let <var>serializedModifierData</var> be an empty
-                        list.
-                        </li>
-                        <li>For each <a>PaymentDetailsModifier</a>
-                        <var>modifier</var> in <var>modifiers</var>:
-                          <ol data-link-for="PaymentDetailsModifier">
-                            <li data-tests=
-                            "updateWith-method-pmi-handling-manual.https.html">
-                            Run the steps to <a data-cite=
-                            "payment-method-id#dfn-validate-a-payment-method-identifier">
-                              validate a payment method identifier</a> with
-                              <var>modifier</var>.<a data-lt=
-                              "PaymentDetailsModifier.supportedMethods">supportedMethods</a>.
-                              If it returns false, then <a>abort the update</a>
-                              with a <a>RangeError</a> exception. Optional,
-                              inform the developer that the payment method
-                              identifier is invalid.
-                            </li>
-                            <li>If the <a>total</a> member of
-                            <var>modifier</var> is present, then:
-                              <ol>
-                                <li>
-                                  <a>Check and canonicalize total</a>
-                                  <var>modifier</var>.<a>total</a>.<a data-lt=
-                                  "PaymentItem.amount">amount</a>. If an
-                                  exception is thrown, then <a>abort the
-                                  update</a> with that exception.
-                                </li>
-                              </ol>
-                            </li>
-                            <li>If the <a>additionalDisplayItems</a> member of
-                            <var>modifier</var> is present, then for each
-                            <a>PaymentItem</a> <var>item</var> in
-                            <var>modifier</var>.<a>additionalDisplayItems</a>:
-                              <ol>
-                                <li>
-                                  <a>Check and canonicalize amount</a>
-                                  <var>item</var>.<a data-lt=
-                                  "PaymentItem.amount">amount</a>. If an
-                                  exception is thrown, then <a>abort the
-                                  update</a> with that exception.
-                                </li>
-                              </ol>
-                            </li>
-                            <li>If the <a data-lt=
-                            "PaymentDetailsModifier.data">data</a> member of
-                            <var>modifier</var> is missing, let
-                            <var>serializedData</var> be null. Otherwise, let
-                            <var>serializedData</var> be the result of
-                            <a>JSON-serializing</a>
-                            <var>modifier</var>.<a data-lt=
-                            "PaymentDetailsModifier.data">data</a> into a
-                            string. If <a>JSON-serializing</a> throws an
-                            exception, then <a>abort the update</a> with that
-                            exception.
-                            </li>
-                            <li>Add <var>serializedData</var> to
-                            <var>serializedModifierData</var>.
-                            </li>
-                            <li>Remove the <a data-lt=
-                            "PaymentDetailsModifier.data">data</a> member of
-                            <var>modifier</var>, if it is present.
-                            </li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li>Update the <a>PaymentRequest</a> using the new details:
-                  <ol>
-                    <li data-link-for="PaymentDetailsUpdate">If the
-                    <a>total</a> member of <var>details</var> is present, then:
-                      <ol>
-                        <li>Set
-                        <var>request</var>.<a>[[\details]]</a>.<a data-link-for="PaymentDetailsInit">total</a>
-                          to <var>details</var>.<a>total</a>.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If the <a>displayItems</a> member of <var>details</var>
-                    is present, then:
-                      <ol>
-                        <li>Set
-                        <var>request</var>.<a>[[\details]]</a>.<a>displayItems</a>
-                        to <var>details</var>.<a>displayItems</a>.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If the <a>shippingOptions</a> member of
-                    <var>details</var> is present, and
-                    <var>request</var>.<a>[[\options]]</a>.<a data-lt=
-                    "PaymentOptions.requestShipping">requestShipping</a> is
-                    true, then:
-                      <ol>
-                        <li>Set
-                        <var>request</var>.<a>[[\details]]</a>.<a>shippingOptions</a>
-                        to <var>shippingOptions</var>.
-                        </li>
-                        <li>Set the value of <var>request</var>'s <a data-lt=
-                        "PaymentRequest.shippingOption">shippingOption</a>
-                        attribute to <var>selectedShippingOption</var>.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If the <a>modifiers</a> member of <var>details</var> is
-                    present, then:
-                      <ol>
-                        <li>Set
-                        <var>request</var>.<a>[[\details]]</a>.<a>modifiers</a>
-                        to <var>details</var>.<a>modifiers</a>.
-                        </li>
-                        <li>Set
-                        <var>request</var>.<a>[[\serializedModifierData]]</a>
-                        to <var>serializedModifierData</var>.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>If <var>request</var>.<a>[[\options]]</a>.<a data-lt=
-                    "PaymentOptions.requestShipping">requestShipping</a> is
-                    true, and
-                    <var>request</var>.<a>[[\details]]</a>.<a>shippingOptions</a>
-                    is empty, then the developer has signified that there are
-                    no valid shipping options for the currently-chosen shipping
-                    address (given by <var>request</var>'s <a data-lt=
-                    "PaymentRequest.shippingAddress">shippingAddress</a>). In
-                    this case, the user agent SHOULD display an error
-                    indicating this, and MAY indicate that the currently-chosen
-                    shipping address is invalid in some way. The user agent
-                    SHOULD use the <a data-lt=
-                    "PaymentDetailsUpdate.error">error</a> member of
-                    <var>details</var>, if it is present, to give more
-                    information about why there are no valid shipping options
-                    for that address.
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li>In either case, run the following steps, after either the upon
-            rejection or upon fulfillment steps have concluded:
-              <ol>
-                <li>Set <var>request</var>.<a>[[\updating]]</a> to false.
-                </li>
-                <li>The <a>user agent</a> SHOULD update the user interface
-                based on any changed values in <var>request</var>. The user
-                agent SHOULD re-enable user interface elements that might have
-                been disabled in the steps above if appropriate.
-                </li>
-              </ol>
+            <li>Run the <a>update a <code>PaymentRequest</code>'s details
+            algorithm</a> with <var>detailsPromise</var> and
+            <var>request</var>.
             </li>
           </ol>
-          <p>
-            If any of the above steps say to <dfn>abort the update</dfn> with
-            an exception <var>exception</var>, then:
-          </p>
-          <ol>
-            <li>Abort the current user interaction and close down any remaining
-            user interface.
-            </li>
-            <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
-            </li>
-            <li>Reject the promise <var>request</var>.<a>[[\acceptPromise]]</a>
-            with <var>exception</var>.
-            </li>
-            <li>Abort the algorithm.
-            </li>
-          </ol>
-          <div class="note">
-            <p>
-              <a data-lt="abort the update">Aborting the update</a> is
-              performed when there is a fatal error updating the payment
-              request, such as the supplied <var>detailsPromise</var>
-              rejecting, or its fulfillment value containing invalid data. This
-              would potentially leave the payment request in an inconsistent
-              state since the developer hasn't successfully handled the change
-              event. Consequently, the <a>PaymentRequest</a> moves to a
-              "<a>closed</a>" state. The error is signaled to the developer
-              through the rejection of the <a>[[\acceptPromise]]</a>, i.e., the
-              promise returned by <a data-lt="PaymentRequest.show">show()</a>.
-            </p>
-            <p>
-              <a>User agents</a> might show an error message to the user when
-              this occurs.
-            </p>
-          </div>
         </section>
         <section>
           <h2>
@@ -3300,6 +2994,315 @@
           with an "<a>AbortError</a>" <a>DOMException</a>.
           </li>
         </ol>
+      </section>
+      <section>
+        <h2>
+          Update a <code>PaymentRequest</code>'s details algorithm
+        </h2>
+        <p>
+          The <dfn>update a <code>PaymentRequest</code>'s details
+          algorithm</dfn> takes a <a>PaymentDetailsUpdate</a>
+          <var>detailsPromise</var> and a <a>PaymentRequest</a>
+          <var>request</var>. The steps are conditional on the
+          <var>detailsPromise</var> settling. If <var>detailsPromise</var>
+          never settles then the payment request is blocked. Users SHOULD
+          always be able to cancel a payment request. Implementations MAY
+          choose to implement a timeout for pending updates if
+          <var>detailsPromise</var> doesn't settle in a reasonable amount of
+          time. If an implementation chooses to implement a timeout, they must
+          execute the steps listed below in the "upon rejection" path. Such a
+          timeout is a fatal error for the payment request.
+        </p>
+        <ol class="algorithm">
+          <li>
+            <a>Upon rejection</a> of <var>detailsPromise</var>:
+            <ol>
+              <li>
+                <a>Abort the update</a> with an "<a>AbortError</a>"
+                <a>DOMException</a>.
+              </li>
+            </ol>
+          </li>
+          <li>
+            <a>Upon fulfillment</a> of <var>detailsPromise</var> with value
+            <var>value</var>:
+            <ol data-link-for="PaymentDetailsBase">
+              <li>Let <var>details</var> be the result of <a data-cite=
+              "!WEBIDL#es-dictionary">converting</a> <var>value</var> to a <a>
+                PaymentDetailsUpdate</a> dictionary. If this <a>throws</a> an
+                exception, <a>abort the update</a> with the thrown exception.
+              </li>
+              <li>Let <var>serializedModifierData</var> be an empty list.
+              </li>
+              <li>Let <var>selectedShippingOption</var> be null.
+              </li>
+              <li>Let <var>shippingOptions</var> be an empty
+                <code><a data-cite="!WEBIDL#idl-sequence">sequence</a></code>&lt;<a>PaymentShippingOption</a>&gt;.
+              </li>
+              <li>Validate and canonicalize the details:
+                <ol>
+                  <li data-link-for="PaymentDetailsUpdate">If the <a>total</a>
+                  member of <var>details</var> is present, then:
+                    <ol>
+                      <li>
+                        <a>Check and canonicalize total</a>
+                        <var>details</var>.<a>total</a>.<a data-lt=
+                        "PaymentItem.amount">amount</a>. If an exception is
+                        thrown, then <a>abort the update</a> with that
+                        exception.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If the <a>displayItems</a> member of <var>details</var>
+                  is present, then for each <var>item</var> in
+                  <var>details</var>.<a>displayItems</a>:
+                    <ol>
+                      <li>
+                        <a>Check and canonicalize amount</a>
+                        <var>item</var>.<a data-lt=
+                        "PaymentItem.amount">amount</a>. If an exception is
+                        thrown, then <a>abort the update</a> with that
+                        exception.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If the <a>shippingOptions</a> member of
+                  <var>details</var> is present, and
+                  <var>request</var>.<a>[[\options]]</a>.<a data-lt=
+                  "PaymentOptions.requestShipping">requestShipping</a> is true,
+                  then:
+                    <ol>
+                      <li>Set <var>shippingOptions</var> to
+                      <var>details</var>.<a>shippingOptions</a>.
+                      </li>
+                      <li>Let <var>seenIDs</var> be an empty list.
+                      </li>
+                      <li>For each <var>option</var> in
+                      <var>shippingOptions</var>:
+                        <ol>
+                          <li>
+                            <a>Check and canonicalize amount</a>
+                            <var>option</var>.<a data-lt=
+                            "PaymentShippingOption.amount">amount</a>. If an
+                            exception is thrown, then <a>abort the update</a>
+                            with that exception.
+                          </li>
+                          <li data-tests=
+                          "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
+                          If <var>seenIDs</var> contains
+                          <var>option</var>.<a data-lt=
+                          "PaymentShippingOption.id">id</a>, then <a>abort the
+                          update</a> with a <a>TypeError</a>.
+                          </li>
+                          <li>Otherwise, append <var>option</var>.<a data-lt=
+                          "PaymentShippingOption.id">id</a> to
+                          <var>seenIDs</var>.
+                          </li>
+                        </ol>
+                      </li>
+                      <li>For each <var>option</var> in
+                      <var>shippingOptions</var>:
+                        <ol>
+                          <li>If <var>option</var>.<a data-lt=
+                          "PaymentShippingOption.selected">selected</a> is
+                          true, then set <var>selectedShippingOption</var> to
+                          <var>option</var>.<a data-lt=
+                          "PaymentShippingOption.id">id</a>.
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If the <a>modifiers</a> member of <var>details</var> is
+                  present, then:
+                    <ol>
+                      <li>Let <var>modifiers</var> be the sequence
+                      <var>details</var>.<a>modifiers</a>.
+                      </li>
+                      <li>Let <var>serializedModifierData</var> be an empty
+                      list.
+                      </li>
+                      <li>For each <a>PaymentDetailsModifier</a>
+                      <var>modifier</var> in <var>modifiers</var>:
+                        <ol data-link-for="PaymentDetailsModifier">
+                          <li data-tests=
+                          "updateWith-method-pmi-handling-manual.https.html">
+                          Run the steps to <a data-cite=
+                          "payment-method-id#dfn-validate-a-payment-method-identifier">
+                            validate a payment method identifier</a> with
+                            <var>modifier</var>.<a data-lt=
+                            "PaymentDetailsModifier.supportedMethods">supportedMethods</a>.
+                            If it returns false, then <a>abort the update</a>
+                            with a <a>RangeError</a> exception. Optional,
+                            inform the developer that the payment method
+                            identifier is invalid.
+                          </li>
+                          <li>If the <a>total</a> member of <var>modifier</var>
+                          is present, then:
+                            <ol>
+                              <li>
+                                <a>Check and canonicalize total</a>
+                                <var>modifier</var>.<a>total</a>.<a data-lt=
+                                "PaymentItem.amount">amount</a>. If an
+                                exception is thrown, then <a>abort the
+                                update</a> with that exception.
+                              </li>
+                            </ol>
+                          </li>
+                          <li>If the <a>additionalDisplayItems</a> member of
+                          <var>modifier</var> is present, then for each
+                          <a>PaymentItem</a> <var>item</var> in
+                          <var>modifier</var>.<a>additionalDisplayItems</a>:
+                            <ol>
+                              <li>
+                                <a>Check and canonicalize amount</a>
+                                <var>item</var>.<a data-lt=
+                                "PaymentItem.amount">amount</a>. If an
+                                exception is thrown, then <a>abort the
+                                update</a> with that exception.
+                              </li>
+                            </ol>
+                          </li>
+                          <li>If the <a data-lt="PaymentDetailsModifier.data">
+                            data</a> member of <var>modifier</var> is missing,
+                            let <var>serializedData</var> be null. Otherwise,
+                            let <var>serializedData</var> be the result of
+                            <a>JSON-serializing</a>
+                            <var>modifier</var>.<a data-lt=
+                            "PaymentDetailsModifier.data">data</a> into a
+                            string. If <a>JSON-serializing</a> throws an
+                            exception, then <a>abort the update</a> with that
+                            exception.
+                          </li>
+                          <li>Add <var>serializedData</var> to
+                          <var>serializedModifierData</var>.
+                          </li>
+                          <li>Remove the <a data-lt=
+                          "PaymentDetailsModifier.data">data</a> member of
+                          <var>modifier</var>, if it is present.
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>Update the <a>PaymentRequest</a> using the new details:
+                <ol>
+                  <li data-link-for="PaymentDetailsUpdate">If the <a>total</a>
+                  member of <var>details</var> is present, then:
+                    <ol>
+                      <li>Set
+                      <var>request</var>.<a>[[\details]]</a>.<a data-link-for="PaymentDetailsInit">total</a>
+                        to <var>details</var>.<a>total</a>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If the <a>displayItems</a> member of <var>details</var>
+                  is present, then:
+                    <ol>
+                      <li>Set
+                      <var>request</var>.<a>[[\details]]</a>.<a>displayItems</a>
+                      to <var>details</var>.<a>displayItems</a>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If the <a>shippingOptions</a> member of
+                  <var>details</var> is present, and
+                  <var>request</var>.<a>[[\options]]</a>.<a data-lt=
+                  "PaymentOptions.requestShipping">requestShipping</a> is true,
+                  then:
+                    <ol>
+                      <li>Set
+                      <var>request</var>.<a>[[\details]]</a>.<a>shippingOptions</a>
+                      to <var>shippingOptions</var>.
+                      </li>
+                      <li>Set the value of <var>request</var>'s <a data-lt=
+                      "PaymentRequest.shippingOption">shippingOption</a>
+                      attribute to <var>selectedShippingOption</var>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If the <a>modifiers</a> member of <var>details</var> is
+                  present, then:
+                    <ol>
+                      <li>Set
+                      <var>request</var>.<a>[[\details]]</a>.<a>modifiers</a>
+                      to <var>details</var>.<a>modifiers</a>.
+                      </li>
+                      <li>Set
+                      <var>request</var>.<a>[[\serializedModifierData]]</a> to
+                      <var>serializedModifierData</var>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If <var>request</var>.<a>[[\options]]</a>.<a data-lt=
+                  "PaymentOptions.requestShipping">requestShipping</a> is true,
+                  and
+                  <var>request</var>.<a>[[\details]]</a>.<a>shippingOptions</a>
+                  is empty, then the developer has signified that there are no
+                  valid shipping options for the currently-chosen shipping
+                  address (given by <var>request</var>'s <a data-lt=
+                  "PaymentRequest.shippingAddress">shippingAddress</a>). In
+                  this case, the user agent SHOULD display an error indicating
+                  this, and MAY indicate that the currently-chosen shipping
+                  address is invalid in some way. The user agent SHOULD use the
+                  <a data-lt="PaymentDetailsUpdate.error">error</a> member of
+                  <var>details</var>, if it is present, to give more
+                  information about why there are no valid shipping options for
+                  that address.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>In either case, run the following steps, after either the upon
+          rejection or upon fulfillment steps have concluded:
+            <ol>
+              <li>Set <var>request</var>.<a>[[\updating]]</a> to false.
+              </li>
+              <li>The <a>user agent</a> SHOULD update the user interface based
+              on any changed values in <var>request</var>. The user agent
+              SHOULD re-enable user interface elements that might have been
+              disabled in the steps above if appropriate.
+              </li>
+            </ol>
+          </li>
+        </ol>
+        <p>
+          If any of the above steps say to <dfn>abort the update</dfn> with an
+          exception <var>exception</var>, then:
+        </p>
+        <ol>
+          <li>Abort the current user interaction and close down any remaining
+          user interface.
+          </li>
+          <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
+          </li>
+          <li>Reject the promise <var>request</var>.<a>[[\acceptPromise]]</a>
+          with <var>exception</var>.
+          </li>
+          <li>Abort the algorithm.
+          </li>
+        </ol>
+        <div class="note">
+          <p>
+            <a data-lt="abort the update">Aborting the update</a> is performed
+            when there is a fatal error updating the payment request, such as
+            the supplied <var>detailsPromise</var> rejecting, or its
+            fulfillment value containing invalid data. This would potentially
+            leave the payment request in an inconsistent state since the
+            developer hasn't successfully handled the change event.
+            Consequently, the <a>PaymentRequest</a> moves to a "<a>closed</a>"
+            state. The error is signaled to the developer through the rejection
+            of the <a>[[\acceptPromise]]</a>, i.e., the promise returned by
+            <a data-lt="PaymentRequest.show">show()</a>.
+          </p>
+          <p>
+            <a>User agents</a> might show an error message to the user when
+            this occurs.
+          </p>
+        </div>
       </section>
     </section>
     <section class="informative">


### PR DESCRIPTION
This adds a `dfn` for "update a PaymentRequest's details", which can then be used newly features to the spec.

This doesn't add anything substantive - it just relocates spec text to its own section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/671.html" title="Last updated on Jan 23, 2018, 12:42 AM GMT (3b045dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/671/0ae75cb...3b045dc.html" title="Last updated on Jan 23, 2018, 12:42 AM GMT (3b045dc)">Diff</a>