### PR TITLE
Rename AddressErrorFields -> AddressErrors

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,10 +505,9 @@
           validation errors with specific attributes of a
           <a>PaymentAddress</a>. The <a data-link-for=
           "PaymentDetailsUpdate">shippingAddressErrors</a> member is a
-          <a>AddressErrorFields</a> dictionary, whose members specifically
-          demarcate the fields of a <a>physical address</a> that are erroneous
-          while also providing helpful error messages to be displayed to the
-          end user.
+          <a>AddressErrors</a> dictionary, whose members specifically demarcate
+          the fields of a <a>physical address</a> that are erroneous while also
+          providing helpful error messages to be displayed to the end user.
         </p>
         <pre class="example">
           request.onshippingaddresschange = ev =&gt; {
@@ -1787,7 +1786,7 @@
           dictionary PaymentDetailsUpdate : PaymentDetailsBase {
             DOMString error;
             PaymentItem total;
-            AddressErrorFields shippingAddressErrors;
+            AddressErrors shippingAddressErrors;
           };
         </pre>
         <p>
@@ -2787,13 +2786,12 @@
           </dd>
         </dl>
       </section>
-      <section data-dfn-for="AddressErrorFields" data-link-for=
-      "AddressErrorFields">
+      <section data-dfn-for="AddressErrors" data-link-for="AddressErrors">
         <h2>
-          <dfn>AddressErrorFields</dfn> dictionary
+          <dfn>AddressErrors</dfn> dictionary
         </h2>
         <pre class="idl">
-          dictionary AddressErrorFields {
+          dictionary AddressErrors {
             DOMString addressLine;
             DOMString city;
             DOMString country;
@@ -2809,7 +2807,7 @@
           };
         </pre>
         <p>
-          The members of the <a>AddressErrorFields</a> dictionary represent
+          The members of the <a>AddressErrors</a> dictionary represent
           validation errors with specific parts of a <a>physical address</a>.
           Each dictionary member has a dual function: firstly, its presence
           denotes that a particular part of an address is suffering from a
@@ -3257,7 +3255,7 @@
           <pre class="idl">
             dictionary PaymentValidationErrors {
               PayerErrorFields payer;
-              AddressErrorFields shippingAddress;
+              AddressErrors shippingAddress;
             };
           </pre>
           <dl>
@@ -4622,8 +4620,8 @@
                       member is present, the user agent SHOULD display an error
                       specifically for each erroneous field of the shipping
                       address. This is done by matching each present member of
-                      the <a>AddressErrorFields</a> to a corresponding input
-                      field in the shown user interface.
+                      the <a>AddressErrors</a> to a corresponding input field
+                      in the shown user interface.
                     </p>
                   </li>
                 </ol>


### PR DESCRIPTION
The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Added Web platform tests](https://github.com/web-platform-tests/wpt/pull/12001)
 * [ ] added MDN Docs (link)
 * [ ] added MDN [compat data](https://github.com/mdn/browser-compat-data)

Implementation commitment:

 * [x] Safari - already implemented as AddressErrors.
 * [ ] Chrome (link to issue)
 * [X] Firefox - already implemented. 
 * [ ] Edge (public signal)

Impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/755.html" title="Last updated on Nov 2, 2018, 9:51 PM GMT (04752ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/755/5234bb0...04752ca.html" title="Last updated on Nov 2, 2018, 9:51 PM GMT (04752ca)">Diff</a>