### PR TITLE
Attach 'payment request is showing boolean' to top-level browsing context

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,9 +610,20 @@
         </p>
       </div>
       <p>
-        Each <a>top-level browsing context</a> has a <dfn>payment request is
-        showing</dfn> boolean, which prevents showing more than one payment UI
-        at a time.
+        A <var>request</var>'s <dfn>payment-relevant browsing context</dfn> is
+        that <a>PaymentRequest</a>'s <a data-cite=
+        "HTML#concept-relevant-global">relevant global object</a>'s browsing
+        context's <a>top-level browsing context</a>. Every <a>payment-relevant
+        browsing context</a> has a <dfn>payment request is showing</dfn>
+        boolean, which prevents showing more than one payment UI at a time.
+      </p>
+      <p class="Note">
+        A payment handlers can restrict the <a>user agent</a> to showing only
+        one payment UI across all browser windows and tabs. Other payment
+        handlers might allow showing a payment UI across disparate browser
+        tabs. However, in all cases, the <a>payment request is showing</a>
+        boolean simply prevents more than one payment UI being shown in a
+        single browser tab.
       </p>
       <section>
         <h2>
@@ -934,9 +945,10 @@
           then return <a>a promise rejected with</a> an
           "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>If the <a>top-level browsing context</a>'s <a>payment request is
-          showing</a> boolean is true, then return <a>a promise rejected
-          with</a> an "<a>AbortError</a>" <a>DOMException</a>.
+          <li>If <var>request</var>'s <a>payment-relevant browsing
+          context</a>'s <a>payment request is showing</a> boolean is true, then
+          return <a>a promise rejected with</a> an "<a>AbortError</a>"
+          <a>DOMException</a>.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
@@ -966,8 +978,8 @@
               advantage of this step.
             </p>
           </li>
-          <li>Set the <a>top-level browsing context</a>'s <a>payment request is
-          showing</a> boolean to true.
+          <li>Set <var>request</var>'s <a>payment-relevant browsing
+          context</a>'s <a>payment request is showing</a> boolean to true.
           </li>
           <li>Return <var>acceptPromise</var> and perform the remaining steps
           <a>in parallel</a>.
@@ -1000,8 +1012,9 @@
                   </li>
                   <li>Reject <var>acceptPromise</var> with <var>error</var>.
                   </li>
-                  <li>Set <a>top-level browsing context</a>'s <a>payment
-                  request is showing</a> boolean to false.
+                  <li>Set <var>request</var>'s <a>payment-relevant browsing
+                  context</a>'s <a>payment request is showing</a> boolean to
+                  false.
                   </li>
                   <li>Terminate this algorithm.
                   </li>
@@ -1031,8 +1044,8 @@
               <li>Reject <var>acceptPromise</var> with
               "<a>NotSupportedError</a>" <a>DOMException</a>.
               </li>
-              <li>Set <a>top-level browsing context</a>'s <a>payment request is
-              showing</a> boolean to false.
+              <li>Set <var>request</var>'s <a>payment-relevant browsing
+              context</a>'s <a>payment request is showing</a> boolean to false.
               </li>
               <li>Terminate this algorithm.
               </li>
@@ -1094,8 +1107,8 @@
             <ol>
               <li>Close down the user interface.
               </li>
-              <li>Set the <a>top-level browsing context</a>'s <a>payment
-              request is showing</a> boolean to false.
+              <li>Set <var>request</var>'s <a>payment-relevant browsing
+              context</a>'s <a>payment request is showing</a> boolean to false.
               </li>
               <li>Reject <var>acceptPromise</var> with an "<a>AbortError</a>"
               <a>DOMException</a>.
@@ -3169,8 +3182,8 @@
               "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
               <a data-cite="WEBIDL#idl-object">object</a>.
               </li>
-              <li>Set <a>top-level browsing context</a>'s <a>payment request is
-              showing</a> boolean to false.
+              <li>Set <var>request</var>'s <a>payment-relevant browsing
+              context</a>'s <a>payment request is showing</a> boolean to false.
               </li>
               <li>If conversion results in a <a data-cite=
               "WEBIDL#dfn-exception">exception</a> <var>error</var>:
