### PR TITLE
Add regionCode attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -2204,21 +2204,24 @@
             the empty string:
               <ol>
                 <li>Let <var>regionCode</var> be the result of <a>strip leading
-                and trailing ASCII whitespace</a> and <a data-cite=
-                "!INFRA#ascii-uppercase">ASCII uppercasing</a>
-                <var>details</var>["<a>regionCode</a>"].
+                and trailing ASCII whitespace</a> from
+                <var>details</var>["<a>regionCode</a>"] and then
+                  <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>
+                  the result.
                 </li>
                 <li>
                   <p>
-                    If <var>regionCode</var> is not a valid subdivision code as
-                    per [[!ISO3166-2]]'s section 5.2 Structure of country
-                    subdivision code elements (details below), throw a
+                    If <var>regionCode</var> is not a valid <a>country
+                    subdivision code element</a> as per [[!ISO3166-2]]'s
+                    section 5.2 "Structure of country subdivision code
+                    elements" (non-normative details below), throw a
                     <a>RangeError</a> exception.
                   </p>
                   <div class="note" title=
                   "Structure of country subdivision code elements">
                     <p>
-                      The structure of country subdivision code elements is
+                      <strong>Do not implement from this note.</strong> The
+                      structure of a <a>country subdivision code element</a> is
                       formally defined in [[!ISO3166-2]] (section 5.2).
                       Although the structure is not expected to change at the
                       time of writing, implementers are expected to track
@@ -2226,8 +2229,8 @@
                     </p>
                     <p>
                       As [[!ISO3166-2]] is not freely available to the general
-                      public, the structure of a country subdivision code
-                      elements at the time of publication is as follow:
+                      public, the structure of a <a>country subdivision code
+                      element</a> at the time of publication is as follows:
                     </p>
                     <ul>
                       <li>Two <a>code points</a> that match an [[!ISO3166-1]]
@@ -2236,15 +2239,33 @@
                       <li>A single U+002D (-) <a>code point</a>.
                       </li>
                       <li>One, two, or three <a data-cite=
-                      "infra#ascii-alphanumeric">ASCII alphanumeric</a> code
-                      points, in any order. This is referred to as the
-                      subdivision name.
+                      "INFRA#ascii-alphanumeric">ASCII alphanumeric</a> code
+                      points, in any order.
                       </li>
                     </ul>
                   </div>
                 </li>
                 <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
                 <var>regionCode</var>.
+                </li>
+                <li>Let <var>region</var> be the corresponding [[!ISO3166-2]]
+                <a>country subdivision name</a> for <var>regionCode</var>.
+                Where [[!ISO3166-2]] defines multiple <a>country subdivision
+                names</a> for a <var>regionCode</var>, it is RECOMMENDED the
+                user agent select one by matching on:
+                  <ol>
+                    <li>The <a data-cite="!HTML#language">language</a> of
+                    <a data-cite="HTML#the-body-element-2">the body
+                    element</a>.
+                    </li>
+                    <li>The user's preferred languages.
+                    </li>
+                    <li>Any other criteria the user agent deems suitable.
+                    </li>
+                  </ol>
+                </li>
+                <li>Set <var>address</var>.<a>[[\region]]</a> to
+                <var>region</var>.
                 </li>
               </ol>
             </li>
@@ -2371,9 +2392,9 @@
           </h2>
           <p data-link-for="">
             Represents the <a>region</a> of the address as an [[!ISO3166-2]]
-            country subdivision code element. When getting, returns the value
-            of the <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal
-            slot.
+            <a>country subdivision code element</a>. When getting, returns the
+            value of the <a>PaymentAddress</a>'s <a>[[\regionCode]]</a>
+            internal slot.
           </p>
         </section>
         <section>
@@ -2494,9 +2515,9 @@
                 <dfn>[[\region]]</dfn>
               </td>
               <td>
-                A <a>region</a> as a country subdivision name or the empty
-                string, such as "Victoria", representing the state of Victoria
-                in Australia.
+                A <a>region</a> as a <a>country subdivision name</a> or the
+                empty string, such as "Victoria", representing the state of
+                Victoria in Australia.
               </td>
             </tr>
             <tr>
@@ -2504,9 +2525,9 @@
                 <dfn>[[\regionCode]]</dfn>
               </td>
               <td>
