### PR TITLE
 Editorial: use internal slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -3143,33 +3143,40 @@
           <dfn>retry()</dfn> method
         </h2>
         <ol class="algorithm">
-          <li>Let response be the context object.
+          <li>Let <var>response</var> be the <a>context object</a>.
           </li>
-          <li>Let request be response.[[\request]].
+          <li>Let <var>request</var> be
+          <var>response</var>.<a>[[\request]]</a>.
           </li>
-          <li>If response.[[\completeCalled]] is true, throw a
-          "InvalidStateError" DOMException.
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, throw a
+          "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>If request.[[\state]] is not "closed", throw a
-          "InvalidStateError" DOMException.
+          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, throw a
+          "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>Set request.[[\state]] to "interactive".
+          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>closed</a>",
+          throw a "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>Set request.[[\retrying]] to true.
+          <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
-          <li>Let promiseToRetry be a newly created promise.
+          <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>In parallel:
+          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
+          created promise.
+          </li>
+          <li>
+            <a>In parallel</a>:
             <ol>
-              <li>If the <a>user accepts the retry</a>, resolve promiseToRetry
-              with undefined.
+              <li>Indicate to the end-user that something is wrong with the
+              data of the payment response.
+                <div class="issue" data-number="647"></div>
               </li>
-              <li>If the <a>user aborts the retry</a>, reject promiseToRetry
-              with an "AbortError" DOMException.
+              <li>Wait for the user to either <a>retry the payment</a> or
+              <a>abort retrying</a>.
               </li>
             </ol>
           </li>
-          <li>Return promiseToRetry.
+          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
           </li>
         </ol>
       </section>
@@ -3338,18 +3345,20 @@
           </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\completeCalled]]</a> is true, reject
-          <var>promise</var> with an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, reject <var>
+            promise</var> with an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
           </li>
-          <li>Otherwise, set <var>response</var>.<a>[[\completeCalled]]</a> to
-          true.
+          <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps <a>in
           parallel</a>.
           </li>
           <li>Close down any remaining user interface. The <a>user agent</a>
           MAY use the value <var>result</var> to influence the user experience.
+          </li>
+          <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
+          boolean to false.
           </li>
           <li>Resolve <var>promise</var> with undefined.
           </li>
@@ -3374,14 +3383,145 @@
           </tr>
           <tr>
             <td>
-              <dfn>[[\completeCalled]]</dfn>
+              <dfn>[[\complete]]</dfn>
             </td>
             <td>
-              true if the <a data-lt="PaymentResponse.complete">complete</a>
-              method has been called and false otherwise.
+              true if that the request for payment has completed, or false
+              otherwise.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\request]]</dfn>
+            </td>
+            <td>
+              The <a>PaymentRequest</a> instance that instantiated this
+              <a>PaymentResponse</a>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\retryPromise]]</dfn>
+            </td>
+            <td>
+              A <a>Promise</a> resolves when a user <a data-lt=
+              "retry the payment">retries the payment</a> or rejects if the
+              user <a>aborts retrying</a>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\retrying]]</dfn>
+            </td>
+            <td>
+              When true, the developer has signaled that the payment response
+              suffers from validation errors that the user needs to correct in
+              the user agent's UI.
             </td>
           </tr>
         </table>
+      </section>
+      <section>
+        <h2>
+          <code>PaymentResponse</code> algorithms
+        </h2>
+        <section>
+          <h3>
+            User retries the payment algorithm
+          </h3>
+          <p>
+            The <dfn data-lt="retry the payment">user retries the payment
+            algorithm</dfn> runs if the developer has called <a>retry()</a> and
+            the user attempts to reaccept a request for payment:
+          </p>
+          <ol class="algorithm">
+            <li>Let <var>response</var> be the <a>PaymentResponse</a>
+            <a>context object</a>.
+            </li>
+            <li>Let <var>request</var> be
+            <var>response</var><a>[[\request]]</a>.
+            </li>
+            <li>If <var>request</var>.<a>[[\updating]]</a> is true, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
+            "<a>interactive</a>", then terminate this algorithm and take no
+            further action. The <a>user agent</a> user interface SHOULD ensure
+            that this never occurs.
+            </li>
+            <li>If the <a data-lt=
+            "PaymentOptions.requestShipping">requestShipping</a> value of <var>
+              request</var>.<a>[[\options]]</a> is true, then if the
+              <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
+              attribute of <var>request</var> is null or if the <a data-lt=
+              "PaymentRequest.shippingOption">shippingOption</a> attribute of
+              <var>request</var> is null, then terminate this algorithm and
+              take no further action. The <a>user agent</a> SHOULD ensure that
+              this never occurs.
+            </li>
+            <li>
+              <a>Queue a task</a> on the <a>user interaction task source</a> to
+              perform the following steps:
+              <ol>
+                <li>Set <var>response</var>.<a>[[\retrying]]</a> to false.
+                </li>
+                <li>Set <var>request</var>.<a>[[\state]]</a> to
+                "<a>closed</a>".
+                </li>
+                <li>Resolve <var>response</var>.<a>[[\retryPromise]]</a> with
+                undefined.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h3>
+            User aborts retrying algorithm
+          </h3>
+          <p>
+            The <dfn data-lt="aborts retrying|abort retrying">user aborts
+            retrying algorithm</dfn> runs if the developer has called
+            <a>retry()</a> and the user aborts the payment request through the
+            currently interactive user interface.
+          </p>
+          <ol class="algorithm">
+            <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
+            object</a>.
+            </li>
+            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
+            "<a>interactive</a>", then terminate this algorithm and take no
+            further action. The <a>user agent</a> user interface SHOULD ensure
+            that this never occurs.
+            </li>
+            <li>
+              <a>Queue a task</a> on the <a>user interaction task source</a> to
+              perform the following steps:
+              <ol>
+                <li>Set <var>request</var>.<a>[[\state]]</a> to
+                "<a>closed</a>".
+                </li>
+                <li>Set the <a>user agent</a>'s <a>payment request is
+                showing</a> boolean to false.
+                </li>
+                <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
+                </li>
+                <li>Reject <var>request</var>.<a>[[\retryPromise]]</a> with an
+                "<a>AbortError</a>" <a>DOMException</a>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
       </section>
     </section>
     <section class="informative">
@@ -3855,12 +3995,9 @@
           "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
           SHOULD format the phone number to adhere to [[!E.164]].
           </li>
-          <li>Set <var>response</var>.<a>[[\completeCalled]]</a> to false.
+          <li>Set <var>response</var>.<a>[[\complete]]</a> to false.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
-          </li>
-          <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-          boolean to false.
           </li>
           <li>Resolve the pending promise
           <var>request</var>.<a>[[\acceptPromise]]</a> with

