### PR TITLE
Add PaymentResponse.prototype.onpayerdetailchange 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3850,7 +3850,7 @@
             "DOM#event-target">target</a> is an instance of
             <a>PaymentResponse</a>, let <var>request</var> be
             <var>event</var>'s <a data-cite=
-            "DOM#event-target">target</a><a>[[\request]]</a>.
+            "DOM#event-target">target</a>.<a>[[\request]]</a>.
             </li>
             <li>Otherwise, let <var>request</var> be the value of
             <var>event</var>'s <a data-cite="DOM#event-target">target</a>.
@@ -4021,6 +4021,75 @@
           identifier</a> of the <a>payment handler</a> the user is interacting
           with:
         </p>
+                <ol class="algorithm">
+          <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
+          the user is interacting with.
+          </li>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            run the following steps:
+            <ol>
+              <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false.
+              Only one update can take place at a time.
+              </li>
+              <li>Assert: <var>request</var>.<a>[[\state]]</a> is
+              "<a>interactive</a>".
+              </li>
+              <li data-link-for="PaymentMethodChangeEvent">
+                <a>Fire an event</a> named "<a>paymentmethodchange</a>" at
+                <var>request</var> using <a>PaymentMethodChangeEvent</a>, with
+                its <a>methodName</a> attribute initialized to
+                <var>methodName</var>, and its <a>methodDetails</a> attribute
+                initialized to <var>methodDetails</var>.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          PaymentRequest updated algorithm
+        </h2>
+        <p data-tests="algorithms-manual.https.html">
+          The <dfn>PaymentRequest updated algorithm</dfn> is run by other
+          algorithms above to <a>fire an event</a> to indicate that a user has
+          made a change to a <a>PaymentRequest</a> called <var>request</var>
+          with an event name of <var>name</var>:
+        </p>
+        <ol class="algorithm">
+          <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false. Only
+          one update can take place at a time.
+          </li>
+          <li>Assert: <var>request</var>.<a>[[\state]]</a> is
+          "<a>interactive</a>".
+          </li>
+          <li>Let <var>event</var> be the result of <a data-cite=
+          "!DOM#concept-event-create">creating an event</a> using the
+          <a>PaymentRequestUpdateEvent</a> interface.
+          </li>
+          <li>Initialize <var>event</var>'s <code><a data-cite=
+          "!DOM#dom-event-type">type</a></code> attribute to <var>name</var>.
+          </li>
+          <li>
+            <a data-cite="!DOM#concept-event-dispatch">Dispatch</a>
+            <var>event</var> at <var>request</var>.
+          </li>
+          <li data-link-for="PaymentRequestUpdateEvent">If
+          <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any part
+          of the user interface that could cause another update event to be
+          fired.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          Payer detail changed algorithm
+        </h2>
+        <p>
+          The user agent MUST run the <dfn>payer detail changed algorithm</dfn>
+          when the user changes the <var>payer name</var>, or the <var>payer
+          email</var>, or the <var>payer phone</var> in the user interface:
+        </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
@@ -4089,75 +4158,6 @@
               <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any
               part of the user interface that could cause another update event
               to be fired.
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2>
-          PaymentRequest updated algorithm
-        </h2>
-        <p data-tests="algorithms-manual.https.html">
-          The <dfn>PaymentRequest updated algorithm</dfn> is run by other
-          algorithms above to <a>fire an event</a> to indicate that a user has
-          made a change to a <a>PaymentRequest</a> called <var>request</var>
-          with an event name of <var>name</var>:
-        </p>
-        <ol class="algorithm">
-          <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false. Only
-          one update can take place at a time.
-          </li>
-          <li>Assert: <var>request</var>.<a>[[\state]]</a> is
-          "<a>interactive</a>".
-          </li>
-          <li>Let <var>event</var> be the result of <a data-cite=
-          "!DOM#concept-event-create">creating an event</a> using the
-          <a>PaymentRequestUpdateEvent</a> interface.
-          </li>
-          <li>Initialize <var>event</var>'s <code><a data-cite=
-          "!DOM#dom-event-type">type</a></code> attribute to <var>name</var>.
-          </li>
-          <li>
-            <a data-cite="!DOM#concept-event-dispatch">Dispatch</a>
-            <var>event</var> at <var>request</var>.
-          </li>
-          <li data-link-for="PaymentRequestUpdateEvent">If
-          <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any part
-          of the user interface that could cause another update event to be
-          fired.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h2>
-          Payer detail changed algorithm
-        </h2>
-        <p>
-          The user agent MUST run the <dfn>payer detail changed algorithm</dfn>
-          when the user changes the <var>payer name</var>, or the <var>payer
-          email</var>, or the <var>payer phone</var> in the user interface:
-        </p>
-        <ol class="algorithm">
-          <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
-          the user is interacting with.
-          </li>
-          <li>
-            <a>Queue a task</a> on the <a>user interaction task source</a> to
-            run the following steps:
-            <ol>
-              <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false.
-              Only one update can take place at a time.
-              </li>
-              <li>Assert: <var>request</var>.<a>[[\state]]</a> is
-              "<a>interactive</a>".
-              </li>
-              <li data-link-for="PaymentMethodChangeEvent">
-                <a>Fire an event</a> named "<a>paymentmethodchange</a>" at
-                <var>request</var> using <a>PaymentMethodChangeEvent</a>, with
-                its <a>methodName</a> attribute initialized to
-                <var>methodName</var>, and its <a>methodDetails</a> attribute
-                initialized to <var>methodDetails</var>.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -4021,7 +4021,7 @@
           identifier</a> of the <a>payment handler</a> the user is interacting
           with:
         </p>