@@ -3203,8 +3216,8 @@
             <ol>
               <li>Close down the user interface.
               </li>
-              <li>Set the <a>top-level browsing context</a>'s <a>payment
-              request is showing</a> boolean to false.
+              <li>Set <var>request</var>'s <a>payment-relevant browsing
+              context</a>'s <a>payment request is showing</a> boolean to false.
               </li>
               <li>Reject <var>retryPromise</var> with an "<a>AbortError</a>"
               <a>DOMException</a>.
@@ -3515,8 +3528,8 @@
             <ol>
               <li>Close down the user interface.
               </li>
-              <li>Set the <a>top-level browsing context</a>'s <a>payment
-              request is showing</a> boolean to false.
+              <li>Set <var>request</var>'s <a>payment-relevant browsing
+              context</a>'s <a>payment request is showing</a> boolean to false.
               </li>
               <li>Reject <var>promise</var> with an "<a>AbortError</a>"
               <a>DOMException</a>.
@@ -3529,8 +3542,8 @@
               agent</a> MAY use the value <var>result</var> to influence the
               user experience.
               </li>
-              <li>Set the <a>top-level browsing context</a>'s <a>payment
-              request is showing</a> boolean to false.
+              <li>Set <var>request</var>'s <a>payment-relevant browsing
+              context</a>'s <a>payment request is showing</a> boolean to false.
               </li>
               <li>Resolve <var>promise</var> with undefined.
               </li>
@@ -4615,8 +4628,8 @@
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
           </li>
-          <li>Set the <a>top-level browsing context</a>'s <a>payment request is
-          showing</a> boolean to false.
+          <li>Set <var>request</var>'s <a>payment-relevant browsing
+          context</a>'s <a>payment request is showing</a> boolean to false.
           </li>
           <li>Let <var>error</var> be an "<a>AbortError</a>"
           <a>DOMException</a>.
@@ -4989,8 +5002,9 @@
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               perform the following steps:
               <ol>
-                <li>Set the <a>top-level browsing context</a>'s <a>payment
-                request is showing</a> boolean to false.
+                <li>Set <var>request</var>'s <a>payment-relevant browsing
+                context</a>'s <a>payment request is showing</a> boolean to
+                false.
                 </li>
                 <li>Set <var>request</var>.<a>[[\state]]</a> to
                 "<a>closed</a>".

--- a/index.html
+++ b/index.html
@@ -614,13 +614,6 @@
         showing</dfn> boolean, which prevents showing more than one payment UI
         at a time.
       </p>
-      <p class="note">
-        Each payment handler controls what happens when multiple browsing
-        context simultaneously call the <a>show()</a> method. For instance,
-        some payment handlers will allow multiple payment UIs to be shown in
-        different browser tabs/windows. Other payment handlers might only allow
-        a single payment UI to be shown for the entire user agent.
-      </p>
       <section>
         <h2>
           Constructor
@@ -896,12 +889,13 @@
             be presented to the user to facilitate the payment request after
             the <a>show()</a> method returns.
           </p>
-          <p>
-            It is not possible to show multiple <a>PaymentRequest</a>s at the
-            same time within one <a>user agent</a>. If a <a>PaymentRequest</a>
-            is already showing, calling <a>show()</a> —from any Web site— will
-            return <a>a promise rejected with</a> an "<a>AbortError</a>"
-            <a>DOMException</a>.
+          <p class="note">
+            Each payment handler controls what happens when multiple browsing
+            context simultaneously call the <a>show()</a> method. For instance,
+            some payment handlers will allow multiple payment UIs to be shown
+            in different browser tabs/windows. Other payment handlers might
+            only allow a single payment UI to be shown for the entire user
+            agent.
           </p>
         </div>
         <p data-tests="payment-request-show-method.https.html">

--- a/index.html
+++ b/index.html
@@ -609,12 +609,17 @@
           member is set.
         </p>
       </div>