-                A <a>region</a> represented as a [[!ISO3166-2]] country
-                subdivision code element or the empty string, stored in its
-                canonical uppercase form. For example, "<code>PT-11</code>"
+                A <a>region</a> represented as a [[!ISO3166-2]] <a>country
+                subdivision code element</a> stored in its canonical uppercase
+                form, or the empty string. For example, "<code>PT-11</code>"
                 represents the Lisbon district of Portugal.
               </td>
             </tr>
@@ -2626,8 +2647,8 @@
             <dfn>regionCode</dfn> member
           </dt>
           <dd>
-            An <a>region</a>, represented as an [[!ISO3166-2]] country
-            subdivision code element.
+            An <a>region</a>, represented as a <a>country subdivision code
+            element</a>.
           </dd>
           <dt>
             <dfn>city</dfn> member
@@ -2769,8 +2790,9 @@
               region, or to the empty string if none was provided.
               </li>
               <li>If <var>details</var>["<a>region</a>"] has as a corresponding
-              [[!ISO3166-2]] country subdivision code element, set
-              <var>details</var>["<a>regionCode</a>"] to that subdivision code.
+              <a>country subdivision code element</a>, set
+              <var>details</var>["<a>regionCode</a>"] to that <a>country
+              subdivision code element</a>.
               </li>
             </ol>
           </li>
@@ -4009,6 +4031,14 @@
         This specification relies on several other underlying specifications.
       </p>
       <dl data-sort="">
+        <dt>
+          ISO 3366-2
+        </dt>
+        <dd>
+          <dfn data-lt="country subdivision names">Country subdivision
+          name</dfn> and <dfn>country subdivision code element</dfn> are
+          defined in [[!ISO3166-2]].
+        </dd>
         <dt>
           Infra
         </dt>

--- a/index.html
+++ b/index.html
@@ -2400,9 +2400,9 @@
             <dfn>regionCode</dfn> attribute
           </h2>
           <p data-link-for="">
-            Represents the <a>region</a> of the address, but as the code
-            element of an [[!ISO3166-2]] country subdivision name (e.g., "CA"
-            for California, USA). When getting, returns the value of the
+            Represents the <a>region</a> of the address as a code element of an
+            [[!ISO3166-2]] country subdivision name (e.g., "CA" for California,
+            USA). When getting, returns the value of the
             <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal slot.
           </p>
         </section>

--- a/index.html
+++ b/index.html
@@ -2185,7 +2185,8 @@
             <li>If <var>details</var> was not passed, return
             <var>address</var>.
             </li>
-            <li>If <var>details</var>["<a>country</a>"] is present:
+            <li>If <var>details</var>["<a>country</a>"] is present and not the
+            empty string:
               <ol>
                 <li>Set <var>country</var> the result of <a>strip leading and
                 trailing ASCII whitespace</a> from
@@ -2203,11 +2204,15 @@
             <li>If <var>details</var>["<a>regionCode</a>"] is present and not
             the empty string:
               <ol>
-                <li>Let <var>regionCode</var> be the result of <a>strip leading
+                <li>Let <var>regionPart</var> be the result of <a>strip leading
                 and trailing ASCII whitespace</a> from
                 <var>details</var>["<a>regionCode</a>"] and then
                   <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>
                   the result.
+                </li>
+                <li>Let <var>regionCode</var> be the concatenation of
+                <var>address</var>.<a>[[\country]]</a>, a single U+002D (-) <a>
+                  code point</a>, <var>regionPart</var>.
                 </li>
                 <li>
                   <p>
@@ -2246,26 +2251,30 @@
                   </div>
                 </li>
                 <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
-                <var>regionCode</var>.
+                <var>regionPart</var>.
                 </li>
-                <li>Let <var>region</var> be the corresponding <a>country
-                subdivision name</a> for <var>regionCode</var>. Where
-                [[!ISO3166-2]] defines multiple <a>country subdivision
-                names</a> for a <var>regionCode</var>, it is RECOMMENDED the
-                user agent select one by matching on:
+                <li>If <var>details</var>["<a>region</a>"] is not present:
                   <ol>