--- a/index.html
+++ b/index.html
@@ -3371,12 +3371,8 @@
         </h2>
         <p data-tests=
         "payment-response/shippingAddress-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> member was set
-          to true in the <a>PaymentOptions</a> passed to the
-          <a>PaymentRequest</a> constructor, then <a data-lt=
-          "PaymentRequest.shippingAddress">shippingAddress</a> will be the full
-          and final shipping address chosen by the user.
+          When getting, the user agent MUST return the value of the <a>context
+          object</a>'s <a>[[\request]]</a>'s <a>shippingAddress</a> attribute.
         </p>
       </section>
       <section>
@@ -3384,14 +3380,10 @@
           <dfn>shippingOption</dfn> attribute
         </h2>
         <p data-tests=
-        "payment-response/shippingOption-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> member was set
-          to true in the <a>PaymentOptions</a> passed to the
-          <a>PaymentRequest</a> constructor, then <a data-lt=
-          "PaymentRequest.shippingOption">shippingOption</a> will be the
-          <a data-lt="PaymentShippingOption.id">id</a> attribute of the
-          selected shipping option.
+        "payment-response/shippingOption-attribute-manual.https.html"
+        data-link-for="PaymentRequest">
+          When getting, the user agent MUST return the value of the <a>context
+          object</a>'s <a>[[\request]]</a>'s <a>shippingOption</a> attribute.
         </p>
       </section>
       <section>
@@ -3399,12 +3391,8 @@
           <dfn>payerName</dfn> attribute
         </h2>
         <p data-tests="payment-response/payerName-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestPayerName">requestPayerName</a> member was set
-          to true in the <a>PaymentOptions</a> passed to the
-          <a>PaymentRequest</a> constructor, then <a data-lt=
-          "PaymentResponse.payerName">payerName</a> will be the name provided
-          by the user.
+          When getting, the user agent MUST return value of the <a>context
+          object</a>'s <a>[[\payerName]]</a> internal slot.
         </p>
       </section>
       <section>
@@ -3413,12 +3401,8 @@
         </h2>
         <p data-tests=
         "payment-response/payerEmail-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestPayerEmail">requestPayerEmail</a> member was
-          set to true in the <a>PaymentOptions</a> passed to the
-          <a>PaymentRequest</a> constructor, then <a data-lt=
-          "PaymentResponse.payerEmail">payerEmail</a> will be the email address
-          chosen by the user.
+          When getting, the user agent MUST return value of the <a>context
+          object</a>'s <a>[[\payerEmail]]</a> internal slot.
         </p>
       </section>
       <section>
@@ -3427,21 +3411,18 @@
         </h2>
         <p data-tests=
         "payment-response/payerPhone-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestPayerPhone">requestPayerPhone</a> member was
-          set to true in the <a>PaymentOptions</a> passed to the
-          <a>PaymentRequest</a> constructor, then <a data-lt=
-          "PaymentResponse.payerPhone">payerPhone</a> will be the phone number
-          chosen by the user.
+          When getting, the user agent MUST return the value of the <a>context
+          object</a>'s <a>[[\payerPhone]]</a> internal slot.
         </p>
       </section>
       <section>
         <h2>
           <dfn>requestId</dfn> attribute
         </h2>
-        <p data-tests="payment-response/requestId-attribute-manual.https.html">
-          The corresponding payment request <a data-lt=
-          "PaymentRequest.id">id</a> that spawned this payment response.
+        <p data-tests="payment-response/requestId-attribute-manual.https.html"
+        data-link-for="PaymentDetailsInit">
+          When getting, the user agent MUST return the value of the <a>context
+          object</a>'s <a>[[\request]]</a><a>[[\details]]</a>.<a>id</a>.
         </p>
       </section>
       <section data-dfn-for="PaymentResponse" data-link-for="PaymentResponse">
@@ -3539,6 +3520,26 @@
           </tr>
           <tr>
             <td>
+              <dfn>[[\methodName]]</dfn>
+            </td>
+            <td>
+              A <a>payment method identifier</a> for the <a>payment method</a>
+              that the user selected to accept the payment.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\responseDetails]]</dfn>
+            </td>
+            <td>
+              An object that allows a payment to be completed (e.g., a credit
+              card number, or tokenized payment information), provided by a
+              <a>payment handler</a>'s <a>steps to respond to a payment
+              request</a>.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <dfn>[[\request]]</dfn>
             </td>
             <td>
@@ -3564,6 +3565,30 @@
               When true, the developer has signaled that the payment response
               suffers from validation errors that the user needs to correct in
               the user agent's UI.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\payerEmail]]</dfn>
+            </td>
+            <td>
+              A DOMString or null, represents the payer's email.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\payerName]]</dfn>
+            </td>
+            <td>
+              A DOMString or null, represents the payer's email.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\payerPhone]]</dfn>
+            </td>
+            <td>
+              A DOMString or null, represents the payer's phone number.
             </td>
           </tr>
         </table>
@@ -3851,6 +3876,9 @@
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
+          <li>Let <var>isRetry</var> be true if
+          <var>request</var><a>[[\response]]</a> is not null, false otherwise.
+          </li>
           <li>
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
@@ -3874,9 +3902,11 @@
                     some countries postal codes are so fine-grained that they
                     can uniquely identify a recipient.
                   </p>
-                </div>Let <var>redactList</var> be the empty list. Optionally,
-                set <var>redactList</var> to « "organization", "phone",
-                "recipient", "addressLine" ».
+                </div>Let <var>redactList</var> be the empty list.
+              </li>
+              <li>Optionally, if <var>isRetry</var> is false, set
+              <var>redactList</var> to « "organization", "phone", "recipient",
+              "addressLine" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided
@@ -3928,9 +3958,8 @@
         </h2>
         <p>
           The user agent MUST run the <dfn>payer detail changed algorithm</dfn>
-          when the user changes the <a>DOMString</a> <var>payer name</var>, or
-          the <a>DOMString</a> <var>payer email</var>, or the <a>DOMString</a>
-          <var>payer phone</var> in the user interface:
+          when the user changes the <var>payer name</var>, or the <var>payer
+          email</var>, or the <var>payer phone</var> in the user interface:
         </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
@@ -3959,8 +3988,8 @@
                   <var>request</var><a>[[\options]]</a>.<a>requestPayerName</a>
                   is true.
                   </li>
-                  <li>Set <var>response</var>'s <a>payerName</a> attribute to
-                  <var>payer name</var>.
+                  <li>Set <var>response</var>'s <a>[[\payerName]]</a> to <var>
+                    payer name</var>.
                   </li>
                 </ol>
               </li>
