### PR TITLE
Define PaymentResponse.retry() method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3143,33 +3143,40 @@
           <dfn>retry()</dfn> method
         </h2>
         <ol class="algorithm">
-          <li>Let response be the context object.
+          <li>Let <var>response</var> be the <a>context object</a>.
           </li>
-          <li>Let request be response.[[\request]].
+          <li>Let <var>request</var> be
+          <var>response</var>.<a>[[\request]]</a>.
           </li>
-          <li>If response.[[\completeCalled]] is true, throw a
-          "InvalidStateError" DOMException.
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, throw a
+          "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>If request.[[\state]] is not "closed", throw a
-          "InvalidStateError" DOMException.
+          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, throw a
+          "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>Set request.[[\state]] to "interactive".
+          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>closed</a>",
+          throw a "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>Set request.[[\retrying]] to true.
+          <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
-          <li>Let promiseToRetry be a newly created promise.
+          <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>In parallel:
+          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
+          created promise.
+          </li>
+          <li>
+            <a>In parallel</a>:
             <ol>
-              <li>If the <a>user accepts the retry</a>, resolve promiseToRetry
-              with undefined.
+              <li>Indicate to the end-user that something is wrong with the
+              data of the payment response.
+                <div class="issue" data-number="647"></div>
               </li>
-              <li>If the <a>user aborts the retry</a>, reject promiseToRetry
-              with an "AbortError" DOMException.
+              <li>Wait for the user to either <a>retry the payment</a> or
+              <a>abort retrying</a>.
               </li>
             </ol>
           </li>
-          <li>Return promiseToRetry.
+          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
           </li>
         </ol>
       </section>
@@ -3338,18 +3345,20 @@
           </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\completeCalled]]</a> is true, reject
-          <var>promise</var> with an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, reject <var>
+            promise</var> with an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
           </li>
-          <li>Otherwise, set <var>response</var>.<a>[[\completeCalled]]</a> to
-          true.
+          <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps <a>in
           parallel</a>.
           </li>
           <li>Close down any remaining user interface. The <a>user agent</a>
           MAY use the value <var>result</var> to influence the user experience.
+          </li>
+          <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
+          boolean to false.
           </li>
           <li>Resolve <var>promise</var> with undefined.
           </li>
@@ -3374,14 +3383,145 @@
           </tr>
           <tr>
             <td>
-              <dfn>[[\completeCalled]]</dfn>
+              <dfn>[[\complete]]</dfn>
             </td>
             <td>
-              true if the <a data-lt="PaymentResponse.complete">complete</a>
-              method has been called and false otherwise.
+              true if that the request for payment has completed, or false
+              otherwise.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\request]]</dfn>
+            </td>
+            <td>
+              The <a>PaymentRequest</a> instance that instantiated this
+              <a>PaymentResponse</a>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\retryPromise]]</dfn>
+            </td>
+            <td>
+              A <a>Promise</a> resolves when a user <a data-lt=
+              "retry the payment">retries the payment</a> or rejects if the
+              user <a>aborts retrying</a>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\retrying]]</dfn>
+            </td>
+            <td>
+              When true, the developer has signaled that the payment response
+              suffers from validation errors that the user needs to correct in
+              the user agent's UI.
             </td>
           </tr>
         </table>
