### PR TITLE
Do .data IDL conversion in constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,6 +663,15 @@
                     <var>paymentMethod</var>.<a data-lt="PaymentMethodData.data">data</a>
                     into a string. Rethrow any exceptions.
                   </li>
+                  <li>If required by the specification that defines the
+                  <var>paymentMethod</var>.<a>supportedMethods</a>,
+                    <a data-lt="converting">convert</a>
+                    <var>paymentMethod</var>.<a>data</a> to an IDL value of the
+                    type specified there (e.g., a <a data-cite=
+                    "payment-method-basic-card#dom-basiccardrequest">BasicCardRequest</a>
+                    in the case of [[?payment-method-basic-card]]). Rethrow any
+                    exceptions.
+                  </li>
                   <li>Add the tuple (<var>paymentMethod</var>.<a data-lt=
                   "PaymentMethodData.supportedMethods">supportedMethods</a>,
                   <var>serializedData</var>) to

--- a/index.html
+++ b/index.html
@@ -663,14 +663,31 @@
                     <var>paymentMethod</var>.<a data-lt="PaymentMethodData.data">data</a>
                     into a string. Rethrow any exceptions.
                   </li>
-                  <li>If required by the specification that defines the
-                  <var>paymentMethod</var>.<a>supportedMethods</a>,
-                    <a data-lt="converting">convert</a>
-                    <var>paymentMethod</var>.<a>data</a> to an IDL value of the
-                    type specified there (e.g., a <a data-cite=
-                    "payment-method-basic-card#dom-basiccardrequest">BasicCardRequest</a>
-                    in the case of [[?payment-method-basic-card]]). Rethrow any
-                    exceptions.
+                  <li>If <var>serializedData</var> is not null, and if required
+                  by the specification that defines the
+                  <var>paymentMethod</var>.<a>supportedMethods</a>:
+                    <ol>
+                      <li>Let <var>object</var> be the result of
+                        <a data-cite="ECMASCRIPT#sec-json.parse">JSON-parsing</a>
+                        <var>serializedData</var>.
+                      </li>
+                      <li>
+                        <p>
+                          <a data-lt="converting">Convert</a> <var>object</var>
+                          to an IDL value of the type specified by the
+                          specification that defines the
+                          <var>paymentMethod</var>.<a>supportedMethods</a>
+                          (e.g., a <a data-cite=
+                          "payment-method-basic-card#dom-basiccardrequest">BasicCardRequest</a>
+                          in the case of [[?payment-method-basic-card]]).
+                          Rethrow any exceptions.
+                        </p>
+                        <p class="note">
+                          This step assures that any IDL type conversion errors
+                          are caught as early as possible.
+                        </p>
+                      </li>
+                    </ol>
                   </li>
                   <li>Add the tuple (<var>paymentMethod</var>.<a data-lt=
                   "PaymentMethodData.supportedMethods">supportedMethods</a>,


### PR DESCRIPTION
Closes #813 

Converts PaymentMethodData.data to IDL type or object. 
 
The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [X] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/14205)
 * [X] Modified MDN Docs - obscure detail, not required. 

Implementation commitment:

 * [x] Safari - Implemented 
 * [x] Chrome - Implemented 
 * [x] Firefox - Implemented 
 * [ ] Edge (public signal)

Optional, Impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/829.html" title="Last updated on Jan 31, 2019, 4:09 AM UTC (75f8cf4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/829/db50bae...75f8cf4.html" title="Last updated on Jan 31, 2019, 4:09 AM UTC (75f8cf4)">Diff</a>