@@ -3970,8 +3999,8 @@
                   <var>request</var><a>[[\options]]</a>.<a>requestPayerEmail</a>
                   is true.
                   </li>
-                  <li>Set <var>response</var>'s <a>payerEmail</a> attribute to
-                  <var>payer email</var>.
+                  <li>Set <var>response</var>'s <a>[[\payerEmail]]</a> to <var>
+                    payer email</var>.
                   </li>
                 </ol>
               </li>
@@ -3981,8 +4010,9 @@
                   <var>request</var><a>[[\options]]</a>.<a>requestPayerPhone</a>
                   is true.
                   </li>
-                  <li>Set <var>response</var>'s <a>payerPhone</a> attribute to
-                  <var>payer phone</var>.
+                  <li>Set <var>response</var>'s <a>[[\payerPhone]]</a> to <var>
+                    payer phone</var>. The user agent SHOULD format the
+                    <var>phone number</var> to adhere to [[!E.164]].
                   </li>
                 </ol>
               </li>
@@ -4057,7 +4087,7 @@
           a task</a> on the <a>user interaction task source</a> to perform the
           following steps:
         </p>
-        <ol class="algorithm">
+        <ol class="algorithm" data-link-for="PaymentOptions">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
           the user is interacting with.
           </li>
@@ -4070,8 +4100,7 @@
           further action. The <a>user agent</a> user interface SHOULD ensure
           that this never occurs.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> value of
+          <li>If the <a>requestShipping</a> value of
           <var>request</var>.<a>[[\options]]</a> is true, then if the
           <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
           attribute of <var>request</var> is null or if the <a data-lt=
@@ -4100,16 +4129,15 @@
               </li>
               <li>Set <var>response</var>.<a>[[\complete]]</a> to false.
               </li>
-              <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
-              attribute value of <var>response</var> to the value of
-              <var>request</var>.<a>[[\details]]</a>.<a data-lt=
-              "PaymentDetailsInit.id">id</a>.
+              <li>Set <var>response</var>.<a>[[\payerEmail]]</a> to null.
               </li>
-              <li>Set the <a data-lt=
-              "PaymentResponse.methodName">methodName</a> attribute value of
-              <var>response</var> to the <a>payment method identifier</a> for
-              the <a>payment method</a> that the user selected to accept the
-              payment.
+              <li>Set <var>response</var>.<a>[[\payerName]]</a> to null.
+              </li>
+              <li>Set <var>response</var>.<a>[[\payerPhone]]</a> to null.
+              </li>
+              <li>Set <var>response</var>.<a>[[\methodName]]</a> to the
+              <a>payment method identifier</a> for the <a>payment method</a>
+              that the user selected to accept the payment.
               </li>
               <li>Set <var>request</var>.<a>[[\response]]</a> to
               <var>response</var>.
@@ -4119,63 +4147,26 @@
           <li>Let <var>handler</var> be the <a>payment handler</a> selected by
           the user.
           </li>
-          <li>Set the <a data-lt="PaymentResponse.details">details</a>
-          attribute value of <var>response</var> to an object resulting from
-          running the <var>handler</var>'s <a>steps to respond to a payment
+          <li>Set <var>request</var><a>[[\responseDetails]]</a> to the result
+          of running <var>handler</var>'s <a>steps to respond to a payment
           request</a>.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> value of
-          <var>request</var>.<a>[[\options]]</a> is false, then set the
-          <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
-          attribute value of <var>response</var> to null. Otherwise:
-            <ol>
-              <li>Let <var>redactList</var> be the empty <a>list</a>.
-              </li>
-              <li>Let <var>shippingAddress</var> be the result of <a>create a
-              <code>PaymentAddress</code> from user-provided input</a> with
-              <var>redactList</var>.
-              </li>
-              <li>Set the <a data-lt=
-              "PaymentResponse.shippingAddress">shippingAddress</a> attribute
-              value of <var>response</var> to <var>shippingAddress</var>.
-              </li>
-              <li>Set the <a data-lt=
-              "PaymentResponse.shippingAddress">shippingAddress</a> attribute
-              value of <var>request</var> to <var>shippingAddress</var>.
-              </li>
-            </ol>
+          <li>If the <a>requestPayerName</a> value of
+          <var>request</var>.<a>[[\options]]</a> is true, then set
+          <var>response</var><a>[[\payerName]]</a> to the payer's name provided
+          by the user, or to null if none was provided.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> value of
-          <var>request</var>.<a>[[\options]]</a> is true, then set the
-          <a data-lt="PaymentResponse.shippingOption">shippingOption</a>
-          attribute of <var>response</var> to the value of the <a data-lt=
-          "PaymentRequest.shippingOption">shippingOption</a> attribute of <var>
-            request</var>. Otherwise, set it to null.
+          <li>If the <a>requestPayerEmail</a> value of
+          <var>request</var>.<a>[[\options]]</a> is true, then set
+          <var>response</var><a>[[\payerEmail]]</a> to the payer's email
+          address provided by the user, or to null if none was provided.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestPayerName">requestPayerName</a> value of <var>
-            request</var>.<a>[[\options]]</a> is true, then set the <a data-lt=
-            "PaymentResponse.payerName">payerName</a> attribute of
-            <var>response</var> to the payer's name provided by the user, or to
-            null if none was provided. Otherwise, set it to null.
-          </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestPayerEmail">requestPayerEmail</a> value of
-          <var>request</var>.<a>[[\options]]</a> is true, then set the
-          <a data-lt="PaymentResponse.payerEmail">payerEmail</a> attribute of
-          <var>response</var> to the payer's email address provided by the
-          user, or to null if none was provided. Otherwise, set it to null.
-          </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestPayerPhone">requestPayerPhone</a> value of
-          <var>request</var>.<a>[[\options]]</a> is true, then set the
-          <a data-lt="PaymentResponse.payerPhone">payerPhone</a> attribute of
-          <var>response</var> to the payer's phone number provided by the user,
-          or to null if none was provided. When setting the <a data-lt=
-          "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
-          SHOULD format the phone number to adhere to [[!E.164]].
+          <li>If the <a>requestPayerPhone</a> value of
+          <var>request</var>.<a>[[\options]]</a> is true, then set
+          <var>response</var><a>[[\payerPhone]]</a> to the payer's phone number
+          provided by the user, or to null if none was provided. When setting
+          the <a>[[\payerPhone]]</a>, the user agent SHOULD format the phone
+          number to adhere to [[!E.164]].
           </li>
           <li>If <var>isRetry</var> is true, resolve
           <var>response</var><a>[[\retryPromise]]</a> with undefined.

--- a/index.html
+++ b/index.html
@@ -3183,8 +3183,8 @@
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to
-          <var>retryPromise</var>.
+          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
+          created promise.
           </li>
           <li>
             <a>In parallel</a>:
