### PR TITLE
Editorial: fix grammatical error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3757,8 +3757,7 @@
               <dfn>methodDetails</dfn> member
             </dt>
             <dd>
-              An object representing the some data from the payment method, or
-              null.
+              An object representing some data from the payment method, or null.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Just a small, grammatical fix.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/payment-request/pull/756.html" title="Last updated on Jul 18, 2018, 7:52 PM GMT (ba33fd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/756/a0ff44f...christianliebel:ba33fd6.html" title="Last updated on Jul 18, 2018, 7:52 PM GMT (ba33fd6)">Diff</a>