-                    <li>The <a data-cite="!HTML#language">language</a> of
-                    <a data-cite="HTML#the-body-element-2">the body
-                    element</a>.
+                    <li>Let <var>region</var> be the corresponding <a>country
+                    subdivision name</a> for <var>regionCode</var>. Where
+                    [[!ISO3166-2]] defines multiple <a>country subdivision
+                    names</a> for a <var>regionCode</var>, it is RECOMMENDED
+                    the user agent select one by matching on:
+                      <ol>
+                        <li>The <a data-cite="!HTML#language">language</a> of
+                        <a data-cite="HTML#the-body-element-2">the body
+                        element</a>.
+                        </li>
+                        <li>The user's preferred languages.
+                        </li>
+                        <li>Any other criteria the user agent deems suitable.
+                        </li>
+                      </ol>
                     </li>
-                    <li>The user's preferred languages.
-                    </li>
-                    <li>Any other criteria the user agent deems suitable.
+                    <li>
+                      <var>details</var>["<a>region</a>"] to <var>region</var>.
                     </li>
                   </ol>
-                </li>
-                <li>Set <var>address</var>.<a>[[\region]]</a> to
-                <var>region</var>.
                 </li>
               </ol>
             </li>
@@ -2391,10 +2400,10 @@
             <dfn>regionCode</dfn> attribute
           </h2>
           <p data-link-for="">
-            Represents the <a>region</a> of the address as an [[!ISO3166-2]]
-            <a>country subdivision code element</a>. When getting, returns the
-            value of the <a>PaymentAddress</a>'s <a>[[\regionCode]]</a>
-            internal slot.
+            Represents the <a>region</a> of the address, but as the code
+            element of an [[!ISO3166-2]] country subdivision name (e.g., "CA"
+            for California, USA). When getting, returns the value of the
+            <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal slot.
           </p>
         </section>
         <section>
@@ -2525,10 +2534,12 @@
                 <dfn>[[\regionCode]]</dfn>
               </td>
               <td>
-                A <a>region</a> represented as a [[!ISO3166-2]] <a>country
-                subdivision code element</a> stored in its canonical uppercase
-                form, or the empty string. For example, "<code>PT-11</code>"
-                represents the Lisbon district of Portugal.
+                Either the empty string, or one to three code points that
+                represent a <a>region</a> as the code element of an
+                [[!ISO3166-2]] country subdivision name (i.e., the characters
+                after the hyphen in an ISO3166-2 <a>country subdivision code
+                element</a>, such as "CA" for the state of California in the
+                USA, or "11" for the Lisbon district of Portugal).
               </td>
             </tr>
             <tr>
@@ -2647,8 +2658,12 @@
             <dfn>regionCode</dfn> member
           </dt>
           <dd>
-            An <a>region</a>, represented as a <a>country subdivision code
-            element</a>.
+            Either the empty string, or one to three code points that represent
+            a <a>region</a> as the code element of an [[!ISO3166-2]] country
+            subdivision name (i.e., the characters after the hyphen in an
+            ISO3166-2 <a>country subdivision code element</a>, such as "CA" for
+            the state of California in the USA, or "11" for the Lisbon district
+            of Portugal)
           </dd>
           <dt>
             <dfn>city</dfn> member

--- a/index.html
+++ b/index.html
@@ -2663,7 +2663,7 @@
             subdivision name (i.e., the characters after the hyphen in an
             ISO3166-2 <a>country subdivision code element</a>, such as "CA" for
             the state of California in the USA, or "11" for the Lisbon district
-            of Portugal)
+            of Portugal).
           </dd>
           <dt>
             <dfn>city</dfn> member

--- a/index.html
+++ b/index.html
@@ -2212,7 +2212,7 @@
                 </li>
                 <li>Let <var>countrySubdivisionCodeElement</var> be the
                 concatenation of <var>address</var>.<a>[[\country]]</a>, a
-                single U+002D (-) <a>code point</a>, <var>regionCode</var>.
+                single U+002D (-) <a>code point</a>, and <var>regionCode</var>.
                 </li>
                 <li>
                   <p>

--- a/index.html
+++ b/index.html
@@ -2789,7 +2789,7 @@
               <li>Set <var>details</var>["<a>region</a>"] to the user-provided
               region, or to the empty string if none was provided.
               </li>
-              <li>If <var>details</var>["<a>region</a>"] has as a corresponding
+              <li>If <var>details</var>["<a>region</a>"] has a corresponding
               <a>country subdivision code element</a>, set
               <var>details</var>["<a>regionCode</a>"] to that <a>country
               subdivision code element</a>.

--- a/index.html
+++ b/index.html
@@ -2210,14 +2210,14 @@
                   <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>
                   the result.
                 </li>
