### PR TITLE
fix: close request if sheet is showing

### DIFF
--- a/index.html
+++ b/index.html
@@ -936,8 +936,14 @@
           "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
           <li>If the <a>user agent</a>'s <a>payment request is showing</a>
-          boolean is true, then return <a>a promise rejected with</a> an
-          "<a>AbortError</a>" <a>DOMException</a>.
+          boolean is true, then:
+            <ol>
+              <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
+              </li>
+              <li>Return <a>a promise rejected with</a> an
+              "<a>InvalidStateError</a>" <a>DOMException</a>.
+              </li>
+            </ol>
           </li>
           <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>interactive</a>".
           </li>

--- a/index.html
+++ b/index.html
@@ -941,7 +941,7 @@
               <li>Set <var>request</var>.<a>[[\state]]</a> to "<a>closed</a>".
               </li>
               <li>Return <a>a promise rejected with</a> an
-              "<a>InvalidStateError</a>" <a>DOMException</a>.
+              "<a>AbortError</a>" <a>DOMException</a>.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
closes #820

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/commit/5f1cbd0a42811a6c66bcfdf25f8a5e7023bf900e)
 * [x] Modified MDN Docs - not needed. 
 * [x] Has undergone security/privacy review - bug fix. Not needed.
 
Implementation commitment:

 * [ ] Safari - @aestes, please provide link 🙏. 
 * [x] Chrome - current behavior. 
 * [x] Firefox - current behavior.
 * [ ] Edge - @zouhir - please confirm 🙏. 

Optional, impact on Payment Handler spec?
None


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/821.html" title="Last updated on Jan 11, 2019, 3:13 AM UTC (bfd7c2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/821/a1e773a...bfd7c2e.html" title="Last updated on Jan 11, 2019, 3:13 AM UTC (bfd7c2e)">Diff</a>