### PR TITLE
Clarify retry() when errorFields are not passed

### DIFF
--- a/index.html
+++ b/index.html
@@ -3197,7 +3197,7 @@
             </ol>
           </li>
           <li>Otherwise, if <var>errorFields</var> was not passed, signal to
-          the end user that they need to manually retry the payment. Re-enable
+          the end user to attempt to retry the payment. Re-enable
           any UI element that affords the end-user the ability to retry
           accepting the payment request.
           </li>

--- a/index.html
+++ b/index.html
@@ -3191,7 +3191,7 @@
               manner that helps the user fix each error. Similarly, if the <a>
                 error</a> member is passed, present the error in the user
                 agent's UI. In the case where the value of a member is the
-                empty string, the user agent MAY substitute a value with with a
+                empty string, the user agent MAY substitute a value with a
                 suitable error message.
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -3182,16 +3182,24 @@
                   </li>
                 </ol>
               </li>
+              <li data-link-for="PaymentValidationErrors">By matching the
+              members of <var>errorFields</var> to input fields in the user
+              agent's UI, indicate to the end-user that something is wrong with
+              the data of the payment response. For example, a user agent might
+              draw the user's attention to the erroneous <var>errorFields</var>
+              in the browser's UI and display the value of each field in a
+              manner that helps the user fix each error. Similarly, if the <a>
+                error</a> member is passed, present the error in the user
+                agent's UI. In the case where the value of a member is the
+                empty string, the user agent MAY substitute a value with with a
+                suitable error message.
+              </li>
             </ol>
           </li>
-          <li data-link-for="PaymentValidationErrors">By matching the members
-          of <var>errorFields</var> to input fields in the user agent's UI,
-          indicate to the end-user that something is wrong with the data of the
-          payment response. For example, a user agent might draw the user's
-          attention to the erroneous <var>errorFields</var> in the browser's UI
-          and display the value of each field in a manner that helps the user
-          fix each error. Similarly, if the <a>error</a> member is passed,
-          present the error in the user agent's UI.
+          <li>Otherwise, if <var>errorFields</var> was not passed, signal to
+          the end user that they need to manually retry the payment. Re-enable
+          any UI element that affords the end-user the ability to retry
+          accepting the payment request.
           </li>
           <li data-tests=
           "payment-response/rejects_if_not_active-manual.https.html">If


### PR DESCRIPTION
closes #792 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests - [already tested](https://github.com/web-platform-tests/wpt/tree/master/payment-request/payment-response/retry-method-manual.https.html). 
 * [x] Modified MDN Docs - not required. 
 * [x] Has undergone security/privacy review - not required.
 
Implementation commitment:

 * [x] Safari - already supports behavior. 
 * [x] Chrome - already supports behavior
 * [x] Firefox - firefox supports behavior. 
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?

None.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/825.html" title="Last updated on Jan 17, 2019, 4:38 AM UTC (5d75975)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/825/a1e773a...5d75975.html" title="Last updated on Jan 17, 2019, 4:38 AM UTC (5d75975)">Diff</a>