### PR TITLE
Add error member to PaymentValidationErrors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3224,12 +3224,14 @@
           <li>Set <var>response</var>.<a>[[\retryPromise]]</a> to
           <var>retryPromise</var>.
           </li>
-          <li>By matching the members of <var>errorFields</var> to input fields
-          in the user agent's UI, indicate to the end-user that something is
-          wrong with the data of the payment response. For example, a user
-          agent might draw the user's attention to the erroneous
-          <var>errorFields</var> in the browser's UI and display the value of
-          each field in a manner that helps the user fix each error.
+          <li data-link-for="PaymentValidationErrors">By matching the members
+          of <var>errorFields</var> to input fields in the user agent's UI,
+          indicate to the end-user that something is wrong with the data of the
+          payment response. For example, a user agent might draw the user's
+          attention to the erroneous <var>errorFields</var> in the browser's UI
+          and display the value of each field in a manner that helps the user
+          fix each error. Similarly, if the <a>error</a> member is passed,
+          present the error in the user agent's UI.
           </li>
           <li data-tests=
           "payment-request/payment-response/rejects_if_not_active-manual.https.html">
@@ -3268,6 +3270,7 @@
             dictionary PaymentValidationErrors {
               PayerErrorFields payer;
               AddressErrors shippingAddress;
+              DOMString error;
             };
           </pre>
           <dl>
@@ -3283,6 +3286,17 @@
             <dd data-link-for="PaymentResponse">
               Represents validation errors with the <a>PaymentResponse</a>'s
               <a>shippingAddress</a>.
+            </dd>
+            <dt>
+              <dfn>error</dfn> member
+            </dt>
+            <dd>
+              A general description of an error with the payment from which the
+              user can attempt to recover from by, for example, retrying a
+              payment. A developer can optionally pass the <a>error</a> member
+              on its own to give a general overview of validation issues, or it
+              can be passed in combination with other members of the
+              <a>PaymentValidationErrors</a> dictionary.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
closes #729

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Added Web platform tests](https://github.com/web-platform-tests/wpt/pull/12394)
 * [x] [Added MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse/retry#Parameters)
 * [ ] added MDN [compat data](https://github.com/mdn/browser-compat-data)

Implementation commitment:

 * [x] Safari - already implemented.
 * [x] [Chrome](https://crbug.com/861704)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1473081)
 * [ ] Edge (public signal)

Impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/747.html" title="Last updated on Apr 2, 2019, 6:50 PM UTC (cb4c61b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/747/ede9460...cb4c61b.html" title="Last updated on Apr 2, 2019, 6:50 PM UTC (cb4c61b)">Diff</a>