### PR TITLE
Editorial: fix link to basic card error dictionary in examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -1886,8 +1886,8 @@
             <p>
               <a>Payment method</a> specific errors. See, for example,
               [[!payment-method-basic-card]]'s <a data-cite=
-              "payment-method-basic-card#basiccarderrorfields-dictionary"><code>
-              BasicCardErrorFields</code></a>.
+              "payment-method-basic-card#basiccarderrors-dictionary"><code>
+              BasicCardErrors</code></a>.
             </p>
           </dd>
         </dl>
@@ -3390,8 +3390,8 @@
             <dd>
               A payment method specific errors. See, for example,
               [[payment-method-basic-card]]'s <a data-cite=
-              "payment-method-basic-card#basiccarderrorfields-dictionary"><code>
-              BasicCardErrorFields</code></a>.
+              "payment-method-basic-card#basiccarderrors-dictionary"><code>
+              BasicCardErrors</code></a>.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Purely editorial change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mnoorenberghe/payment-request/pull/783.html" title="Last updated on Sep 27, 2018, 8:13 AM GMT (da9b9fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/783/21bc47b...mnoorenberghe:da9b9fc.html" title="Last updated on Sep 27, 2018, 8:13 AM GMT (da9b9fc)">Diff</a>