### PR TITLE
Fix a small bug in `abort`'s error handling.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,8 +1113,9 @@
           <li>Let <var>request</var> be the <a>context object</a>.
           </li>
           <li>If the value of <var>request</var>.<a>[[\state]]</a> is not
-          "<a>interactive</a>" then <a>throw</a> an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
+          "<a>interactive</a>" then return a promise rejected with a
+          "<a>InvalidStateError</a>" <a>DOMException</a> and terminate this
+          algorithm.
           </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>


### PR DESCRIPTION
Because `PaymentRequest.abort` returns a `Promise<void>`, it shouldn't be specified to throw exceptions. Instead, it should return rejected promises.

Somewhat complicating this is that Safari does throw an exception (even though Firefox and Blink do not). This has an impact on web developers as an eager exception will stop their scripts and a rejected promise will not.