### PR TITLE
Support fine-grained errors for payment methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -3225,11 +3225,32 @@
           <var>retryPromise</var>.
           </li>
           <li data-link-for="PaymentValidationErrors" data-tests=
-          "payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html">
-          By matching the members of <var>errorFields</var> to input fields in
-          the user agent's UI, indicate to the end-user that something is wrong
-          with the data of the payment response. For example, a user agent
-          might draw the user's attention to the erroneous
+          "payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html">If
+          <var>errorFields</var>'s <a>paymentMethod</a> member was passed, and
+          if required by the specification that defines <var>response</var>'s
+          <a>payment method</a>, then <a data-cite=
+          "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
+          <var>errorFields</var> <a>paymentMethod</a> to an IDL value.
+          Otherwise, <a data-cite=
+          "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
+          <a data-cite="!WEBIDL#idl-object">object</a>.
+          </li>
+          <li>If conversion results in a <a data-cite="!WEBIDL#dfn-exception">
+            exception</a> <var>error</var>:
+            <ol>
+              <li>Reject <var>retryPromise</var> with <var>error</var>.
+              </li>
+              <li>Set <a>user agent</a>'s <a>payment request is showing</a>
+              boolean to false.
+              </li>
+              <li>Return.
+              </li>
+            </ol>
+          </li>
+          <li>By matching the members of <var>errorFields</var> to input fields
+          in the user agent's UI, indicate to the end-user that something is
+          wrong with the data of the payment response. For example, a user
+          agent might draw the user's attention to the erroneous
           <var>errorFields</var> in the browser's UI and display the value of
           each field in a manner that helps the user fix each error. Similarly,
           if the <a>error</a> member is passed, present the error in the user
@@ -3273,6 +3294,7 @@
               PayerErrorFields payer;
               AddressErrors shippingAddress;
               DOMString error;
+              object paymentMethod;
             };
           </pre>
           <dl>
@@ -3299,6 +3321,14 @@
               on its own to give a general overview of validation issues, or it
               can be passed in combination with other members of the
               <a>PaymentValidationErrors</a> dictionary.
+            </dd>
+            <dt>
+              <dfn>paymentMethod</dfn> member
+            </dt>
+            <dd>
+              A payment method specific error. See, for example,
+              [[payment-method-basic-card]]'s <code><a data-cite=
+              "payment-method-basic-card#basiccarderrorfields-dictionary">BasicCardErrorFields</a></code>.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -981,7 +981,8 @@
               <li>If required by the specification that defines the
               <var>identifer</var>, then <a data-cite=
               "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-              <var>data</var> to an IDL value. Otherwise, <a data-cite=
+              <var>data</var> to an IDL value of the type specified there.
+              Otherwise, <a data-cite=
               "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
               <a data-cite="!WEBIDL#idl-object">object</a>.
               </li>
@@ -1040,7 +1041,7 @@
           </li>
           <li data-tests=
           "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">
-          If <var>detailsPromise</var> was passed, then:
+          If <var>detailsPromise</var> is present, then:
             <ol>
               <li>Run the <a>update a <code>PaymentRequest</code>'s details
               algorithm</a> with <var>detailsPromise</var> and
@@ -3230,8 +3231,8 @@
           if required by the specification that defines <var>response</var>'s
           <a>payment method</a>, then <a data-cite=
           "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-          <var>errorFields</var> <a>paymentMethod</a> to an IDL value.
-          Otherwise, <a data-cite=
+          <var>errorFields</var> <a>paymentMethod</a> to an IDL value of the
+          type specified there. Otherwise, <a data-cite=
           "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
           <a data-cite="!WEBIDL#idl-object">object</a>.
           </li>
@@ -3326,7 +3327,7 @@
               <dfn>paymentMethod</dfn> member
             </dt>
             <dd>
-              A payment method specific error. See, for example,
+              A payment method specific errors. See, for example,
               [[payment-method-basic-card]]'s <code><a data-cite=
               "payment-method-basic-card#basiccarderrorfields-dictionary">BasicCardErrorFields</a></code>.
             </dd>

--- a/index.html
+++ b/index.html
@@ -1041,7 +1041,7 @@
           </li>
           <li data-tests=
           "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">
-          If <var>detailsPromise</var> is present, then:
+          If <var>detailsPromise</var> was passed, then:
             <ol>
               <li>Run the <a>update a <code>PaymentRequest</code>'s details
               algorithm</a> with <var>detailsPromise</var> and

--- a/index.html
+++ b/index.html
@@ -3226,10 +3226,10 @@
           <var>retryPromise</var>.
           </li>
           <li data-link-for="PaymentValidationErrors" data-tests=
-          "payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html">If
-          <var>errorFields</var>'s <a>paymentMethod</a> member was passed, and
-          if required by the specification that defines <var>response</var>'s
-          <a>payment method</a>, then <a data-cite=
+          "payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html">
+          If <var>errorFields</var>'s <a>paymentMethod</a> member was passed,
+          and if required by the specification that defines
+          <var>response</var>'s <a>payment method</a>, then <a data-cite=
           "!WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
           <var>errorFields</var> <a>paymentMethod</a> to an IDL value of the
           type specified there. Otherwise, <a data-cite=


### PR DESCRIPTION
closes  #727

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] Added Web platform tests (link)
 * [ ] added MDN Docs (link)
 * [ ] added MDN [compat data](https://github.com/mdn/browser-compat-data)

Implementation commitment:

 * [x] Safari - already implemented.
 * [ ] [Chrome](https://crbug.com/861704)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1473081)
 * [ ] Edge (public signal)

Impact on Payment Handler spec?
See: https://github.com/w3c/payment-handler/issues/306

So we can do, for example: 
<img width="576" alt="screenshot 2018-06-26 14 14 33" src="https://user-images.githubusercontent.com/870154/42403085-c4c63532-814c-11e8-8ad7-d0858b8e62f6.png">


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/752.html" title="Last updated on Nov 2, 2018, 9:53 PM GMT (ae06907)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/752/4efc654...ae06907.html" title="Last updated on Nov 2, 2018, 9:53 PM GMT (ae06907)">Diff</a>