### PR TITLE
Call out payment handlers in abort()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1010,8 +1010,8 @@
           <li>Return <var>promise</var> and perform the remaining steps <a>in
           parallel</a>.
           </li>
-          <li>Try to abort the current user interaction and close down any
-          remaining user interface.
+          <li>Try to abort the current user interaction with the payment
+          handler and close down any remaining user interface.
           </li>
           <li>
             <a>Queue a task</a> on the <a>user interaction task source</a> to


### PR DESCRIPTION
Per 29 Jan 2018 Payment Handler API editor discussion [1], acknowledge
connection to payment handlers in abort() method.

Relates to Issue #476.

[1] https://www.w3.org/2018/01/29-apps-minutes#item02


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/678.html" title="Last updated on Jan 29, 2018, 9:07 PM GMT (1ee49bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/678/e65a217...1ee49bf.html" title="Last updated on Jan 29, 2018, 9:07 PM GMT (1ee49bf)">Diff</a>