### PR TITLE
Fix #785 : data-test should be changed to data-tests in spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@
               or the <a>user aborts the payment request algorithm</a>, which
               are triggered through interaction with the user interface.
             </p>
-            <p data-test="rejects_if_not_active.https.html">
+            <p data-tests="rejects_if_not_active.https.html">
               If <var>document</var> stops being <a data-cite=
               "!HTML#fully-active">fully active</a> while the user interface is
               being shown, or no longer is by the time this step is reached,
@@ -3921,7 +3921,7 @@
           <h3>
             <dfn>complete()</dfn> method
           </h3>
-          <p data-test=
+          <p data-tests=
           "payment-request/MerchantValidationEvent/complete-method-manual.https.html">
             The <a>MerchantValidationEvent</a>'s
             <code>complete(<var>merchantSessionPromise</var>)</code> method


### PR DESCRIPTION
The bug is fixed. Now the spec contains `data-tests` everywhere. @marcoscaceres Please review. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Sylvia23/payment-request/pull/786.html" title="Last updated on Sep 28, 2018, 8:54 AM GMT (969175f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/786/db5b354...Sylvia23:969175f.html" title="Last updated on Sep 28, 2018, 8:54 AM GMT (969175f)">Diff</a>