-                <li>Let <var>countrySubdivisionCodeElement</var> be the
+                <li>Let <var>putativeCountrySubdivisionCodeElement</var> be the
                 concatenation of <var>address</var>.<a>[[\country]]</a>, a
                 single U+002D (-) <a>code point</a>, and <var>regionCode</var>.
                 </li>
                 <li>
                   <p>
-                    If <var>countrySubdivisionCodeElement</var> is not a valid
-                    <a>country subdivision code element</a> as per
+                    If <var>putativeCountrySubdivisionCodeElement</var> is not
+                    a valid <a>country subdivision code element</a> as per
                     [[!ISO3166-2]]'s section 5.2 "Structure of country
                     subdivision code elements" (non-normative details below),
                     throw a <a>RangeError</a> exception.

--- a/index.html
+++ b/index.html
@@ -2208,8 +2208,40 @@
                 "!INFRA#ascii-uppercase">ASCII uppercasing</a>
                 <var>details</var>["<a>regionCode</a>"].
                 </li>
-                <li>If <var>regionCode</var> is not a valid [[!ISO3166-2]]
-                subdivision code, throw a <a>RangeError</a> exception.
+                <li>
+                  <p>
+                    If <var>regionCode</var> is not a valid subdivision code as
+                    per [[!ISO3166-2]]'s section 5.2 Structure of country
+                    subdivision code elements (details below), throw a
+                    <a>RangeError</a> exception.
+                  </p>
+                  <div class="note" title=
+                  "Structure of country subdivision code elements">
+                    <p>
+                      The structure of country subdivision code elements is
+                      formally defined in [[!ISO3166-2]] (section 5.2).
+                      Although the structure is not expected to change at the
+                      time of writing, implementers are expected to track
+                      updates to [[!ISO3166-2]] directly from ISO.
+                    </p>
+                    <p>
+                      As [[!ISO3166-2]] is not freely available to the general
+                      public, the structure of a country subdivision code
+                      elements at the time of publication is as follow:
+                    </p>
+                    <ul>
+                      <li>Two <a>code points</a> that match an [[!ISO3166-1]]
+                      alpha-2 country code.
+                      </li>
+                      <li>A single U+002D (-) <a>code point</a>.
+                      </li>
+                      <li>One, two, or three <a data-cite=
+                      "infra#ascii-alphanumeric">ASCII alphanumeric</a> code
+                      points, in any order. This is referred to as the
+                      subdivision name.
+                      </li>
+                    </ul>
+                  </div>
                 </li>
                 <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
                 <var>regionCode</var>.
@@ -2339,8 +2371,9 @@
           </h2>
           <p data-link-for="">
             Represents the <a>region</a> of the address as an [[!ISO3166-2]]
-            code. When getting, returns the value of the
-            <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal slot.
+            country subdivision code element. When getting, returns the value
+            of the <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal
+            slot.
           </p>
         </section>
         <section>
@@ -2471,10 +2504,10 @@
                 <dfn>[[\regionCode]]</dfn>
               </td>
               <td>
-                A <a>region</a> represented as a [[!ISO3166-2]] subdivision
-                code or the empty string, stored in its canonical uppercase
-                form. For example, "<code>PT-11</code>" represents the Lisbon
-                district of Portugal.
+                A <a>region</a> represented as a [[!ISO3166-2]] country
+                subdivision code element or the empty string, stored in its
+                canonical uppercase form. For example, "<code>PT-11</code>"
+                represents the Lisbon district of Portugal.
               </td>
             </tr>
             <tr>
@@ -2593,8 +2626,8 @@
             <dfn>regionCode</dfn> member
           </dt>
           <dd>
-            An <a>region</a>, represented as an [[!ISO3166-2]] subdivision
-            code.
+            An <a>region</a>, represented as an [[!ISO3166-2]] country
+            subdivision code element.
           </dd>
           <dt>
             <dfn>city</dfn> member
@@ -2736,7 +2769,7 @@
               region, or to the empty string if none was provided.
               </li>
               <li>If <var>details</var>["<a>region</a>"] has as a corresponding
-              [[!ISO3166-2]] subdivision code, set
+              [[!ISO3166-2]] country subdivision code element, set
               <var>details</var>["<a>regionCode</a>"] to that subdivision code.
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -2204,23 +2204,23 @@
             <li>If <var>details</var>["<a>regionCode</a>"] is present and not
             the empty string:
               <ol>