-      <p data-link-for="PaymentRequest">
-        Because the simultaneous display of multiple <a>PaymentRequest</a> user
-        interfaces might confuse the user, this specification limits the
-        <a>user agent</a> to displaying one at a time via the <a>show()</a>
-        method. This is ensured by a <dfn>payment request is showing</dfn>
-        boolean.
+      <p>
+        Each <a>top-level browsing context</a> has a <dfn>payment request is
+        showing</dfn> boolean, which prevents showing more than one payment UI
+        at a time.
+      </p>
+      <p class="note">
+        Each payment handler controls what happens when multiple browsing
+        context simultaneously call the <a>show()</a> method. For instance,
+        some payment handlers will allow multiple payment UIs to be shown in
+        different browser tabs/windows. Other payment handlers might only allow
+        a single payment UI to be shown for the entire user agent.
       </p>
       <section>
         <h2>
@@ -935,9 +940,9 @@
           then return <a>a promise rejected with</a> an
           "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
-          <li>If the <a>user agent</a>'s <a>payment request is showing</a>
-          boolean is true, then return <a>a promise rejected with</a> an
-          "<a>AbortError</a>" <a>DOMException</a>.
+          <li>If the <a>top-level browsing context</a>'s <a>payment request is
+          showing</a> boolean is true, then return <a>a promise rejected
+          with</a> an "<a>AbortError</a>" <a>DOMException</a>.
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>
@@ -967,8 +972,8 @@
               advantage of this step.
             </p>
           </li>
-          <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-          boolean to true.
+          <li>Set the <a>top-level browsing context</a>'s <a>payment request is
+          showing</a> boolean to true.
           </li>
           <li>Return <var>acceptPromise</var> and perform the remaining steps
           <a>in parallel</a>.
@@ -1001,8 +1006,8 @@
                   </li>
                   <li>Reject <var>acceptPromise</var> with <var>error</var>.
                   </li>
-                  <li>Set <a>user agent</a>'s <a>payment request is showing</a>
-                  boolean to false.
+                  <li>Set <a>top-level browsing context</a>'s <a>payment
+                  request is showing</a> boolean to false.
                   </li>
                   <li>Terminate this algorithm.
                   </li>
@@ -1032,8 +1037,8 @@
               <li>Reject <var>acceptPromise</var> with
               "<a>NotSupportedError</a>" <a>DOMException</a>.
               </li>
-              <li>Set <a>user agent</a>'s <a>payment request is showing</a>
-              boolean to false.
+              <li>Set <a>top-level browsing context</a>'s <a>payment request is
+              showing</a> boolean to false.
               </li>
               <li>Terminate this algorithm.
               </li>
@@ -1095,8 +1100,8 @@
             <ol>
               <li>Close down the user interface.
               </li>
-              <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-              boolean to false.
+              <li>Set the <a>top-level browsing context</a>'s <a>payment
+              request is showing</a> boolean to false.
               </li>
               <li>Reject <var>acceptPromise</var> with an "<a>AbortError</a>"
               <a>DOMException</a>.
@@ -1204,9 +1209,9 @@
           </li>
           <li data-tests=
           "payment-request/payment-request-canmakepayment-method-protection.https.html">
-          Optionally, at the <a>user agent</a>'s discretion, return <a>a
-          promise rejected with</a> a "<a>NotAllowedError</a>"
-          <a>DOMException</a>.
+          Optionally, at the <a>top-level browsing context</a>'s discretion,
+          return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
+            DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
               abuse of the <a>canMakePayment()</a> method for fingerprinting
@@ -3170,6 +3175,9 @@
               "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
               <a data-cite="WEBIDL#idl-object">object</a>.
               </li>
+              <li>Set <a>top-level browsing context</a>'s <a>payment request is
+              showing</a> boolean to false.
+              </li>
               <li>If conversion results in a <a data-cite=
               "WEBIDL#dfn-exception">exception</a> <var>error</var>:
                 <ol>
@@ -3201,8 +3209,8 @@
             <ol>
               <li>Close down the user interface.
               </li>
-              <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-              boolean to false.
+              <li>Set the <a>top-level browsing context</a>'s <a>payment
+              request is showing</a> boolean to false.
               </li>
               <li>Reject <var>retryPromise</var> with an "<a>AbortError</a>"
               <a>DOMException</a>.
@@ -3513,8 +3521,8 @@
             <ol>
               <li>Close down the user interface.
               </li>
