### PR TITLE
editorial: small non-normative bug fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@
             <ol>
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
-                <a>Check and canonicalize total</a>
+                <a>Check and canonicalize total amount</a>
                 <var>details</var>.<a>total</a>.<a data-lt=
                 "PaymentItem.amount">amount</a>. Rethrow any exceptions.
               </li>
@@ -680,13 +680,11 @@
               <li>If the <a>shippingOptions</a> member of <var>details</var> is
               present, then:
                 <ol data-link-for="PaymentShippingOption">
-                  <li>Let <var>seenIDs</var> be an empty list.
+                  <li>Let <var>seenIDs</var> be an empty set.
                   </li>
-                  <li>Set <var>options</var> to
+                  <li>For each <var>option</var> in
                   <var>details</var>.<a data-link-for=
-                  "PaymentDetailsBase">shippingOptions</a>.
-                  </li>
-                  <li>For each <var>option</var> in <var>options</var>:
+                  "PaymentDetailsBase">shippingOptions</a>:
                     <ol>
                       <li data-tests=
                       "payment-request-ctor-currency-code-checks.https.html">
@@ -703,10 +701,6 @@
                       <li>Otherwise, append <var>option</var>.<a>id</a> to
                       <var>seenIDs</var>.
                       </li>
-                    </ol>
-                  </li>
-                  <li>For each <var>option</var> in <var>options</var>:
-                    <ol>
                       <li>If <var>option</var>.<a>selected</a> is true, then
                       set <var>selectedShippingOption</var> to
                       <var>option</var>.<a>id</a>.
@@ -743,7 +737,7 @@
                         <ol>
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
-                            <a>Check and canonicalize total</a>
+                            <a>Check and canonicalize total amount</a>
                             <var>modifier</var>.<a data-lt=
                             "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>.
                             Rethrow any exceptions.
@@ -988,9 +982,6 @@
           If <var>detailsPromise</var> was passed, then:
             <ol>
               <li>Set <var>request</var>.<a>[[\updating]]</a> to true.
-              </li>
-              <li>Disable the user interface user interface that will allow the
-              user to interact with the <var>handlers</var>
               </li>
               <li>Run the <a>update a <code>PaymentRequest</code>'s details
               algorithm</a> with <var>detailsPromise</var> and
@@ -1548,14 +1539,9 @@
           steps:
         </p>
         <ol data-link-for="PaymentCurrencyAmount">
-          <li>Let <var>isValidCurrency</var> be the result of calling
-          <a data-cite=
-          "!ecma-402#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a>
-          abstract operation with <var>amount</var>.<a>currency</a> as the
-          argument.
-          </li>
-          <li>If <var>isValidCurrency</var> is false, then throw a
-          <a>RangeError</a> exception and terminate this algorithm, optionally
+          <li>If the result of <a data-cite=
+          "!ecma-402#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a>(<var>amount</var>.<a>currency</a>)
+          is false, then throw a <a>RangeError</a> exception, optionally
           informing the developer that the currency is invalid.
           </li>
           <li>If <var>amount</var>.<a>value</a> is not a <a>valid decimal
@@ -1568,8 +1554,8 @@
           </li>
         </ol>
         <p>
-          To <dfn>check and canonicalize total</dfn> given a
-          <a>PaymentCurrencyAmount</a> <var>total</var>, run the following
+          To <dfn>check and canonicalize total amount</dfn> given a
+          <a>PaymentCurrencyAmount</a> <var>amount</var>, run the following
           steps:
         </p>
         <ol data-link-for="PaymentCurrencyAmount">
@@ -1577,9 +1563,9 @@
             <a>Check and canonicalize amount</a> <var>amount</var>. Rethrow any
             exceptions.
           </li>