+      </section>
+      <section>
+        <h2>
+          <code>PaymentResponse</code> algorithms
+        </h2>
+        <section>
+          <h3>
+            User retries the payment algorithm
+          </h3>
+          <p>
+            The <dfn data-lt="retry the payment">user retries the payment
+            algorithm</dfn> runs if the developer has called <a>retry()</a> and
+            the user attempts to reaccept a request for payment:
+          </p>
+          <ol class="algorithm">
+            <li>Let <var>response</var> be the <a>PaymentResponse</a>
+            <a>context object</a>.
+            </li>
+            <li>Let <var>request</var> be
+            <var>response</var><a>[[\request]]</a>.
+            </li>
+            <li>If <var>request</var>.<a>[[\updating]]</a> is true, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
+            "<a>interactive</a>", then terminate this algorithm and take no
+            further action. The <a>user agent</a> user interface SHOULD ensure
+            that this never occurs.
+            </li>
+            <li>If the <a data-lt=
+            "PaymentOptions.requestShipping">requestShipping</a> value of <var>
+              request</var>.<a>[[\options]]</a> is true, then if the
+              <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
+              attribute of <var>request</var> is null or if the <a data-lt=
+              "PaymentRequest.shippingOption">shippingOption</a> attribute of
+              <var>request</var> is null, then terminate this algorithm and
+              take no further action. The <a>user agent</a> SHOULD ensure that
+              this never occurs.
+            </li>
+            <li>
+              <a>Queue a task</a> on the <a>user interaction task source</a> to
+              perform the following steps:
+              <ol>
+                <li>Set <var>response</var>.<a>[[\retrying]]</a> to false.
+                </li>
+                <li>Set <var>request</var>.<a>[[\state]]</a> to
+                "<a>closed</a>".
+                </li>
+                <li>Resolve <var>response</var>.<a>[[\retryPromise]]</a> with
+                undefined.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h3>
+            User aborts retrying algorithm
+          </h3>
+          <p>
+            The <dfn data-lt="aborts retrying|abort retrying">user aborts
+            retrying algorithm</dfn> runs if the developer has called
+            <a>retry()</a> and the user aborts the payment request through the
+            currently interactive user interface.
+          </p>
+          <ol class="algorithm">
+            <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
+            object</a>.
+            </li>
+            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
+            "<a>interactive</a>", then terminate this algorithm and take no
+            further action. The <a>user agent</a> user interface SHOULD ensure
+            that this never occurs.
+            </li>
+            <li>
+              <a>Queue a task</a> on the <a>user interaction task source</a> to
+              perform the following steps:
+              <ol>
+                <li>Set <var>request</var>.<a>[[\state]]</a> to
+                "<a>closed</a>".
+                </li>
+                <li>Set the <a>user agent</a>'s <a>payment request is
+                showing</a> boolean to false.
+                </li>
+                <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
+                </li>
+                <li>Reject <var>request</var>.<a>[[\retryPromise]]</a> with an
+                "<a>AbortError</a>" <a>DOMException</a>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
       </section>
     </section>
     <section class="informative">
@@ -3855,12 +3995,9 @@
           "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
           SHOULD format the phone number to adhere to [[!E.164]].
           </li>
-          <li>Set <var>response</var>.<a>[[\completeCalled]]</a> to false.
+          <li>Set <var>response</var>.<a>[[\complete]]</a> to false.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
-          </li>
-          <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-          boolean to false.
           </li>
           <li>Resolve the pending promise
           <var>request</var>.<a>[[\acceptPromise]]</a> with

--- a/index.html
+++ b/index.html
@@ -3183,8 +3183,8 @@
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to
-          <var>retryPromise</var>.
+          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
+          created promise.
           </li>
           <li>
             <a>In parallel</a>:
@@ -3198,7 +3198,7 @@
               </li>
             </ol>
           </li>
-          <li>Return <var>retryPromise</var>.
+          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3531,6 +3531,9 @@
             further action. The <a>user agent</a> user interface SHOULD ensure
             that this never occurs.
             </li>
+            <li>Try to abort the current user interaction with the <a>payment
+            handler</a> and close down any remaining user interface.
+            </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               perform the following steps:

--- a/index.html
+++ b/index.html
@@ -3142,6 +3142,9 @@
         <h2>
           <dfn>retry()</dfn> method
         </h2>
+        <p data-tests="payment-response/retry-method-manual.https.html">
+          The <a>retry()</a> method MUST act as follows:
+        </p>
         <ol class="algorithm">
           <li>Let <var>response</var> be the <a>context object</a>.
           </li>
@@ -3352,9 +3355,11 @@
             promise</var> with an "<a>InvalidStateError</a>"
             <a>DOMException</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, reject <var>
-            promise</var> with an "<a>InvalidStateError</a>"
-            <a>DOMException</a>.
+          <li data-tests=
+          "payment-request/payment-response/retry-method-manual.https.html">If
+          <var>response</var>.<a>[[\retrying]]</a> is true, reject
+          <var>promise</var> with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
           <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>