-                <li>Let <var>regionPart</var> be the result of <a>strip leading
+                <li>Let <var>regionCode</var> be the result of <a>strip leading
                 and trailing ASCII whitespace</a> from
                 <var>details</var>["<a>regionCode</a>"] and then
                   <a data-cite="!INFRA#ascii-uppercase">ASCII uppercasing</a>
                   the result.
                 </li>
-                <li>Let <var>regionCode</var> be the concatenation of
-                <var>address</var>.<a>[[\country]]</a>, a single U+002D (-) <a>
-                  code point</a>, <var>regionPart</var>.
+                <li>Let <var>countrySubdivisionCodeElement</var> be the
+                concatenation of <var>address</var>.<a>[[\country]]</a>, a
+                single U+002D (-) <a>code point</a>, <var>regionCode</var>.
                 </li>
                 <li>
                   <p>
-                    If <var>regionCode</var> is not a valid <a>country
-                    subdivision code element</a> as per [[!ISO3166-2]]'s
-                    section 5.2 "Structure of country subdivision code
-                    elements" (non-normative details below), throw a
-                    <a>RangeError</a> exception.
+                    If <var>countrySubdivisionCodeElement</var> is not a valid
+                    <a>country subdivision code element</a> as per
+                    [[!ISO3166-2]]'s section 5.2 "Structure of country
+                    subdivision code elements" (non-normative details below),
+                    throw a <a>RangeError</a> exception.
                   </p>
                   <div class="note" title=
                   "Structure of country subdivision code elements">
@@ -2251,7 +2251,7 @@
                   </div>
                 </li>
                 <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
-                <var>regionPart</var>.
+                <var>regionCode</var>.
                 </li>
                 <li>If <var>details</var>["<a>region</a>"] is not present:
                   <ol>

--- a/index.html
+++ b/index.html
@@ -2248,9 +2248,9 @@
                 <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
                 <var>regionCode</var>.
                 </li>
-                <li>Let <var>region</var> be the corresponding [[!ISO3166-2]]
-                <a>country subdivision name</a> for <var>regionCode</var>.
-                Where [[!ISO3166-2]] defines multiple <a>country subdivision
+                <li>Let <var>region</var> be the corresponding <a>country
+                subdivision name</a> for <var>regionCode</var>. Where
+                [[!ISO3166-2]] defines multiple <a>country subdivision
                 names</a> for a <var>regionCode</var>, it is RECOMMENDED the
                 user agent select one by matching on:
                   <ol>

--- a/index.html
+++ b/index.html
@@ -2148,6 +2148,7 @@
             readonly attribute DOMString postalCode;
             readonly attribute DOMString recipient;
             readonly attribute DOMString region;
+            readonly attribute DOMString regionCode;
             readonly attribute DOMString sortingCode;
             readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
           };
@@ -2196,6 +2197,22 @@
                 </li>
                 <li>Set <var>address</var>.<a>[[\country]]</a> to
                 <var>country</var>.
+                </li>
+              </ol>
+            </li>
+            <li>If <var>details</var>["<a>regionCode</a>"] is present and not
+            the empty string:
+              <ol>
+                <li>Let <var>regionCode</var> be the result of <a>strip leading
+                and trailing ASCII whitespace</a> and <a data-cite=
+                "!INFRA#ascii-uppercase">ASCII uppercasing</a>
+                <var>details</var>["<a>regionCode</a>"].
+                </li>
+                <li>If <var>regionCode</var> is not a valid [[!ISO3166-2]]
+                subdivision code, throw a <a>RangeError</a> exception.
+                </li>
+                <li>Set <var>address</var>.<a>[[\regionCode]]</a> to
+                <var>regionCode</var>.
                 </li>
               </ol>
             </li>
@@ -2314,6 +2331,16 @@
             Represents the <a>region</a> of the address. When getting, returns
             the value of the <a>PaymentAddress</a>'s <a>[[\region]]</a>
             internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>regionCode</dfn> attribute
+          </h2>
+          <p data-link-for="">
+            Represents the <a>region</a> of the address as an [[!ISO3166-2]]
+            code. When getting, returns the value of the
+            <a>PaymentAddress</a>'s <a>[[\regionCode]]</a> internal slot.
           </p>
         </section>
         <section>
@@ -2441,6 +2468,17 @@
             </tr>
             <tr>
               <td>