-          <li>If the first <a>code point</a> of <var>value</var> is U+002D (-),
-          then throw a <a>TypeError</a> optionally informing the developer that
-          a total can't be a negative number.
+          <li>If the first <a>code point</a> of <var>amount</var>.<a>value</a>
+          is U+002D (-), then throw a <a>TypeError</a> optionally informing the
+          developer that a total's value can't be a negative number.
           </li>
         </ol>
         <aside class="note" title="No alteration of values">
@@ -3319,7 +3305,8 @@
           </aside>
           <p data-tests=
           "payment-request-update-event-updatewith-method.https.html, PaymentRequestUpdateEvent/updateWith-incremental-update-manual.https.html">
-            The <a>updateWith(detailsPromise)</a> method MUST act as follows:
+            The <a><code>updateWith(<var>detailsPromise</var>)</code></a>
+            method MUST act as follows:
           </p>
           <ol class="algorithm">
             <li>Let <var>event</var> be this <a>PaymentRequestUpdateEvent</a>
@@ -3333,8 +3320,10 @@
               throw</a> an "<a>InvalidStateError</a>" <a>DOMException</a>.
             </li>
             <li>Let <var>request</var> be the value of <var>event</var>'s
-            <code><a data-cite="DOM#dom-event-target">target</a></code>
-            attribute.
+            <a data-cite="DOM#event-target">target</a>.
+            </li>
+            <li>Assert: <var>request</var> is an instance of
+            <a>PaymentRequest</a>.
             </li>
             <li>If <var>request</var>.<a>[[\state]]</a> is not
             "<a>interactive</a>", then <a>throw</a> an
@@ -3349,13 +3338,6 @@
             <li>Set <var>event</var>.<a>[[\waitForUpdate]]</a> to true.
             </li>
             <li>Set <var>request</var>.<a>[[\updating]]</a> to true.
-            </li>
-            <li>The <a>user agent</a> SHOULD disable the user interface that
-            allows the user to accept the payment request. This is to ensure
-            that the payment is not accepted until developers have made changes
-            required by the change. Developers MUST settle the
-            <var>detailsPromise</var> to indicate that the payment request is
-            valid again.
             </li>
             <li>Run the <a>update a <code>PaymentRequest</code>'s details
             algorithm</a> with <var>detailsPromise</var> and
@@ -3707,11 +3689,17 @@
         </p>
         <ol class="algorithm">
           <li>
+            <a>In parallel</a>, disable the user interface that allows the user
+            to accept the payment request. This is to ensure that the payment
+            is not accepted until the user interface is updated with any new
+            details.
+          </li>
+          <li>
             <a>Upon rejection</a> of <var>detailsPromise</var>:
             <ol>
               <li>
-                <a>Abort the update</a> with an "<a>AbortError</a>"
-                <a>DOMException</a>.
+                <a>Abort the update</a> with <var>request</var> and an
+                "<a>AbortError</a>" <a>DOMException</a>.
               </li>
             </ol>
           </li>
@@ -3722,7 +3710,8 @@
               <li>Let <var>details</var> be the result of <a data-cite=
               "!WEBIDL#es-dictionary">converting</a> <var>value</var> to a <a>
                 PaymentDetailsUpdate</a> dictionary. If this <a>throws</a> an
-                exception, <a>abort the update</a> with the thrown exception.
+                exception, <a>abort the update</a> with <var>request</var> and
+                with the thrown exception.
               </li>
               <li>Let <var>serializedModifierData</var> be an empty list.
               </li>
@@ -3737,11 +3726,11 @@
                   member of <var>details</var> is present, then:
                     <ol>
                       <li>
-                        <a>Check and canonicalize total</a>
+                        <a>Check and canonicalize total amount</a>
                         <var>details</var>.<a>total</a>.<a data-lt=
                         "PaymentItem.amount">amount</a>. If an exception is
-                        thrown, then <a>abort the update</a> with that
-                        exception.
+                        thrown, then <a>abort the update</a> with
+                        <var>request</var> and that exception.
                       </li>
                     </ol>
                   </li>
