### PR TITLE
fix: while retrying complete() returns a rejected promise

### DIFF
--- a/index.html
+++ b/index.html
@@ -3445,14 +3445,14 @@
           promise rejected with</a> an "<a>InvalidStateError</a>"
           <a>DOMException</a>.
           </li>
+          <li data-tests="payment-response/retry-method-manual.https.html">If
+          <var>response</var>.<a>[[\retryPromise]]</a> is not null, return <a>
+            a promise rejected with</a> an "<a>InvalidStateError</a>"
+            <a>DOMException</a>.
+          </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
           </li>
           <li>Set <var>response</var>.<a>[[\complete]]</a> to true.
-          </li>
-          <li data-tests="payment-response/retry-method-manual.https.html">If
-          <var>response</var>.<a>[[\retryPromise]]</a> is not null, reject
-          <var>promise</var> with an "<a>InvalidStateError</a>"
-          <a>DOMException</a>.
           </li>
           <li>Return <var>promise</var> and perform the remaining steps <a>in
           parallel</a>.


### PR DESCRIPTION
closes #795

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/14117)

Implementation commitment:

 * [x] Safari (link to issue)
 * [x] Chrome (link to issue)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1510118)
 * [ ] Edge (public signal)

Optional, Impact on Payment Handler spec?
None.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/808.html" title="Last updated on Dec 3, 2018, 10:49 PM GMT (4c7b92a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/808/1d5bcd8...4c7b92a.html" title="Last updated on Dec 3, 2018, 10:49 PM GMT (4c7b92a)">Diff</a>