@@ -3198,7 +3198,7 @@
               </li>
             </ol>
           </li>
-          <li>Return <var>retryPromise</var>.
+          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3531,6 +3531,9 @@
             further action. The <a>user agent</a> user interface SHOULD ensure
             that this never occurs.
             </li>
+            <li>Try to abort the current user interaction with the <a>payment
+            handler</a> and close down any remaining user interface.
+            </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               perform the following steps:

--- a/index.html
+++ b/index.html
@@ -3142,6 +3142,9 @@
         <h2>
           <dfn>retry()</dfn> method
         </h2>
+        <p data-tests="payment-response/retry-method-manual.https.html">
+          The <a>retry()</a> method MUST act as follows:
+        </p>
         <ol class="algorithm">
           <li>Let <var>response</var> be the <a>context object</a>.
           </li>
@@ -3352,9 +3355,11 @@
             promise</var> with an "<a>InvalidStateError</a>"
             <a>DOMException</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, reject <var>
-            promise</var> with an "<a>InvalidStateError</a>"
-            <a>DOMException</a>.
+          <li data-tests=
+          "payment-request/payment-response/retry-method-manual.https.html">If
+          <var>response</var>.<a>[[\retrying]]</a> is true, reject
+          <var>promise</var> with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
           <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>

--- a/index.html
+++ b/index.html
@@ -4426,7 +4426,20 @@
                 <li>Set <var>request</var>.<a>[[\state]]</a> to
                 "<a>closed</a>".
                 </li>
-                <li>Reject the promise
+                <li>If <var>request</var><a>[[\response]]</a> is not null,
+                then:
+                  <ol>
+                    <li>Let <var>response</var> be
+                    <var>request</var><a>[[\response]]</a>.
+                    </li>
+                    <li>Assert: <var>response</var><a>[[\retrying]]</a> is true.
+                    </li>
+                    <li>Reject <var>response</var><a>[[\retryPromise]]</a> with
+                    <var>exception</var>.
+                    </li>
+                  </ol>
+                </li>
+                <li>Otherwise, reject the promise
                 <var>request</var>.<a>[[\acceptPromise]]</a> with
                 <var>exception</var>.
                 </li>

--- a/index.html
+++ b/index.html
@@ -3971,7 +3971,7 @@
                   is true.
                   </li>
                   <li>Set <var>response</var>'s <a>payerEmail</a> attribute to
-                  <a>payer email</a>.
+                  <var>payer email</var>.
                   </li>
                 </ol>
               </li>

--- a/index.html
+++ b/index.html
@@ -834,6 +834,8 @@
           <li>Set <var>request</var>.<a>[[\serializedMethodData]]</a> to <var>
             serializedMethodData</var>.
           </li>
+          <li>Set <var>request</var>.<a>[[\response]]</a> to null.
+          </li>
           <li>Set the value of <var>request</var>'s <a data-lt=
           "PaymentRequest.shippingOption">shippingOption</a> attribute to <var>
             selectedShippingOption</var>.
@@ -1112,9 +1114,14 @@
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>context object</a>.
           </li>
+          <li>If <var>request</var>.<a>[[\response]]</a> is not null, and <var>
+            request</var>.<a>[[\response]]</a>.<a>[[\retrying]]</a> is true,
+            return a newly created promise an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
+          </li>
           <li>If the value of <var>request</var>.<a>[[\state]]</a> is not
-          "<a>interactive</a>" then <a>throw</a> an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
+          "<a>interactive</a>" then return a newly created promise rejected
+          with an "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>
@@ -1422,6 +1429,15 @@
               The pending <a>Promise</a> created during <a data-lt=
               "PaymentRequest.show">show</a> that will be resolved if the user
               accepts the payment request.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\response]]</dfn>
+            </td>
+            <td>
+              Null, or the <a>PaymentResponse</a> instantiated by this
+              <a>PaymentRequest</a>.
             </td>
           </tr>
         </table>
@@ -3934,7 +3950,11 @@
           </li>
           <li>Let <var>response</var> be a new <a>PaymentResponse</a>.
           </li>
-          <li>Let <var>response</var>.[[\request]] be <var>request</var>.
+          <li>Let <var>response</var>.<a>[[\request]]</a> be
+          <var>request</var>.
+          </li>
+          <li>Set <var>request</var>.<a>[[\response]]</a> to
+          <var>response</var>.
           </li>
           <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
           attribute value of <var>response</var> to the value of

--- a/index.html
+++ b/index.html
@@ -3352,6 +3352,10 @@
             promise</var> with an "<a>InvalidStateError</a>"
             <a>DOMException</a>.
           </li>
+          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, reject <var>
+            promise</var> with an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
+          </li>
           <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps <a>in

--- a/index.html
+++ b/index.html
@@ -3134,7 +3134,7 @@
       </h2>
       <pre class="idl">
         [SecureContext, Exposed=Window]