@@ -3753,8 +3742,8 @@
                         <a>Check and canonicalize amount</a>
                         <var>item</var>.<a data-lt=
                         "PaymentItem.amount">amount</a>. If an exception is
-                        thrown, then <a>abort the update</a> with that
-                        exception.
+                        thrown, then <a>abort the update</a> with
+                        <var>request</var> and that exception.
                       </li>
                     </ol>
                   </li>
@@ -3764,37 +3753,32 @@
                   "PaymentOptions.requestShipping">requestShipping</a> is true,
                   then:
                     <ol>
-                      <li>Set <var>shippingOptions</var> to
-                      <var>details</var>.<a>shippingOptions</a>.
-                      </li>
-                      <li>Let <var>seenIDs</var> be an empty list.
+                      <li>Let <var>seenIDs</var> be an empty set.
                       </li>
                       <li>For each <var>option</var> in
-                      <var>shippingOptions</var>:
+                      <var>details</var>.<a>shippingOptions</a>:
                         <ol>
                           <li>
                             <a>Check and canonicalize amount</a>
                             <var>option</var>.<a data-lt=
                             "PaymentShippingOption.amount">amount</a>. If an
                             exception is thrown, then <a>abort the update</a>
-                            with that exception.
+                            with <var>request</var> and that exception.
                           </li>
                           <li data-tests=
                           "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
-                          If <var>seenIDs</var> contains
-                          <var>option</var>.<a data-lt=
-                          "PaymentShippingOption.id">id</a>, then <a>abort the
-                          update</a> with a <a>TypeError</a>.
+                          If <var>seenIDs</var>[<var>option</var>.<a data-lt=
+                          "PaymentShippingOption.id">id</a>] exists, then
+                          <a>abort the update</a> with <var>request</var> and a
+                          <a>TypeError</a>.
                           </li>
-                          <li>Otherwise, append <var>option</var>.<a data-lt=
+                          <li>Append <var>option</var>.<a data-lt=
                           "PaymentShippingOption.id">id</a> to
                           <var>seenIDs</var>.
                           </li>
-                        </ol>
-                      </li>
-                      <li>For each <var>option</var> in
-                      <var>shippingOptions</var>:
-                        <ol>
+                          <li>Append <var>option</var> to
+                          <var>shippingOptions</var>.
+                          </li>
                           <li>If <var>option</var>.<a data-lt=
                           "PaymentShippingOption.selected">selected</a> is
                           true, then set <var>selectedShippingOption</var> to
@@ -3825,19 +3809,20 @@
                             <var>modifier</var>.<a data-lt=
                             "PaymentDetailsModifier.supportedMethods">supportedMethods</a>.
                             If it returns false, then <a>abort the update</a>
-                            with a <a>RangeError</a> exception. Optional,
-                            inform the developer that the payment method
-                            identifier is invalid.
+                            with <var>request</var> and a <a>RangeError</a>
+                            exception. Optionally, inform the developer that
+                            the payment method identifier is invalid.
                           </li>
                           <li>If the <a>total</a> member of <var>modifier</var>
                           is present, then:
                             <ol>
                               <li>
-                                <a>Check and canonicalize total</a>
+                                <a>Check and canonicalize total amount</a>
                                 <var>modifier</var>.<a>total</a>.<a data-lt=
                                 "PaymentItem.amount">amount</a>. If an
                                 exception is thrown, then <a>abort the
-                                update</a> with that exception.
+                                update</a> with <var>request</var> and that
+                                exception.
                               </li>
                             </ol>
                           </li>
@@ -3851,7 +3836,8 @@
                                 <var>item</var>.<a data-lt=
                                 "PaymentItem.amount">amount</a>. If an
                                 exception is thrown, then <a>abort the
-                                update</a> with that exception.
+                                update</a> with <var>request</var> and that
+                                exception.
                               </li>
                             </ol>
                           </li>
