### PR TITLE
Retry request abort the update

### DIFF
--- a/index.html
+++ b/index.html
@@ -3239,10 +3239,10 @@
           </li>
           <li>Return <var>retryPromise</var>.
             <p class="note">
-              The <var>retryPromise</var> will later be resolved or rejected by
-              either the <a>user accepts the payment request algorithm</a> or
-              the <a>user aborts the payment request algorithm</a>, which are
-              triggered through interaction with the user interface.
+              The <var>retryPromise</var> will later be resolved by the <a>user
+              accepts the payment request algorithm</a>, or rejected by either
+              the <a>user aborts the payment request algorithm</a> or <a>abort
+              the update</a>.
             </p>
           </li>
         </ol>
@@ -4218,10 +4218,15 @@
           <li>Let <var>response</var> be
           <var>request</var>.<a>[[\response]]</a>.
           </li>
-          <li>If <var>response</var> not null:
+          <li>If <var>response</var> is not null:
             <ol>
+              <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
+              </li>
+              <li>Assert: <var>response</var>.<a>[[\retryPromise]]</a> is not
+              null.
+              </li>
               <li>Reject <var>response</var>.<a>[[\retryPromise]]</a> with
-              <var>error</var>
+              <var>error</var>.
               </li>
             </ol>
           </li>
@@ -4546,16 +4551,18 @@
                 <li>Set <var>request</var>.<a>[[\state]]</a> to
                 "<a>closed</a>".
                 </li>
-                <li>If <var>request</var><a>[[\response]]</a> is not null,
-                then:
+                <li>Let <var>response</var> be
+                <var>request</var>.<a>[[\response]]</a>.
+                </li>
+                <li>If <var>response</var> is not null, then:
                   <ol>
-                    <li>Let <var>response</var> be
-                    <var>request</var><a>[[\response]]</a>.
+                    <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
                     </li>
-                    <li>Set <var>response</var><a>[[\complete]]</a> to true.
+                    <li>Assert: <var>response</var>.<a>[[\retryPromise]]</a> is
+                    not null.
                     </li>
-                    <li>Reject <var>response</var><a>[[\retryPromise]]</a> with
-                    <var>exception</var>.
+                    <li>Reject <var>response</var>.<a>[[\retryPromise]]</a>
+                    with <var>exception</var>.
                     </li>
                   </ol>
                 </li>
@@ -4579,10 +4586,18 @@
             fulfillment value containing invalid data. This would potentially
             leave the payment request in an inconsistent state since the
             developer hasn't successfully handled the change event.
+          </p>
+          <p>
             Consequently, the <a>PaymentRequest</a> moves to a "<a>closed</a>"
             state. The error is signaled to the developer through the rejection
             of the <a>[[\acceptPromise]]</a>, i.e., the promise returned by
             <a data-lt="PaymentRequest.show">show()</a>.
+          </p>
+          <p data-link-for="PaymentResponse">
+            Similarly, aborting the update occurs during a <a>retry()</a>, will
+            cause the <a>[[\retryPromise]]</a> to reject, and the corresponding
+            <a>PaymentRequest</a> is put into a "<a>complete</a>" state (i.e.,
+            meaning it can no longer be used).
           </p>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -4546,7 +4546,20 @@
                 <li>Set <var>request</var>.<a>[[\state]]</a> to
                 "<a>closed</a>".
                 </li>
-                <li>Reject the promise
+                <li>If <var>request</var><a>[[\response]]</a> is not null,
+                then:
+                  <ol>
+                    <li>Let <var>response</var> be
+                    <var>request</var><a>[[\response]]</a>.
+                    </li>
+                    <li>Set <var>response</var><a>[[\complete]]</a> to true.
+                    </li>
+                    <li>Reject <var>response</var><a>[[\retryPromise]]</a> with
+                    <var>exception</var>.
+                    </li>
+                  </ol>
+                </li>
+                <li>Otherwise, reject
                 <var>request</var>.<a>[[\acceptPromise]]</a> with
                 <var>exception</var>.
                 </li>

--- a/index.html
+++ b/index.html
@@ -4595,7 +4595,7 @@
             <a data-lt="PaymentRequest.show">show()</a>.
           </p>
           <p data-link-for="PaymentResponse">
-            Similarly, aborting the update occurs during a <a>retry()</a>, will
+            Similarly, aborting the update occurs during a <a>retry()</a> will
             cause the <a>[[\retryPromise]]</a> to reject, and the corresponding
             <a>PaymentRequest</a>'s <a>[[\complete]]</a> internal slot will be
             set to true (i.e., meaning it can no longer be used).

--- a/index.html
+++ b/index.html
@@ -4596,8 +4596,8 @@
           <p data-link-for="PaymentResponse">
             Similarly, aborting the update occurs during a <a>retry()</a>, will
             cause the <a>[[\retryPromise]]</a> to reject, and the corresponding
-            <a>PaymentRequest</a> is put into a "<a>complete</a>" state (i.e.,
-            meaning it can no longer be used).
+            <a>PaymentRequest</a>'s <a>[[\complete]]</a> internal slot will be
+            set to true (i.e., meaning it can no longer be used).
           </p>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -4581,12 +4581,12 @@
         </section>
         <div class="note">
           <p>
-            <a data-lt="abort the update">Aborting the update</a> is performed
-            when there is a fatal error updating the payment request, such as
-            the supplied <var>detailsPromise</var> rejecting, or its
-            fulfillment value containing invalid data. This would potentially
-            leave the payment request in an inconsistent state since the
-            developer hasn't successfully handled the change event.
+            <a>Abort the update</a> runs when there is a fatal error updating
+            the payment request, such as the supplied <var>detailsPromise</var>
+            rejecting, or its fulfillment value containing invalid data. This
+            would potentially leave the payment request in an inconsistent
+            state since the developer hasn't successfully handled the change
+            event.
           </p>
           <p>
             Consequently, the <a>PaymentRequest</a> moves to a "<a>closed</a>"
@@ -4595,10 +4595,10 @@
             <a data-lt="PaymentRequest.show">show()</a>.
           </p>
           <p data-link-for="PaymentResponse">
-            Similarly, aborting the update occurs during a <a>retry()</a> will
-            cause the <a>[[\retryPromise]]</a> to reject, and the corresponding
-            <a>PaymentRequest</a>'s <a>[[\complete]]</a> internal slot will be
-            set to true (i.e., meaning it can no longer be used).
+            Similarly, <a>abort the update</a> occurring during <a>retry()</a>
+            causes the <a>[[\retryPromise]]</a> to reject, and the
+            corresponding <a>PaymentRequest</a>'s <a>[[\complete]]</a> internal
+            slot will be set to true (i.e., it can no longer be used).
           </p>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -3546,7 +3546,8 @@
             </td>
             <td data-link-for="PaymentResponse">
               Is true if the request for payment has completed (i.e.,
-              <a>complete()</a> was called), or false otherwise.
+              <a>complete()</a> was called, or there was a fatal error that
+              made the response not longer usable), or false otherwise.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
part 3 of #705 - aborting the update when in retry state

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Added Web platform tests](https://github.com/web-platform-tests/wpt/pull/11101/commits/9f479ea1e137a1744e767eae4d10a5bb158166e8) 
 * [ ] added MDN Docs (link)

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)

Impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/723.html" title="Last updated on Jun 22, 2018, 8:23 PM GMT (5f7a7f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/723/9470b78...5f7a7f8.html" title="Last updated on Jun 22, 2018, 8:23 PM GMT (5f7a7f8)">Diff</a>