### PR TITLE
fix: complete() returns rejected promise

### DIFF
--- a/index.html
+++ b/index.html
@@ -3490,24 +3490,25 @@
           arguments.
         </p>
         <p data-tests="payment-response/complete-method-manual.https.html">
-          The <a>complete(result)</a> method MUST act as follows:
+          The <a><code>complete(<var>result</var>)</code></a> method MUST act
+          as follows:
         </p>
         <ol class="algorithm">
           <li>Let <var>response</var> be the <a>context object</a>.
           </li>
+          <li>If <var>response</var>.<a>[[\complete]]</a> is true, return <a>a
+          promise rejected with</a> an "<a>InvalidStateError</a>"
+          <a>DOMException</a>.
+          </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>
-          <li>If <var>response</var>.<a>[[\complete]]</a> is true, reject <var>
-            promise</var> with an "<a>InvalidStateError</a>"
-            <a>DOMException</a>.
+          <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li data-tests=
           "payment-request/payment-response/retry-method-manual.https.html">If
           <var>response</var>.<a>[[\retryPromise]]</a> is not null, reject
           <var>promise</var> with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
-          </li>
-          <li>Otherwise, set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps <a>in
           parallel</a>.


### PR DESCRIPTION
The current spec text read as if calling complete() twice would cause
the interface to close down based on the second call.

This just returns a rejected promise if the completeCalled is `true`.

 * [x] [Added WP Tests](https://github.com/web-platform-tests/wpt/pull/11665/)

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/732.html" title="Last updated on Jun 19, 2018, 6:01 PM GMT (0f76266)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/732/e434531...0f76266.html" title="Last updated on Jun 19, 2018, 6:01 PM GMT (0f76266)">Diff</a>