-        interface PaymentResponse {
+        interface PaymentResponse : EventTarget  {
           [Default] object toJSON();
 
           readonly attribute DOMString requestId;
@@ -3148,6 +3148,8 @@
 
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
           Promise&lt;void&gt; retry(PaymentValidationErrors errorFields);
+
+          attribute EventHandler onpayerdetailchange;
         };
       </pre>
       <p class="note">
@@ -3501,6 +3503,14 @@
           </li>
         </ol>
       </section>
+      <section data-dfn-for="PaymentResponse" data-link-for="PaymentResponse">
+        <h2>
+          <dfn>onpayerdetailchange</dfn> attribute
+        </h2>
+        <p>
+          Allows a developer to handle "<a>payerdetailchange</a>" events.
+        </p>
+      </section>
       <section>
         <h2>
           Internal Slots
@@ -3589,6 +3599,9 @@
             <th>
               Dispatched when…
             </th>
+            <th>
+              Target
+            </th>
           </tr>
           <tr>
             <td>
@@ -3600,6 +3613,9 @@
             <td>
               The user provides a new shipping address.
             </td>
+            <td>
+              <a>PaymentRequest</a>
+            </td>
           </tr>
           <tr>
             <td>
@@ -3610,6 +3626,24 @@
             </td>
             <td>
               The user chooses a new shipping option.
+            </td>
+            <td>
+              <a>PaymentRequest</a>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code><dfn>payerdetailchange</dfn></code>
+            </td>
+            <td>
+              <a>PaymentRequestUpdateEvent</a>
+            </td>
+            <td>
+              The user changes the payer name, the payer email, or the payer
+              phone (see <a>payer detail changed algorithm</a>).
+            </td>
+            <td>
+              <a>PaymentResponse</a>
             </td>
           </tr>
         </table>
@@ -3727,8 +3761,14 @@
             <li>If <var>event</var>.<a>[[\waitForUpdate]]</a> is true, then <a>
               throw</a> an "<a>InvalidStateError</a>" <a>DOMException</a>.
             </li>
-            <li>Let <var>request</var> be the value of <var>event</var>'s
-            <a data-cite="DOM#event-target">target</a>.
+            <li>If <var>event</var>'s <a data-cite=
+            "DOM#event-target">target</a> is an instance of
+            <a>PaymentResponse</a>, let <var>request</var> be
+            <var>event</var>'s <a data-cite=
+            "DOM#event-target">target</a><a>[[\request]]</a>.
+            </li>
+            <li>Otherwise, let <var>request</var> be the value of
+            <var>event</var>'s <a data-cite="DOM#event-target">target</a>.
             </li>
             <li>Assert: <var>request</var> is an instance of
             <a>PaymentRequest</a>.
@@ -3877,6 +3917,91 @@
               </li>
               <li>Run the <a>PaymentRequest updated algorithm</a> with
               <var>request</var> and "<a>shippingoptionchange</a>".
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          Payer detail changed algorithm
+        </h2>
+        <p>
+          The user agent MUST run the <dfn>payer detail changed algorithm</dfn>
+          when the user changes the <a>DOMString</a> <var>payer name</var>, or
+          the <a>DOMString</a> <var>payer email</var>, or the <a>DOMString</a>
+          <var>payer phone</var> in the user interface:
+        </p>
+        <ol class="algorithm">
+          <li>Let <var>request</var> be the <a>PaymentRequest</a> object that
+          the user is interacting with.
+          </li>
+          <li>If <var>request</var><a>[[\response]]</a> is null, terminate this
+          algorithm.
+          </li>
+          <li>Let <var>response</var> be
+          <var>request</var><a>[[\response]]</a>.
+          </li>
+          <li>Assert: <var>response</var><a>[[\retrying]]</a> is true.
+          </li>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            run the following steps:
+            <ol data-link-for="PaymentResponse">
+              <li>Assert: <var>request</var>.<a>[[\updating]]</a> is false.
+              </li>
+              <li>Assert: <var>request</var>.<a>[[\state]]</a> is
+              "<a>interactive</a>".
+              </li>
+              <li>If <var>payer name</var> changed:
+                <ol>
+                  <li data-link-for="PaymentOptions">Assert:
+                  <var>request</var><a>[[\options]]</a>.<a>requestPayerName</a>
+                  is true.
+                  </li>
+                  <li>Set <var>response</var>'s <a>payerName</a> attribute to
+                  <var>payer name</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>If <var>payer email</var> changed:
+                <ol>
+                  <li data-link-for="PaymentOptions">Assert:
+                  <var>request</var><a>[[\options]]</a>.<a>requestPayerEmail</a>
+                  is true.
+                  </li>
+                  <li>Set <var>response</var>'s <a>payerEmail</a> attribute to
+                  <a>payer email</a>.
+                  </li>
+                </ol>
+              </li>
+              <li>If <var>payer phone</var> changed:
+                <ol>
+                  <li data-link-for="PaymentOptions">Assert:
+                  <var>request</var><a>[[\options]]</a>.<a>requestPayerPhone</a>
+                  is true.
+                  </li>
+                  <li>Set <var>response</var>'s <a>payerPhone</a> attribute to
+                  <var>payer phone</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>Let <var>event</var> be the result of <a data-cite=
+              "!DOM#concept-event-create">creating an event</a> using
+              <a>PaymentRequestUpdateEvent</a>.
+              </li>
+              <li>Initialize <var>event</var>'s <code><a data-cite=
+              "!DOM#dom-event-type">type</a></code> attribute to
+              "<a>payerdetailchange</a>".
+              </li>
+              <li>
+                <a data-cite="!DOM#concept-event-dispatch">Dispatch</a>
+                <var>event</var> at <var>response</var>.
+              </li>
+              <li data-link-for="PaymentRequestUpdateEvent">If
+              <var>event</var>.<a>[[\waitForUpdate]]</a> is true, disable any
+              part of the user interface that could cause another update event
+              to be fired.
               </li>
             </ol>
           </li>
@@ -4432,7 +4557,8 @@
                     <li>Let <var>response</var> be
                     <var>request</var><a>[[\response]]</a>.
                     </li>
-                    <li>Assert: <var>response</var><a>[[\retrying]]</a> is true.
+                    <li>Assert: <var>response</var><a>[[\retrying]]</a> is
+                    true.
                     </li>
                     <li>Reject <var>response</var><a>[[\retryPromise]]</a> with
                     <var>exception</var>.

--- a/index.html
+++ b/index.html
@@ -3148,21 +3148,24 @@
           <li>Let <var>request</var> be
           <var>response</var>.<a>[[\request]]</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\complete]]</a> is true, throw a
-          "<a>InvalidStateError</a>" <a>DOMException</a>.
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, return a
+          promise rejected with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
-          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, throw a
-          "<a>InvalidStateError</a>" <a>DOMException</a>.
+          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, return a
+          promise rejected with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
           <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>closed</a>",
-          throw a "<a>InvalidStateError</a>" <a>DOMException</a>.
+          return a promise rejected with an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
           </li>
           <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
-          created promise.
+          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to
+          <var>retryPromise</var>.
           </li>
           <li>
             <a>In parallel</a>:
@@ -3176,7 +3179,7 @@
               </li>
             </ol>
           </li>
-          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
+          <li>Return <var>retryPromise</var>.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3175,10 +3175,6 @@
           promise rejected with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
-          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>closed</a>",
-          return a promise rejected with an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
-          </li>
           <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".

--- a/index.html
+++ b/index.html
@@ -3518,22 +3518,6 @@
             <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
             object</a>.
             </li>
-            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If <var>request</var>.<a>[[\state]]</a> is not
-            "<a>interactive</a>", then terminate this algorithm and take no
-            further action. The <a>user agent</a> user interface SHOULD ensure
-            that this never occurs.
-            </li>
-            <li>Try to abort the current user interaction with the <a>payment
-            handler</a> and close down any remaining user interface.
-            </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               perform the following steps:

--- a/index.html
+++ b/index.html
@@ -3234,6 +3234,7 @@
           <pre class="idl">
             dictionary PaymentValidationErrors {
               PayerErrorFields payerErrors;
+              AddressErrorFields shippingAddressErrors;
             };
           </pre>
           <dl>
@@ -3242,6 +3243,13 @@
             </dt>
             <dd>
               Validation errors related to the <a>payer details</a>.
