### PR TITLE
Feat: allow show() to take optional detailsPromise

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,17 @@
             <a>PaymentItemType</a> enum (see <a href=
             "https://github.com/w3c/payment-request/issues/163">issue 163</a>).
           </li>
+          <li data-link-for="PaymentRequest">As the <code>optional
+          detailsPromise</code> argument of the <a>show()</a> method was added
+          late in the Candidate Recommendation phase, the working group is
+          treating it "at risk" and considering moving it to a future version
+          of the specification. This is to avoid this version of the
+          specification from being delayed from progressing along the
+          Recommendation Track, in case we can't get two interoperable
+          implementations in a timely manner. However, if it gets interoperably
+          implemented relatively quickly, the feature will remain in this
+          version of the specification.
+          </li>
         </ul>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -499,7 +499,7 @@
         [Constructor(sequence&lt;PaymentMethodData&gt; methodData, PaymentDetailsInit details, optional PaymentOptions options),
         SecureContext, Exposed=Window]
         interface PaymentRequest : EventTarget {
-          Promise&lt;PaymentResponse&gt; show();
+          Promise&lt;PaymentResponse&gt; show(optional Promise&lt;PaymentDetailsUpdate&gt; detailsPromise);
           Promise&lt;void&gt; abort();
           Promise&lt;boolean&gt; canMakePayment();
 
@@ -824,7 +824,8 @@
           </p>
         </div>
         <p data-tests="payment-request-show-method.https.html">
-          The <a>show()</a> method MUST act as follows:
+          The <code><a data-lt="show()">show(detailsPromise)</a></code> method
+          MUST act as follows:
         </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
@@ -936,6 +937,37 @@
           <var>acceptPromise</var> with a "<a>NotSupportedError</a>"
           <a>DOMException</a>, and set the <a>user agent</a>'s <a>payment
           request is showing</a> boolean to false.
+          </li>
+          <li>Otherwise, present a user interface that will allow the user to
+          interact with the <var>handlers</var>. The user agent SHOULD
+          prioritize the preference of the user when presenting payment
+          methods.
+          </li>
+          <li data-tests=
+          "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">
+          If <var>detailsPromise</var> was passed, then:
+            <ol>
+              <li>Set <var>request</var>.<a>[[\updating]]</a> to true.
+              </li>
+              <li>Disable the user interface user interface that will allow the
+              user to interact with the <var>handlers</var>
+              </li>
+              <li>Run the <a>update a <code>PaymentRequest</code>'s details
+              algorithm</a> with <var>detailsPromise</var> and
+              <var>request</var>.
+              </li>
+              <li>Wait for the <var>detailsPromise</var> to settle.
+                <p class="note">
+                  Based on how the <var>detailsPromise</var> settles, the
+                  <a>update a <code>PaymentRequest</code>'s details
+                  algorithm</a> determines how the payment UI behaves. That is,
+                  <a>upon rejection</a> of the <var>detailsPromise</var>, the
+                  payment request aborts. Otherwise, <a>upon fulfillment</a>
+                  <var>detailsPromise</var>, the user agent re-enables the
+                  payment request UI and the payment flow can continue.
+                </p>
+              </li>
+            </ol>
           </li>
           <li>
             <p>
@@ -3345,9 +3377,9 @@
               <li>Set <var>request</var>.<a>[[\updating]]</a> to false.
               </li>
               <li>The <a>user agent</a> SHOULD update the user interface based
-              on any changed values in <var>request</var>. The user agent
-              SHOULD re-enable user interface elements that might have been
-              disabled in the steps above if appropriate.
+              on any changed values in <var>request</var>. If appropriate, the
+              user agent SHOULD re-enable user interface elements that might
+              have been disabled prior to running this algorithm.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
closes #645 

 * [x] tests - [Part 1 - rejects](https://github.com/w3c/web-platform-tests/pull/9617), [Part 2 - resolves](https://github.com/w3c/web-platform-tests/pull/9617)
 * [x] [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show)

Implementer issues filed:
   * [x] [Safari](https://bugs.webkit.org/show_bug.cgi?id=182538) 
   * [x] [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=817073)
   * [x] Edge - ack from @adrianba
   * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1441709)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/672.html" title="Last updated on Feb 28, 2018, 4:47 AM GMT (6255cc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/672/f5096c6...6255cc0.html" title="Last updated on Feb 28, 2018, 4:47 AM GMT (6255cc0)">Diff</a>