### PR TITLE
fix: give dictionary members sensible defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -1819,8 +1819,8 @@
           dictionary PaymentDetailsUpdate : PaymentDetailsBase {
             DOMString error;
             PaymentItem total;
-            AddressErrors shippingAddressErrors;
-            PayerErrorFields payerErrors;
+            AddressErrors shippingAddressErrors = null;
+            PayerErrorFields payerErrors = null;
             object paymentMethodErrors;
           };
         </pre>
@@ -3353,8 +3353,8 @@
           </h3>
           <pre class="idl">
             dictionary PaymentValidationErrors {
-              PayerErrorFields payer;
-              AddressErrors shippingAddress;
+              PayerErrorFields payer = null;
+              AddressErrors shippingAddress = null;
               DOMString error;
               object paymentMethod;
             };


### PR DESCRIPTION
*closes #780

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] Modified Web platform tests (link)
 * [ ] Modified MDN Docs (link)

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1368949)
 * [ ] Edge (public signal)

Optional, Impact on Payment Handler spec?
None.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/781.html" title="Last updated on Sep 26, 2018, 9:19 AM GMT (f21c95e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/781/4020346...f21c95e.html" title="Last updated on Sep 26, 2018, 9:19 AM GMT (f21c95e)">Diff</a>