### PR TITLE
fix: retry()'s errorFields should be optional per WebIDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -3087,7 +3087,7 @@
           [NewObject]
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
           [NewObject]
-          Promise&lt;void&gt; retry(PaymentValidationErrors errorFields);
+          Promise&lt;void&gt; retry(optional PaymentValidationErrors errorFields);
 
           attribute EventHandler onpayerdetailchange;
         };


### PR DESCRIPTION
closes #804 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests (auto fixes on next IDL crawl)
 * [x] Modified MDN Docs (nothing to fix, not covered at this level of detail)

Implementation commitment:

 * [x] [Safari](https://bugs.webkit.org/show_bug.cgi?id=191212)
 * [x] [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=901703)
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1499992) - Our IDL binding layer caught this. 
 * [ ] Edge (public signal)

Optional, Impact on Payment Handler spec?