### PR TITLE
fix: give PaymentMethodChangeEventInit defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -3822,7 +3822,7 @@
           <pre class="idl">
             dictionary PaymentMethodChangeEventInit : PaymentRequestUpdateEventInit {
               DOMString methodName = "";
-              object? methodDetails;
+              object? methodDetails = null;
             };
           </pre>
           <dl>

--- a/index.html
+++ b/index.html
@@ -3821,7 +3821,7 @@
           </h3>
           <pre class="idl">
             dictionary PaymentMethodChangeEventInit : PaymentRequestUpdateEventInit {
-              required DOMString methodName;
+              DOMString methodName = "";
               object? methodDetails;
             };
           </pre>


### PR DESCRIPTION
closes #770 

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests (link)
 * [x] Modified MDN Docs (link)

Implementation commitment:

 * [ ] [Safari](https://bugs.webkit.org/show_bug.cgi?id=189100)
 * [ ] Chrome (link to issue)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1487295)
 * [ ] Edge (public signal)

Optional, Impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/771.html" title="Last updated on Sep 4, 2018, 7:39 AM GMT (ddfc88a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/771/138a787...ddfc88a.html" title="Last updated on Sep 4, 2018, 7:39 AM GMT (ddfc88a)">Diff</a>