+            </dd>
+            <dt>
+              <dfn>shippingAddressErrors</dfn> member
+            </dt>
+            <dd data-link-for="PaymentResponse">
+              Represents validation errors with the <a>PaymentResponse</a>'s
+              <a>shippingAddress</a>.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -3217,9 +3217,8 @@
                   </li>
                 </ol>
               </li>
-              <li>
-                Finally, when <var>retryPromise</var> settles, set
-                <var>response</var><a>[[\retrying]]</a> to false.
+              <li>Finally, when <var>retryPromise</var> settles, set
+              <var>response</var><a>[[\retrying]]</a> to false.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -1116,8 +1116,8 @@
           </li>
           <li>If <var>request</var>.<a>[[\response]]</a> is not null, and <var>
             request</var>.<a>[[\response]]</a>.<a>[[\retrying]]</a> is true,
-            return a newly created promise an "<a>InvalidStateError</a>"
-            <a>DOMException</a>.
+            return a newly created promise rejected with an
+            "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
           <li>If the value of <var>request</var>.<a>[[\state]]</a> is not
           "<a>interactive</a>" then return a newly created promise rejected

--- a/index.html
+++ b/index.html
@@ -3171,7 +3171,7 @@
           promise rejected with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
-          <li>If <var>request</var>.<a>[[\retrying]]</a> is true, return a
+          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, return a
           promise rejected with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
@@ -3519,7 +3519,7 @@
             <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
             object</a>.
             </li>
-            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
+            <li>If the <var>response</var>.<a>[[\retrying]]</a> is false, then
             terminate this algorithm and take no further action. The <a>user
             agent</a> user interface SHOULD ensure that this never occurs.
             </li>

--- a/index.html
+++ b/index.html
@@ -3216,10 +3216,10 @@
                   "<a>AbortError</a>" <a>DOMException</a>.
                   </li>
                 </ol>
-                <p>
-                  Finally, when <var>retryPromise</var> settles, set
-                  <var>response</var><a>[[\retrying]]</a> to false.
-                </p>
+              </li>
+              <li>
+                Finally, when <var>retryPromise</var> settles, set
+                <var>response</var><a>[[\retrying]]</a> to false.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -3147,7 +3147,7 @@
           readonly attribute DOMString? payerPhone;
 
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
-          Promise&lt;void&gt; retry();
+          Promise&lt;void&gt; retry(PaymentValidationErrors errorFields);
         };
       </pre>
       <p class="note">
@@ -3159,7 +3159,8 @@
           <dfn>retry()</dfn> method
         </h2>
         <p data-tests="payment-response/retry-method-manual.https.html">
-          The <a>retry()</a> method MUST act as follows:
+          The <code>retry(<var>errorFields</var>)</code> method MUST act as
+          follows:
         </p>
         <ol class="algorithm">
           <li>Let <var>response</var> be the <a>context object</a>.
@@ -3187,8 +3188,9 @@
           <li>
             <a>In parallel</a>:
             <ol>
-              <li>In the payments UI, indicate to the end-user that something
-              is wrong with the user-provided data of the payment response.
+              <li>By matching the members of <var>errorFields</var> to input
+              fields in the user agent's UI, indicate to the end-user that
+              something is wrong with the data of the payment response.
               </li>
               <li>
                 <p>
@@ -3224,6 +3226,83 @@
           <li>Return <var>retryPromise</var>.
           </li>
         </ol>
+        <section data-dfn-for="PaymentValidationErrors" data-link-for=
+        "PaymentValidationErrors">
+          <h3>
+            <dfn>PaymentValidationErrors</dfn> dictionary
+          </h3>
+          <pre class="idl">
+            dictionary PaymentValidationErrors {
+              PayerErrorFields payerErrors;
+            };
+          </pre>
+          <dl>
+            <dt>
+              <dfn>payerErrors</dfn> member
+            </dt>
+            <dd>
+              Validation errors related to the <a>payer details</a>.
+            </dd>
+          </dl>
+        </section>
+        <section data-dfn-for="PayerErrorFields" data-link-for=
+        "PayerErrorFields">
+          <h3>
+            <dfn>PayerErrorFields</dfn> dictionary
+          </h3>
+          <pre class="idl">
+          dictionary PayerErrorFields {
+            DOMString payerEmailError;
+            DOMString payerNameError;
+            DOMString payerPhoneError;
+          };
+        </pre>
+          <p>
+            The <a>PayerErrorFields</a> is used to represent validation errors
+            with one or more <a>payer details</a>.
+          </p>
+          <p>
+            <dfn>Payer details</dfn> are any of the payer's name, payer's phone
+            number, and payer's email.
+          </p>
+          <dl data-link-for="PaymentResponse">
+            <dt>
+              <dfn>payerEmailError</dfn> member
+            </dt>
+            <dd>
+              Denotes that the payer's email suffers from a validation error.
+              In the user agent's UI, this member corresponds to the input
+              field that provided the <a>PaymentResponse</a>'s
+              <a>payerEmail</a> attribute's value.
+            </dd>
+            <dt>
+              <dfn>payerNameError</dfn> member
+            </dt>
+            <dd>
+              Denotes that the payer's name suffers from a validation error. In
+              the user agent's UI, this member corresponds to the input field
+              that provided the <a>PaymentResponse</a>'s <a>payerName</a>
+              attribute's value.
+            </dd>
+            <dt>
+              <dfn>payerPhoneError</dfn> member
+            </dt>
+            <dd>
+              Denotes that the payer's phone number suffers from a validation
+              error. In the user agent's UI, this member corresponds to the
+              input field that provided the <a>PaymentResponse</a>'s
+              <a>payerPhone</a> attribute's value.
+            </dd>
+          </dl>
+          <pre class="example js" title="Payer-related validation errors">
+          const payerErrors = {
+            payerEmailError: "The domain is invalid.",
+            payerPhoneError: "Unknown country code.",
+            payerNameError: "Not in database",
+          };
+          await response.retry({ payerErrors });
+          </pre>
+        </section>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -3167,34 +3167,61 @@
           <li>Let <var>request</var> be
           <var>response</var>.<a>[[\request]]</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\complete]]</a> is true, return a
-          promise rejected with an "<a>InvalidStateError</a>"
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, return <a>a
+          promise rejected with</a> an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, return a
-          promise rejected with an "<a>InvalidStateError</a>"
+          <li>If <var>response</var>.<a>[[\retrying]]</a> is true, return <a>a
+          promise rejected with</a> an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
           <li>Set <var>response</var>.<a>[[\retrying]]</a> to true.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
-          <li>Set <var>request</var>.<a>[[\retryPromise]]</a> to a newly
-          created promise.
+          <li>Let <var>retryPromise</var> be <a>a new promise</a>.
+          </li>
+          <li>Set <var>response</var>.<a>[[\retryPromise]]</a> to
+          <var>retryPromise</var>.
           </li>
           <li>
             <a>In parallel</a>:
             <ol>