--- a/index.html
+++ b/index.html
@@ -834,6 +834,8 @@
           <li>Set <var>request</var>.<a>[[\serializedMethodData]]</a> to <var>
             serializedMethodData</var>.
           </li>
+          <li>Set <var>request</var>.<a>[[\response]]</a> to null.
+          </li>
           <li>Set the value of <var>request</var>'s <a data-lt=
           "PaymentRequest.shippingOption">shippingOption</a> attribute to <var>
             selectedShippingOption</var>.
@@ -1112,9 +1114,14 @@
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>context object</a>.
           </li>
+          <li>If <var>request</var>.<a>[[\response]]</a> is not null, and <var>
+            request</var>.<a>[[\response]]</a>.<a>[[\retrying]]</a> is true,
+            return a newly created promise an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
+          </li>
           <li>If the value of <var>request</var>.<a>[[\state]]</a> is not
-          "<a>interactive</a>" then <a>throw</a> an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
+          "<a>interactive</a>" then return a newly created promise rejected
+          with an "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>
@@ -1422,6 +1429,15 @@
               The pending <a>Promise</a> created during <a data-lt=
               "PaymentRequest.show">show</a> that will be resolved if the user
               accepts the payment request.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\response]]</dfn>
+            </td>
+            <td>
+              Null, or the <a>PaymentResponse</a> instantiated by this
+              <a>PaymentRequest</a>.
             </td>
           </tr>
         </table>
@@ -3934,7 +3950,11 @@
           </li>
           <li>Let <var>response</var> be a new <a>PaymentResponse</a>.
           </li>
-          <li>Let <var>response</var>.[[\request]] be <var>request</var>.
+          <li>Let <var>response</var>.<a>[[\request]]</a> be
+          <var>request</var>.
+          </li>
+          <li>Set <var>request</var>.<a>[[\response]]</a> to
+          <var>response</var>.
           </li>
           <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
           attribute value of <var>response</var> to the value of

--- a/index.html
+++ b/index.html
@@ -3352,6 +3352,10 @@
             promise</var> with an "<a>InvalidStateError</a>"
             <a>DOMException</a>.
           </li>
+          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, reject <var>
+            promise</var> with an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
+          </li>
           <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps <a>in

--- a/index.html
+++ b/index.html
@@ -3148,21 +3148,24 @@
           <li>Let <var>request</var> be
           <var>response</var>.<a>[[\request]]</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\complete]]</a> is true, throw a
-          "<a>InvalidStateError</a>" <a>DOMException</a>.
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, return a
+          promise rejected with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
-          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, throw a
-          "<a>InvalidStateError</a>" <a>DOMException</a>.
+          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, return a
+          promise rejected with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
           <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>closed</a>",
-          throw a "<a>InvalidStateError</a>" <a>DOMException</a>.
+          return a promise rejected with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
           <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
-          created promise.
+          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to
+          <var>retryPromise</var>.
           </li>
           <li>
             <a>In parallel</a>:
@@ -3176,7 +3179,7 @@
               </li>
             </ol>
           </li>
-          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
+          <li>Return <var>retryPromise</var>.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3175,10 +3175,6 @@
           promise rejected with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
-          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>closed</a>",
-          return a promise rejected with an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
-          </li>
           <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".

--- a/index.html
+++ b/index.html
@@ -3518,22 +3518,6 @@
             <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
             object</a>.
             </li>
-            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If <var>request</var>.<a>[[\state]]</a> is not
-            "<a>interactive</a>", then terminate this algorithm and take no
-            further action. The <a>user agent</a> user interface SHOULD ensure
-            that this never occurs.
-            </li>
-            <li>Try to abort the current user interaction with the <a>payment
-            handler</a> and close down any remaining user interface.
-            </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               perform the following steps:

--- a/index.html
+++ b/index.html
@@ -1116,8 +1116,8 @@
           </li>
           <li>If <var>request</var>.<a>[[\response]]</a> is not null, and <var>
             request</var>.<a>[[\response]]</a>.<a>[[\retrying]]</a> is true,
-            return a newly created promise an "<a>InvalidStateError</a>"
-            <a>DOMException</a>.
+            return a newly created promise rejected with an
+            "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
           <li>If the value of <var>request</var>.<a>[[\state]]</a> is not
           "<a>interactive</a>" then return a newly created promise rejected