@@ -3863,8 +3849,8 @@
                             <var>modifier</var>.<a data-lt=
                             "PaymentDetailsModifier.data">data</a> into a
                             string. If <a>JSON-serializing</a> throws an
-                            exception, then <a>abort the update</a> with that
-                            exception.
+                            exception, then <a>abort the update</a> with
+                            <var>request</var> and that exception.
                           </li>
                           <li>Add <var>serializedData</var> to
                           <var>serializedModifierData</var>.
@@ -3948,35 +3934,45 @@
               </li>
             </ol>
           </li>
-          <li>In either case, run the following steps, after either the upon
-          rejection or upon fulfillment steps have concluded:
-            <ol>
-              <li>Set <var>request</var>.<a>[[\updating]]</a> to false.
-              </li>
-              <li>The <a>user agent</a> SHOULD update the user interface based
-              on any changed values in <var>request</var>. If appropriate, the
-              user agent SHOULD re-enable user interface elements that might
-              have been disabled prior to running this algorithm.
-              </li>
-            </ol>
+          <li>Set <var>request</var>.<a>[[\updating]]</a> to false.
+          </li>
+          <li>Update the user interface based on any changed values in
+          <var>request</var>. Re-enable user interface elements disabled prior
+          to running this algorithm.
           </li>
         </ol>
-        <p>
-          If any of the above steps say to <dfn>abort the update</dfn> with an
-          exception <var>exception</var>, then:
-        </p>
-        <ol>
-          <li>Abort the current user interaction and close down any remaining
-          user interface.
-          </li>
-          <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
-          </li>
-          <li>Reject the promise <var>request</var>.<a>[[\acceptPromise]]</a>
-          with <var>exception</var>.
-          </li>
-          <li>Abort the algorithm.
-          </li>
-        </ol>
+        <section>
+          <h2>
+            Abort the update
+          </h2>
+          <p>
+            To <dfn>abort the update</dfn> with a <a>PaymentRequest</a>
+            <var>request</var> and <a data-cite=
+            "WEBIDL#dfn-exception">exception</a> <var>exception</var>:
+          </p>
+          <ol class="algorithm">
+            <li>Abort the current user interaction and close down any remaining
+            user interface.
+            </li>
+            <li>
+              <a>Queue a task</a> on the <a>user interaction task source</a> to
+              perform the following steps:
+              <ol>
+                <li>Set <var>request</var>.<a>[[\state]]</a> to
+                "<a>closed</a>".
+                </li>
+                <li>Reject the promise
+                <var>request</var>.<a>[[\acceptPromise]]</a> with
+                <var>exception</var>.
+                </li>
+                <li>Set <var>request</var>.<a>[[\updating]]</a> to false.
+                </li>
+              </ol>
+            </li>
+            <li>Abort the algorithm.
+            </li>
+          </ol>
+        </section>
         <div class="note">
           <p>
             <a data-lt="abort the update">Aborting the update</a> is performed


### PR DESCRIPTION
Editorial fixes:
 
 * use a set, not a list, for seenIDs (makes the language a little nicer). 
 * remove redundant variables. 
 * call IsWellFormedCurrencyCode() is the same way as the ES spec.
 * rename some variables, as they were ambiguous.  
 * puts Abort the update into its own section. 
 * Make it clear that "update a PaymentRequest's details algorithm" is running in parallel and let that algorithm control disabling the UI.
 * Fix buggy "update a PaymentRequest's details algorithm" step "In either case".  Abort the update now handles state changes to request, and then can say "Abort the algorithm." Similarly, if update succeeds, then now it's just handled directly 👌


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/719.html" title="Last updated on May 30, 2018, 10:57 AM GMT (67a24ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/719/80638c5...67a24ba.html" title="Last updated on May 30, 2018, 10:57 AM GMT (67a24ba)">Diff</a>