-              <li>Indicate to the end-user that something is wrong with the
-              data of the payment response.
-                <div class="issue" data-number="647"></div>
+              <li>In the payments UI, indicate to the end-user that something
+              is wrong with the user-provided data of the payment response.
               </li>
-              <li>Wait for the user to either <a>retry the payment</a> or
-              <a>abort retrying</a>.
+              <li>
+                <p>
+                  The <var>retryPromise</var> will later be resolved or
+                  rejected by either the <a>user accepts the payment request
+                  algorithm</a> or the <a>user aborts the payment request
+                  algorithm</a>, which are triggered through interaction with
+                  the user interface.
+                </p>
+                <p data-test="rejects_if_not_active.https.html">
+                  If <var>document</var> stops being <a data-cite=
+                  "!HTML#fully-active">fully active</a> while the user
+                  interface is being shown, or no longer is by the time this
+                  step is reached, then:
+                </p>
+                <ol>
+                  <li>Close down the user interface.
+                  </li>
+                  <li>Set the <a>user agent</a>'s <a>payment request is
+                  showing</a> boolean to false.
+                  </li>
+                  <li>Reject <var>retryPromise</var> with an
+                  "<a>AbortError</a>" <a>DOMException</a>.
+                  </li>
+                </ol>
+                <p>
+                  Finally, when <var>retryPromise</var> settles, set
+                  <var>response</var><a>[[\retrying]]</a> to false.
+                </p>
               </li>
             </ol>
           </li>
-          <li>Return <var>request</var>.<a>[[\retryPromise]]</a>.
+          <li>Return <var>retryPromise</var>.
           </li>
         </ol>
       </section>
@@ -3410,7 +3437,7 @@
               <dfn>[[\complete]]</dfn>
             </td>
             <td>
-              true if that the request for payment has completed, or false
+              Is true if that the request for payment has completed, or false
               otherwise.
             </td>
           </tr>
@@ -3428,9 +3455,9 @@
               <dfn>[[\retryPromise]]</dfn>
             </td>
             <td>
-              A <a>Promise</a> resolves when a user <a data-lt=
-              "retry the payment">retries the payment</a> or rejects if the
-              user <a>aborts retrying</a>.
+              When <a>[[\retrying]]</a> is true, a <a>Promise</a> resolves when
+              a <a>user accepts the payment request</a> or rejects if the
+              <a>user aborts the payment request</a>.
             </td>
           </tr>
           <tr>
@@ -3444,109 +3471,6 @@
             </td>
           </tr>
         </table>
-      </section>
-      <section>
-        <h2>
-          <code>PaymentResponse</code> algorithms
-        </h2>
-        <section>
-          <h3>
-            User retries the payment algorithm
-          </h3>
-          <p>
-            The <dfn data-lt="retry the payment">user retries the payment
-            algorithm</dfn> runs if the developer has called <a>retry()</a> and
-            the user attempts to reaccept a request for payment:
-          </p>
-          <ol class="algorithm">
-            <li>Let <var>response</var> be the <a>PaymentResponse</a>
-            <a>context object</a>.
-            </li>
-            <li>Let <var>request</var> be
-            <var>response</var><a>[[\request]]</a>.
-            </li>
-            <li>If <var>request</var>.<a>[[\updating]]</a> is true, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If <var>request</var>.<a>[[\state]]</a> is not
-            "<a>interactive</a>", then terminate this algorithm and take no
-            further action. The <a>user agent</a> user interface SHOULD ensure
-            that this never occurs.
-            </li>
-            <li>If the <a data-lt=
-            "PaymentOptions.requestShipping">requestShipping</a> value of <var>
-              request</var>.<a>[[\options]]</a> is true, then if the
-              <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
-              attribute of <var>request</var> is null or if the <a data-lt=
-              "PaymentRequest.shippingOption">shippingOption</a> attribute of
-              <var>request</var> is null, then terminate this algorithm and
-              take no further action. The <a>user agent</a> SHOULD ensure that
-              this never occurs.
-            </li>
-            <li>
-              <a>Queue a task</a> on the <a>user interaction task source</a> to
-              perform the following steps:
-              <ol>
-                <li>Set <var>response</var>.<a>[[\retrying]]</a> to false.
-                </li>
-                <li>Set <var>request</var>.<a>[[\state]]</a> to
-                "<a>closed</a>".
-                </li>
-                <li>Resolve <var>response</var>.<a>[[\retryPromise]]</a> with
-                undefined.
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h3>
-            User aborts retrying algorithm
-          </h3>
-          <p>
-            The <dfn data-lt="aborts retrying|abort retrying">user aborts
-            retrying algorithm</dfn> runs if the developer has called
-            <a>retry()</a> and the user aborts the payment request through the
-            currently interactive user interface. Aborting closes down any
-            remaining user interface.
-          </p>
-          <ol class="algorithm">
-            <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
-            object</a>.
-            </li>
-            <li>If the <var>response</var>.<a>[[\retrying]]</a> is false, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
-            terminate this algorithm and take no further action. The <a>user
-            agent</a> user interface SHOULD ensure that this never occurs.
-            </li>
-            <li>If <var>request</var>.<a>[[\state]]</a> is not
-            "<a>interactive</a>", then terminate this algorithm and take no
-            further action. The <a>user agent</a> user interface SHOULD ensure
-            that this never occurs.
-            </li>
-            <li>
-              <a>Queue a task</a> on the <a>user interaction task source</a> to
-              perform the following steps:
-              <ol>
-                <li>Set <var>request</var>.<a>[[\state]]</a> to
-                "<a>closed</a>".
-                </li>
-                <li>Set the <a>user agent</a>'s <a>payment request is
-                showing</a> boolean to false.
-                </li>
-                <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
-                </li>
-                <li>Reject <var>request</var>.<a>[[\retryPromise]]</a> with an
-                "<a>AbortError</a>" <a>DOMException</a>.
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </section>
       </section>
     </section>
     <section class="informative">
@@ -3945,23 +3869,41 @@
             further action. The <a>user agent</a> SHOULD ensure that this never
             occurs.
           </li>
-          <li>Let <var>response</var> be a new <a>PaymentResponse</a>.
+          <li>Let <var>isRetry</var> be true if
+          <var>request</var><a>[[\response]]</a> is not null, false otherwise.
           </li>
-          <li>Let <var>response</var>.<a>[[\request]]</a> be
-          <var>request</var>.
+          <li>Let <var>response</var> be <var>request</var><a>[[\response]]</a>
+          if <var>isRetry</var> is true, or a new <a>PaymentResponse</a>
+          otherwise.
           </li>