+                <dfn>[[\regionCode]]</dfn>
+              </td>
+              <td>
+                A <a>region</a> represented as a [[!ISO3166-2]] subdivision
+                code or the empty string, stored in its canonical uppercase
+                form. For example, "<code>PT-11</code>" represents the Lisbon
+                district of Portugal.
+              </td>
+            </tr>
+            <tr>
+              <td>
                 <dfn>[[\city]]</dfn>
               </td>
               <td>
@@ -2516,6 +2554,7 @@
             DOMString country;
             sequence&lt;DOMString&gt; addressLine;
             DOMString region;
+            DOMString regionCode;
             DOMString city;
             DOMString dependentLocality;
             DOMString postalCode;
@@ -2549,6 +2588,13 @@
           </dt>
           <dd>
             A <a>region</a>.
+          </dd>
+          <dt>
+            <dfn>regionCode</dfn> member
+          </dt>
+          <dd>
+            An <a>region</a>, represented as an [[!ISO3166-2]] subdivision
+            code.
           </dd>
           <dt>
             <dfn>city</dfn> member
@@ -2684,9 +2730,16 @@
           <var>details</var>["<a>recipient</a>"] to the user-provided recipient
           of the transaction, or to the empty string if none was provided.
           </li>
-          <li>If "region" is not in <var>redactList</var>, set
-          <var>details</var>["<a>region</a>"] to the user-provided region, or
-          to the empty string if none was provided.
+          <li>If "region" is not in <var>redactList</var>:
+            <ol>
+              <li>Set <var>details</var>["<a>region</a>"] to the user-provided
+              region, or to the empty string if none was provided.
+              </li>
+              <li>If <var>details</var>["<a>region</a>"] has as a corresponding
+              [[!ISO3166-2]] subdivision code, set
+              <var>details</var>["<a>regionCode</a>"] to that subdivision code.
+              </li>
+            </ol>
           </li>
           <li>If "sortingCode" is not in <var>redactList</var>, set
           <var>details</var>["<a>sortingCode</a>"] to the user-provided sorting

--- a/index.html
+++ b/index.html
@@ -2271,8 +2271,8 @@
                         </li>
                       </ol>
                     </li>
-                    <li>
-                      <var>details</var>["<a>region</a>"] to <var>region</var>.
+                    <li>Set <var>details</var>["<a>region</a>"] to
+                    <var>region</var>.
                     </li>
                   </ol>
                 </li>
@@ -2534,12 +2534,12 @@
                 <dfn>[[\regionCode]]</dfn>
               </td>
               <td>
-                Either the empty string, or one to three code points that
-                represent a <a>region</a> as the code element of an
-                [[!ISO3166-2]] country subdivision name (i.e., the characters
-                after the hyphen in an ISO3166-2 <a>country subdivision code
-                element</a>, such as "CA" for the state of California in the
-                USA, or "11" for the Lisbon district of Portugal).
+                The empty string, or one to three code points that represent a
+                <a>region</a> as the code element of an [[!ISO3166-2]] country
+                subdivision name (i.e., the characters after the hyphen in an
+                ISO3166-2 <a>country subdivision code element</a>, such as "CA"
+                for the state of California in the USA, or "11" for the Lisbon
+                district of Portugal).
               </td>
             </tr>
             <tr>
@@ -2658,8 +2658,8 @@
             <dfn>regionCode</dfn> member
           </dt>
           <dd>
-            Either the empty string, or one to three code points that represent
-            a <a>region</a> as the code element of an [[!ISO3166-2]] country
+            The empty string, or one to three code points that represent a
+            <a>region</a> as the code element of an [[!ISO3166-2]] country
             subdivision name (i.e., the characters after the hyphen in an
             ISO3166-2 <a>country subdivision code element</a>, such as "CA" for
             the state of California in the USA, or "11" for the Lisbon district


### PR DESCRIPTION
closes w3c/contact-picker#65 

The following tasks have been completed:

 * [x] [web platform tests](https://github.com/w3c/web-platform-tests/pull/11021)
 * [x] [MDN Docs added ](https://developer.mozilla.org/en-US/docs/Web/API/PaymentAddress/regionCode) 

Implementation commitment:

 * [ ] Safari (link to issue)
 * [x] [Chrome](https://crbug.com/817960) 
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1441752)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/690.html" title="Last updated on May 16, 2018, 6:20 AM GMT (699d329)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/690/b2c32fe...699d329.html" title="Last updated on May 16, 2018, 6:20 AM GMT (699d329)">Diff</a>