### PR TITLE
Fix #787 : Fix the links to the `data-tests` in the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,7 +637,7 @@
         </p>
         <ol data-link-for="PaymentDetailsBase" class="algorithm">
           <li data-tests=
-          "active-document-cross-origin.https.sub.html, active-document-same-origin.https.html, removing-allowpaymentrequest.https.sub.html, setting-allowpaymentrequest-timing.https.sub.html, setting-allowpaymentrequest.https.sub.html">
+          "allowpaymentrequest/active-document-cross-origin.https.sub.html, allowpaymentrequest/active-document-same-origin.https.html, allowpaymentrequest/removing-allowpaymentrequest.https.sub.html, allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html, allowpaymentrequest/setting-allowpaymentrequest.https.sub.html">
           If the <a>current settings object</a>'s <a data-cite=
           "!HTML#responsible-document">responsible document</a> is not
           <a>allowed to use</a> the feature indicated by attribute name
@@ -901,13 +901,13 @@
           </p>
         </div>
         <p data-tests=
-        "payment-request-show-method.https.html, payment-request-show-method-manual.https.html">
+        "payment-request-show-method.https.html, payment-request-show-method.https.html">
           The <code>show(optional <var>detailsPromise</var>)</code> method MUST
           act as follows:
         </p>
         <ol class="algorithm">
           <li data-tests=
-          "payment-request-show-method-manual.https.html, show-method-postmessage-manual.https.html">
+          "payment-request-show-method.https.html, show-method-postmessage-manual.https.html">
           If the method was not <a>triggered by user activation</a>, return <a>
             a promise rejected with</a> with a "<a>SecurityError</a>"
             <a>DOMException</a>.
@@ -1135,7 +1135,7 @@
             request</a>.
           </p>
         </div>
-        <p data-tests="payment-request-abort-method-manual.https.html">
+        <p data-tests="payment-request-abort-method.https.html">
           The <a>abort()</a> method MUST act as follows:
         </p>
         <ol class="algorithm">
@@ -1194,7 +1194,7 @@
           <a>DOMException</a>, at its discretion.
         </p>
         <p data-tests=
-        "payment-request-canmakepayment-method-manual.https.html">
+        "payment-request-canmakepayment-method.https.html">
           The <a>canMakePayment()</a> method MUST act as follows:
         </p>
         <ol class="algorithm">
@@ -1297,7 +1297,7 @@
           <dfn>onmerchantvalidation</dfn> attribute
         </h2>
         <p data-tests=
-        "payment-request/onmerchantvalidation-attribute.https.html">
+        "onmerchantvalidation-attribute.https.html">
           A <a>PaymentRequest</a>'s <a>onmerchantvalidation</a> attribute is an
           <a>EventHandler</a> for a <a>MerchantValidationEvent</a> named
           "<a>merchantvalidation</a>".
@@ -3287,7 +3287,7 @@
           <var>retryPromise</var>.
           </li>
           <li data-link-for="PaymentValidationErrors" data-tests=
-          "payment-request/PaymentValidationErrors/retry-shows-error-member-manual.https.html">
+          "PaymentValidationErrors/retry-shows-error-member-manual.https.html">
           If <var>errorFields</var>'s <a>paymentMethod</a> member was passed,
           and if required by the specification that defines
           <var>response</var>'s <a>payment method</a>, then <a data-cite=
@@ -3319,7 +3319,7 @@
           present the error in the user agent's UI.
           </li>
           <li data-tests=
-          "payment-request/payment-response/rejects_if_not_active-manual.https.html">
+          "payment-response/rejects_if_not_active-manual.https.html">
           If <var>document</var> stops being <a data-cite="!HTML#fully-active">
             fully active</a> while the user interface is being shown, or no
             longer is by the time this step is reached, then:
@@ -3627,7 +3627,7 @@
           <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
           </li>
           <li data-tests=
-          "payment-request/payment-response/retry-method-manual.https.html">If
+          "payment-response/retry-method-manual.https.html">If
           <var>response</var>.<a>[[\retryPromise]]</a> is not null, reject
           <var>promise</var> with an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
@@ -4174,7 +4174,7 @@
             </pre>
           </aside>
           <p data-tests=
-          "payment-request-update-event-updatewith-method.https.html, PaymentRequestUpdateEvent/updateWith-incremental-update-manual.https.html">
+          "PaymentRequestUpdateEvent/updatewith-method.https.html, PaymentRequestUpdateEvent/updateWith-incremental-update-manual.https.html">
             The <a><code>updateWith(<var>detailsPromise</var>)</code></a>
             method MUST act as follows:
           </p>


### PR DESCRIPTION
We need to fix the links of the data-tests by linking them to appropriate test suite in the payment-request directory. Some of them have been renamed, some had wrong address. This PR fixes the issue and now all the data-tests in the spec point to appropriate data suite in the payment request directory. @marcoscaceres Please review. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Sylvia23/payment-request/pull/788.html" title="Last updated on Sep 28, 2018, 10:37 AM GMT (6a38bf7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/788/db5b354...Sylvia23:6a38bf7.html" title="Last updated on Sep 28, 2018, 10:37 AM GMT (6a38bf7)">Diff</a>