-          <li>Set <var>request</var>.<a>[[\response]]</a> to
-          <var>response</var>.
-          </li>
-          <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
-          attribute value of <var>response</var> to the value of
-          <var>request</var>.<a>[[\details]]</a>.<a data-lt=
-          "PaymentDetailsInit.id">id</a>.
-          </li>
-          <li>Set the <a data-lt="PaymentResponse.methodName">methodName</a>
-          attribute value of <var>response</var> to the <a>payment method
-          identifier</a> for the <a>payment method</a> that the user selected
-          to accept the payment.
+          <li>If <var>isRetry</var> if false, initialize the newly created
+          <var>response</var>:
+            <ol>
+              <li>Set <var>response</var>.<a>[[\request]]</a> to
+              <var>request</var>.
+              </li>
+              <li>Set <var>response</var>.<a>[[\retrying]]</a> to false.
+              </li>
+              <li>Set <var>response</var>.<a>[[\retryPromise]]</a> to
+              undefined.
+              </li>
+              <li>Set <var>response</var>.<a>[[\complete]]</a> to false.
+              </li>
+              <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
+              attribute value of <var>response</var> to the value of
+              <var>request</var>.<a>[[\details]]</a>.<a data-lt=
+              "PaymentDetailsInit.id">id</a>.
+              </li>
+              <li>Set the <a data-lt=
+              "PaymentResponse.methodName">methodName</a> attribute value of
+              <var>response</var> to the <a>payment method identifier</a> for
+              the <a>payment method</a> that the user selected to accept the
+              payment.
+              </li>
+              <li>Set <var>request</var>.<a>[[\response]]</a> to
+              <var>response</var>.
+              </li>
+            </ol>
           </li>
           <li>Let <var>handler</var> be the <a>payment handler</a> selected by
           the user.
@@ -4024,13 +3966,12 @@
           "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
           SHOULD format the phone number to adhere to [[!E.164]].
           </li>
-          <li>Set <var>response</var>.<a>[[\complete]]</a> to false.
+          <li>If <var>isRetry</var> is true, resolve
+          <var>response</var><a>[[\retryPromise]]</a> with undefined.
+          Otherwise, resolve <var>request</var>.<a>[[\acceptPromise]]</a> with
+          <var>response</var>.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
-          </li>
-          <li>Resolve the pending promise
-          <var>request</var>.<a>[[\acceptPromise]]</a> with
-          <var>response</var>.
           </li>
         </ol>
       </section>
@@ -4063,8 +4004,23 @@
           <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
           boolean to false.
           </li>
-          <li>Reject the promise <var>request</var>.<a>[[\acceptPromise]]</a>
-          with an "<a>AbortError</a>" <a>DOMException</a>.
+          <li>Let <var>error</var> be an "<a>AbortError</a>"
+          <a>DOMException</a>.
+          </li>
+          <li>Let <var>response</var> be
+          <var>request</var><a>[[\response]]</a>.
+          </li>
+          <li>If <var>response</var> not null:
+            <ol>
+              <li>Assert: <var>response</var><a>[[\retrying]]</a> is true.
+              </li>
+              <li>Reject <var>response</var><a>[[\retryPromise]]</a> with <var>
+                error</var>
+              </li>
+            </ol>
+          </li>
+          <li>Otherwise, reject <var>request</var>.<a>[[\acceptPromise]]</a>
+          with <var>error</var>.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3512,11 +3512,25 @@
             The <dfn data-lt="aborts retrying|abort retrying">user aborts
             retrying algorithm</dfn> runs if the developer has called
             <a>retry()</a> and the user aborts the payment request through the
-            currently interactive user interface.
+            currently interactive user interface. Aborting closes down any
+            remaining user interface.
           </p>
           <ol class="algorithm">
             <li>Let <var>request</var> be the <a>PaymentRequest</a> <a>context
             object</a>.
+            </li>
+            <li>If the <var>request</var>.<a>[[\retrying]]</a> is false, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If the <var>request</var>.<a>[[\updating]]</a> is true, then
+            terminate this algorithm and take no further action. The <a>user
+            agent</a> user interface SHOULD ensure that this never occurs.
+            </li>
+            <li>If <var>request</var>.<a>[[\state]]</a> is not
+            "<a>interactive</a>", then terminate this algorithm and take no
+            further action. The <a>user agent</a> user interface SHOULD ensure
+            that this never occurs.
             </li>
             <li>
               <a>Queue a task</a> on the <a>user interaction task source</a> to

--- a/index.html
+++ b/index.html
@@ -3131,12 +3131,48 @@
           readonly attribute DOMString? payerPhone;
 
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
+          Promise&lt;void&gt; retry();
         };
       </pre>
       <p class="note">
         A <a>PaymentResponse</a> is returned when a user has selected a payment
         method and approved a payment request.
       </p>
+      <section>
+        <h2>
+          <dfn>retry()</dfn> method
+        </h2>
+        <ol class="algorithm">
+          <li>Let response be the context object.
+          </li>
+          <li>Let request be response.[[\request]].
+          </li>
+          <li>If response.[[\completeCalled]] is true, throw a
+          "InvalidStateError" DOMException.
+          </li>
+          <li>If request.[[\state]] is not "closed", throw a
+          "InvalidStateError" DOMException.
+          </li>
+          <li>Set request.[[\state]] to "interactive".
+          </li>
+          <li>Set request.[[\retrying]] to true.
+          </li>
+          <li>Let promiseToRetry be a newly created promise.
+          </li>
+          <li>In parallel:
+            <ol>
+              <li>If the <a>user accepts the retry</a>, resolve promiseToRetry
+              with undefined.
+              </li>
+              <li>If the <a>user aborts the retry</a>, reject promiseToRetry
+              with an "AbortError" DOMException.
+              </li>
+            </ol>
+          </li>
+          <li>Return promiseToRetry.
+          </li>
+        </ol>
+      </section>
       <section>
         <h2>
           <dfn>toJSON()</dfn> method
@@ -3745,6 +3781,8 @@
             occurs.
           </li>
           <li>Let <var>response</var> be a new <a>PaymentResponse</a>.
+          </li>
+          <li>Let <var>response</var>.[[\request]] be <var>request</var>.
           </li>
           <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
           attribute value of <var>response</var> to the value of


### PR DESCRIPTION
Finally, part 5 of #705  - closes #705 

Defines PaymentRequest's internal slots. 
In some cases, PaymentResponse just puts forward PaymentRequest's internal slot values.  

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/726.html" title="Last updated on Jun 12, 2018, 1:25 PM GMT (4c766a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/726/12ef9c4...4c766a5.html" title="Last updated on Jun 12, 2018, 1:25 PM GMT (4c766a5)">Diff</a>