-                <ol class="algorithm">
+        <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
@@ -4094,8 +4094,7 @@
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
-          <li>If <var>request</var>.<a>[[\response]]</a> is null, terminate
-          this algorithm.
+          <li>If <var>request</var>.<a>[[\response]]</a> is null, return.
           </li>
           <li>Let <var>response</var> be
           <var>request</var>.<a>[[\response]]</a>.
@@ -4109,34 +4108,31 @@
               <li>Assert: <var>request</var>.<a>[[\state]]</a> is
               "<a>interactive</a>".
               </li>
-              <li>If <var>payer name</var> changed:
+              <li>Let <var>options</var> be
+              <var>request</var>.<a>[[\options]]</a>.
+              </li>
+              <li>If <var>payer name</var> changed and
+              <var>options</var>.<a data-link-for=
+              "PaymentOptions">requestPayerName</a> is true:
                 <ol>
-                  <li data-link-for="PaymentOptions">Assert:
-                  <var>request</var>.<a>[[\options]]</a>.<a>requestPayerName</a>
-                  is true.
-                  </li>
                   <li>Set <var>response</var>'s <a>payerName</a> attribute to
                   <var>payer name</var>.
                   </li>
                 </ol>
               </li>
-              <li>If <var>payer email</var> changed:
+              <li>If <var>payer email</var> changed and
+              <var>options</var>.<a data-link-for=
+              "PaymentOptions">requestPayerEmail</a> is true:
                 <ol>
-                  <li data-link-for="PaymentOptions">Assert:
-                  <var>request</var>.<a>[[\options]]</a>.<a>requestPayerEmail</a>
-                  is true.
-                  </li>
                   <li>Set <var>response</var>'s <a>payerEmail</a> attribute to
                   <var>payer email</var>.
                   </li>
                 </ol>
               </li>
-              <li>If <var>payer phone</var> changed:
+              <li>If <var>payer phone</var> changed and
+              <var>options</var>.<a data-link-for=
+              "PaymentOptions">requestPayerPhone</a> is true:
                 <ol>
-                  <li data-link-for="PaymentOptions">Assert:
-                  <var>request</var>.<a>[[\options]]</a>.<a>requestPayerPhone</a>
-                  is true.
-                  </li>
                   <li>Set <var>response</var>'s <a>payerPhone</a> attribute to
                   <var>payer phone</var>.
                   </li>
@@ -4156,8 +4152,8 @@
               </li>
               <li data-link-for="PaymentRequestUpdateEvent">If
               <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any
-              part of the user interface that could cause another update event
-              to be fired.
+              part of the user interface that could cause another change to the
+              payer details to be fired.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -4025,11 +4025,11 @@
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
-          <li>If <var>request</var><a>[[\response]]</a> is null, terminate this
-          algorithm.
+          <li>If <var>request</var>.<a>[[\response]]</a> is null, terminate
+          this algorithm.
           </li>
           <li>Let <var>response</var> be
-          <var>request</var><a>[[\response]]</a>.
+          <var>request</var>.<a>[[\response]]</a>.
           </li>
           <li>
             <a>Queue a task</a> on the <a>user interaction task source</a> to
@@ -4043,7 +4043,7 @@
               <li>If <var>payer name</var> changed:
                 <ol>
                   <li data-link-for="PaymentOptions">Assert:
-                  <var>request</var><a>[[\options]]</a>.<a>requestPayerName</a>
+                  <var>request</var>.<a>[[\options]]</a>.<a>requestPayerName</a>
                   is true.
                   </li>
                   <li>Set <var>response</var>'s <a>payerName</a> attribute to
@@ -4054,7 +4054,7 @@
               <li>If <var>payer email</var> changed:
                 <ol>
                   <li data-link-for="PaymentOptions">Assert:
-                  <var>request</var><a>[[\options]]</a>.<a>requestPayerEmail</a>
+                  <var>request</var>.<a>[[\options]]</a>.<a>requestPayerEmail</a>
                   is true.
                   </li>
                   <li>Set <var>response</var>'s <a>payerEmail</a> attribute to
