### PR TITLE
PaymentOptions.shippingType definition should link to PaymentShippingType, not to itself

### DIFF
--- a/index.html
+++ b/index.html
@@ -1879,7 +1879,7 @@
           <dfn>shippingType</dfn> member
         </dt>
         <dd>
-          A <a>ShippingType</a> enum value. Some transactions require an
+          A <a>PaymentShippingType</a> enum value. Some transactions require an
           address for delivery but the term "shipping" isn't appropriate. For
           example, "pizza delivery" not "pizza shipping" and "laundry pickup"
           not "laundry shipping". If <a>requestShipping</a> is set to true,


### PR DESCRIPTION
This fixes what seems to me to be a bad link.  The definition of `PaymentOptions.shippingType` currently links to itself, when I think it intends to link to `PaymentShippingType`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/payment-request/pull/696.html" title="Last updated on Mar 23, 2018, 2:07 AM GMT (06ac673)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/696/68648b4...dbaron:06ac673.html" title="Last updated on Mar 23, 2018, 2:07 AM GMT (06ac673)">Diff</a>