--- a/index.html
+++ b/index.html
@@ -3171,7 +3171,7 @@
           promise rejected with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
-          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, return a
+          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, return a
           promise rejected with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
@@ -3519,7 +3519,7 @@
             <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
             object</a>.
             </li>
-            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
+            <li>If the <var>response</var>.<a>[[\retrying]]</a> is false, then
             terminate this algorithm and take no further action. The <a>user
             agent</a> user interface SHOULD ensure that this never occurs.
             </li>

--- a/index.html
+++ b/index.html
@@ -3512,11 +3512,25 @@
             The <dfn data-lt="aborts retrying|abort retrying">user aborts
             retrying algorithm</dfn> runs if the developer has called
             <a>retry()</a> and the user aborts the payment request through the
-            currently interactive user interface.
+            currently interactive user interface. Aborting closes down any
+            remaining user interface.
           </p>
           <ol class="algorithm">
             <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
             object</a>.
+            </li>
+            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
+            "<a>interactive</a>", then terminate this algorithm and take no
+            further action. The <a>user agent</a> user interface SHOULD ensure
+            that this never occurs.
             </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to

--- a/index.html
+++ b/index.html
@@ -3131,12 +3131,48 @@
           readonly attribute DOMString? payerPhone;
 
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
+          Promise&lt;void&gt; retry();
         };
       </pre>
       <p class="note">
         A <a>PaymentResponse</a> is returned when a user has selected a payment
         method and approved a payment request.
       </p>
+      <section>
+        <h2>
+          <dfn>retry()</dfn> method
+        </h2>
+        <ol class="algorithm">
+          <li>Let response be the context object.
+          </li>
+          <li>Let request be response.[[\request]].
+          </li>
+          <li>If response.[[\completeCalled]] is true, throw a
+          "InvalidStateError" DOMException.
+          </li>
+          <li>If request.[[\state]] is not "closed", throw a
+          "InvalidStateError" DOMException.
+          </li>
+          <li>Set request.[[\state]] to "interactive".
+          </li>
+          <li>Set request.[[\retrying]] to true.
+          </li>
+          <li>Let promiseToRetry be a newly created promise.
+          </li>
+          <li>In parallel:
+            <ol>
+              <li>If the <a>user accepts the retry</a>, resolve promiseToRetry
+              with undefined.
+              </li>
+              <li>If the <a>user aborts the retry</a>, reject promiseToRetry
+              with an "AbortError" DOMException.
+              </li>
+            </ol>
+          </li>
+          <li>Return promiseToRetry.
+          </li>
+        </ol>
+      </section>
       <section>
         <h2>
           <dfn>toJSON()</dfn> method
@@ -3745,6 +3781,8 @@
             occurs.
           </li>
           <li>Let <var>response</var> be a new <a>PaymentResponse</a>.
+          </li>
+          <li>Let <var>response</var>.[[\request]] be <var>request</var>.
           </li>
           <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
           attribute value of <var>response</var> to the value of


### PR DESCRIPTION
part of #705 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Added Web platform tests](https://github.com/w3c/web-platform-tests/pull/11101)
 * [ ] added MDN Docs (link)

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1435161) - currently P3 bug
 * [ ] Edge (public signal)

Impact on Payment Handler spec?

Unknown. 

## Example
This pull request gets us here... the user doesn't yet know what's actually wrong with the payment, but at least they know something is wrong. 

```JS
async function doPaymentRequest() {
  const request = new PaymentRequest(methodData, details, options);
  const response = await request.show();
  try {
    await recursiveValidate(request, response);
  } catch (err) { // retry aborted.
    console.error(err);
    return;
  }
  await response.complete("success");
}

async function recursiveValidate(request, response) {
  const promisesToFixThings = [];
  const errors = await validate(request, response);
  if (!errors) {
    return;
  }
  await response.retry();
  return recursiveValidate(request, response);
}

doPaymentRequest();
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/715.html" title="Last updated on Jun 6, 2018, 5:18 AM GMT (80f58a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/715/04d996f...80f58a2.html" title="Last updated on Jun 6, 2018, 5:18 AM GMT (80f58a2)">Diff</a>