@@ -4065,7 +4065,7 @@
               <li>If <var>payer phone</var> changed:
                 <ol>
                   <li data-link-for="PaymentOptions">Assert:
-                  <var>request</var><a>[[\options]]</a>.<a>requestPayerPhone</a>
+                  <var>request</var>.<a>[[\options]]</a>.<a>requestPayerPhone</a>
                   is true.
                   </li>
                   <li>Set <var>response</var>'s <a>payerPhone</a> attribute to

--- a/index.html
+++ b/index.html
@@ -3152,7 +3152,7 @@
       </h2>
       <pre class="idl">
         [SecureContext, Exposed=Window]
-        interface PaymentResponse {
+        interface PaymentResponse : EventTarget  {
           [Default] object toJSON();
 
           readonly attribute DOMString requestId;
@@ -3166,6 +3166,8 @@
 
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
           Promise&lt;void&gt; retry(PaymentValidationErrors errorFields);
+
+          attribute EventHandler onpayerdetailchange;
         };
       </pre>
       <p class="note">
@@ -3523,6 +3525,14 @@
           </li>
         </ol>
       </section>
+      <section data-dfn-for="PaymentResponse" data-link-for="PaymentResponse">
+        <h2>
+          <dfn>onpayerdetailchange</dfn> attribute
+        </h2>
+        <p>
+          Allows a developer to handle "<a>payerdetailchange</a>" events.
+        </p>
+      </section>
       <section>
         <h2>
           Internal Slots
@@ -3602,6 +3612,9 @@
             <th>
               Dispatched when…
             </th>
+            <th>
+              Target
+            </th>
           </tr>
           <tr>
             <td>
@@ -3613,6 +3626,9 @@
             <td>
               The user provides a new shipping address.
             </td>
+            <td>
+              <a>PaymentRequest</a>
+            </td>
           </tr>
           <tr>
             <td>
@@ -3623,6 +3639,24 @@
             </td>
             <td>
               The user chooses a new shipping option.
+            </td>
+            <td>
+              <a>PaymentRequest</a>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code><dfn>payerdetailchange</dfn></code>
+            </td>
+            <td>
+              <a>PaymentRequestUpdateEvent</a>
+            </td>
+            <td>
+              The user changes the payer name, the payer email, or the payer
+              phone (see <a>payer detail changed algorithm</a>).
+            </td>
+            <td>
+              <a>PaymentResponse</a>
             </td>
           </tr>
           <tr>
@@ -3812,8 +3846,14 @@
             <li>If <var>event</var>.<a>[[\waitForUpdate]]</a> is true, then <a>
               throw</a> an "<a>InvalidStateError</a>" <a>DOMException</a>.
             </li>
-            <li>Let <var>request</var> be the value of <var>event</var>'s
-            <a data-cite="DOM#event-target">target</a>.
+            <li>If <var>event</var>'s <a data-cite=
+            "DOM#event-target">target</a> is an instance of
+            <a>PaymentResponse</a>, let <var>request</var> be
+            <var>event</var>'s <a data-cite=
+            "DOM#event-target">target</a><a>[[\request]]</a>.
+            </li>
+            <li>Otherwise, let <var>request</var> be the value of
+            <var>event</var>'s <a data-cite="DOM#event-target">target</a>.
             </li>
             <li>Assert: <var>request</var> is an instance of
             <a>PaymentRequest</a>.
@@ -3985,26 +4025,70 @@
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
+          <li>If <var>request</var><a>[[\response]]</a> is null, terminate this
+          algorithm.
+          </li>
+          <li>Let <var>response</var> be
+          <var>request</var><a>[[\response]]</a>.
+          </li>
           <li>
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
-            <ol>
-              <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
-              terminate this algorithm and take no further action. Only one
-              update may take place at a time. The <a>user agent</a> SHOULD
-              ensure that this never occurs.
+            <ol data-link-for="PaymentResponse">
+              <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false.
               </li>
-              <li>If the <var>request</var>.<a>[[\state]]</a> is not set to
-              "<a>interactive</a>", then terminate this algorithm and take no
-              further action. The <a>user agent</a> user interface SHOULD
-              ensure that this never occurs.
+              <li>Assert: <var>request</var>.<a>[[\state]]</a> is
+              "<a>interactive</a>".
               </li>
-              <li data-link-for="PaymentMethodChangeEvent">
-                <a>Fire an event</a> named "<a>paymentmethodchange</a>" at
-                <var>request</var> using <a>PaymentMethodChangeEvent</a>, with
-                its <a>methodName</a> attribute initialized to
-                <var>methodName</var>, and its <a>methodDetails</a> attribute
-                initialized to <var>methodDetails</var>.
+              <li>If <var>payer name</var> changed:
+                <ol>
+                  <li data-link-for="PaymentOptions">Assert:
+                  <var>request</var><a>[[\options]]</a>.<a>requestPayerName</a>
+                  is true.
+                  </li>
+                  <li>Set <var>response</var>'s <a>payerName</a> attribute to
+                  <var>payer name</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>If <var>payer email</var> changed:
+                <ol>
+                  <li data-link-for="PaymentOptions">Assert:
+                  <var>request</var><a>[[\options]]</a>.<a>requestPayerEmail</a>
+                  is true.
+                  </li>
+                  <li>Set <var>response</var>'s <a>payerEmail</a> attribute to
+                  <var>payer email</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>If <var>payer phone</var> changed:
+                <ol>
+                  <li data-link-for="PaymentOptions">Assert:
+                  <var>request</var><a>[[\options]]</a>.<a>requestPayerPhone</a>
+                  is true.
+                  </li>
+                  <li>Set <var>response</var>'s <a>payerPhone</a> attribute to
+                  <var>payer phone</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>Let <var>event</var> be the result of <a data-cite=
+              "!DOM#concept-event-create">creating an event</a> using
+              <a>PaymentRequestUpdateEvent</a>.
+              </li>
+              <li>Initialize <var>event</var>'s <code><a data-cite=
+              "!DOM#dom-event-type">type</a></code> attribute to
+              "<a>payerdetailchange</a>".
+              </li>
+              <li>
+                <a data-cite="!DOM#concept-event-dispatch">Dispatch</a>
+                <var>event</var> at <var>response</var>.
+              </li>
+              <li data-link-for="PaymentRequestUpdateEvent">If
+              <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any
+              part of the user interface that could cause another update event
+              to be fired.
               </li>
             </ol>
           </li>
@@ -4021,19 +4105,15 @@
           with an event name of <var>name</var>:
         </p>
         <ol class="algorithm">
-          <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
-          terminate this algorithm and take no further action. Only one update
-          may take place at a time. The <a>user agent</a> SHOULD ensure that
-          this never occurs.
+          <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false. Only
+          one update can take place at a time.
           </li>
-          <li>If the <var>request</var>.<a>[[\state]]</a> is not set to
-          "<a>interactive</a>", then terminate this algorithm and take no
-          further action. The <a>user agent</a> user interface SHOULD ensure
-          that this never occurs.
+          <li>Assert: <var>request</var>.<a>[[\state]]</a> is
+          "<a>interactive</a>".
           </li>
           <li>Let <var>event</var> be the result of <a data-cite=
-          "!DOM#concept-event-create">creating an event</a> using
-          <a>PaymentRequestUpdateEvent</a>.
+          "!DOM#concept-event-create">creating an event</a> using the
+          <a>PaymentRequestUpdateEvent</a> interface.
           </li>
           <li>Initialize <var>event</var>'s <code><a data-cite=
           "!DOM#dom-event-type">type</a></code> attribute to <var>name</var>.
@@ -4046,6 +4126,40 @@
           <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any part
           of the user interface that could cause another update event to be
           fired.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          Payer detail changed algorithm
+        </h2>
+        <p>
+          The user agent MUST run the <dfn>payer detail changed algorithm</dfn>
+          when the user changes the <var>payer name</var>, or the <var>payer
+          email</var>, or the <var>payer phone</var> in the user interface:
+        </p>
+        <ol class="algorithm">
+          <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
+          the user is interacting with.
+          </li>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            run the following steps:
+            <ol>
+              <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false.
+              Only one update can take place at a time.
+              </li>
+              <li>Assert: <var>request</var>.<a>[[\state]]</a> is
+              "<a>interactive</a>".
+              </li>
+              <li data-link-for="PaymentMethodChangeEvent">
+                <a>Fire an event</a> named "<a>paymentmethodchange</a>" at
+                <var>request</var> using <a>PaymentMethodChangeEvent</a>, with
+                its <a>methodName</a> attribute initialized to
+                <var>methodName</var>, and its <a>methodDetails</a> attribute
+                initialized to <var>methodDetails</var>.
+              </li>
+            </ol>
           </li>
         </ol>
       </section>


### PR DESCRIPTION
part 4 of #705 - define eventing model for "payerdetailchange". 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Added Web platform tests](https://github.com/web-platform-tests/wpt/pull/11772)
 * [x] [added MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/onpayerdetailchange)

Implementation commitment:

 * [x] [Safari](https://bugs.webkit.org/show_bug.cgi?id=189249)
 * [ ] Chrome (link to issue)
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1472026)
 * [ ] Edge (public signal)

Impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/724.html" title="Last updated on Nov 2, 2018, 9:56 PM GMT (397c3b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/724/b417638...397c3b6.html" title="Last updated on Nov 2, 2018, 9:56 PM GMT (397c3b6)">Diff</a>