-              <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-              boolean to false.
+              <li>Set the <a>top-level browsing context</a>'s <a>payment
+              request is showing</a> boolean to false.
               </li>
               <li>Reject <var>promise</var> with an "<a>AbortError</a>"
               <a>DOMException</a>.
@@ -3527,8 +3535,8 @@
               agent</a> MAY use the value <var>result</var> to influence the
               user experience.
               </li>
-              <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-              boolean to false.
+              <li>Set the <a>top-level browsing context</a>'s <a>payment
+              request is showing</a> boolean to false.
               </li>
               <li>Resolve <var>promise</var> with undefined.
               </li>
@@ -4613,8 +4621,8 @@
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
           </li>
-          <li>Set the <a>user agent</a>'s <a>payment request is showing</a>
-          boolean to false.
+          <li>Set the <a>top-level browsing context</a>'s <a>payment request is
+          showing</a> boolean to false.
           </li>
           <li>Let <var>error</var> be an "<a>AbortError</a>"
           <a>DOMException</a>.
@@ -4987,8 +4995,8 @@
               <a>Queue a task</a> on the <a>user interaction task source</a> to
               perform the following steps:
               <ol>
-                <li>Set the <a>user agent</a>'s <a>payment request is
-                showing</a> boolean to false.
+                <li>Set the <a>top-level browsing context</a>'s <a>payment
+                request is showing</a> boolean to false.
                 </li>
                 <li>Set <var>request</var>.<a>[[\state]]</a> to
                 "<a>closed</a>".

--- a/index.html
+++ b/index.html
@@ -619,10 +619,11 @@
       </p>
       <p class="Note">
         The <a>payment request is showing</a> boolean simply prevents more than
-        one payment UI being shown in a single browser tab. However, a payment
-        handler can restrict the <a>user agent</a> to showing only one payment
-        UI across all browser windows and tabs. Other payment handlers might
-        allow showing a payment UI across disparate browser tabs.
+        one payment UI being shown in a single browser tab. However, a
+        <a>payment handler</a> can restrict the <a>user agent</a> to showing
+        only one payment UI across all browser windows and tabs. Other payment
+        handlers might allow showing a payment UI across disparate browser
+        tabs.
       </p>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -618,7 +618,7 @@
         boolean, which prevents showing more than one payment UI at a time.
       </p>
       <p class="Note">
-        A payment handlers can restrict the <a>user agent</a> to showing only
+        A payment handler can restrict the <a>user agent</a> to showing only
         one payment UI across all browser windows and tabs. Other payment
         handlers might allow showing a payment UI across disparate browser
         tabs. However, in all cases, the <a>payment request is showing</a>

--- a/index.html
+++ b/index.html
@@ -618,12 +618,11 @@
         boolean, which prevents showing more than one payment UI at a time.
       </p>
       <p class="Note">
-        A payment handler can restrict the <a>user agent</a> to showing only
-        one payment UI across all browser windows and tabs. Other payment
-        handlers might allow showing a payment UI across disparate browser
-        tabs. However, in all cases, the <a>payment request is showing</a>
-        boolean simply prevents more than one payment UI being shown in a
-        single browser tab.
+        The <a>payment request is showing</a> boolean simply prevents more than
+        one payment UI being shown in a single browser tab. However, a payment
+        handler can restrict the <a>user agent</a> to showing only one payment
+        UI across all browser windows and tabs. Other payment handlers might
+        allow showing a payment UI across disparate browser tabs.
       </p>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -889,7 +889,7 @@
             be presented to the user to facilitate the payment request after
             the <a>show()</a> method returns.
           </p>
-          <p class="note">
+          <p>
             Each payment handler controls what happens when multiple browsing
             context simultaneously call the <a>show()</a> method. For instance,
             some payment handlers will allow multiple payment UIs to be shown


### PR DESCRIPTION
closes #809

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/14297)
 * [ ] Modified MDN Docs (link)

Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] [Chrome](https://crbug.com/907509)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1469419)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?

Yes. Payment Handlers might need to have a means of keeping track of open payment sheets.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/811.html" title="Last updated on Jan 16, 2019, 7:06 AM UTC (ae602e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/811/3148aa3...ae602e9.html" title="Last updated on Jan 16, 2019, 7:06 AM UTC (ae602e9)">Diff</a>