### PR TITLE
Add PaymentRequest.prototype.hasEnrolledInstrument()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1318,38 +1318,9 @@
           </p>
         </div>
         <p data-tests="payment-request-canmakepayment-method.https.html">
-          The <a>canMakePayment()</a> method MUST act as follows:
+          The <a>canMakePayment()</a> method MUST run the <a>can make payment
+          algorithm</a> with <var>checkForInstruments</var> set to false.
         </p>
-        <ol class="algorithm">
-          <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
-          which the method was called.
-          </li>
-          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>",
-          then return <a>a promise rejected with</a> an
-          "<a>InvalidStateError</a>" <a>DOMException</a>.
-          </li>
-          <li>Let <var>hasHandlerPromise</var> be <a>a new promise</a>.
-          </li>
-          <li>Return <var>hasHandlerPromise</var>, and perform the remaining
-          steps <a>in parallel</a>.
-          </li>
-          <li>For each <var>paymentMethod</var> tuple in
-          <var>request</var>.<a>[[\serializedMethodData]]</a>:
-            <ol>
-              <li>Let <var>identifier</var> be the first element in the
-              <var>paymentMethod</var> tuple.
-              </li>
-              <li>If the user agent has a <a>payment handler</a> that supports
-              handling payment requests for <var>identifier</var>, or if it can
-              perform just-in-time installation of a suitable payment handler,
-              resolve <var>hasHandlerPromise</var> with true and terminate this
-              algorithm.
-              </li>
-            </ol>
-          </li>
-          <li>Resolve <var>hasHandlerPromise</var> with false.
-          </li>
-        </ol>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
         <h2>
@@ -1365,79 +1336,9 @@
           discretion.
         </p>
         <p data-tests="payment-request-hasenrolledinstrument-method.https.html">
-          The <a>hasEnrolledInstrument()</a> method MUST act as follows:
+          The <a>hasEnrolledInstrument()</a> method MUST run the <a>can make
+          payment algorithm</a> with <var>checkForInstruments</var> set to true.
         </p>
-        <ol class="algorithm">
-          <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
-          which the method was called.
-          </li>
-          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>",
-          then return <a>a promise rejected with</a> an
-          "<a>InvalidStateError</a>" <a>DOMException</a>.
-          </li>
-          <li data-tests=
-          "payment-request/payment-request-hasenrolledinstrument-method-protection.https.html">
-          Optionally, at the <a>top-level browsing context</a>'s discretion,
-          return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
-          DOMException</a>.
-            <p class="note" data-link-for="PaymentRequest">
-              This allows user agents to apply heuristics to detect and prevent
-              abuse of the <a>hasEnrolledInstrument()</a> method for
-              fingerprinting purposes, such as creating <a>PaymentRequest</a>
-              objects with a variety of supported <a>payment methods</a> and
-              calling <a>hasEnrolledInstrument()</a> on them one after the
-              other. For example, a user agent may restrict the number of
-              successful calls that can be made based on the <a>top-level
-              browsing context</a> or the time period in which those calls were
-              made.
-            </p>
-          </li>
-          <li>Let <var>promise</var> be <a>a new promise</a>.
-          </li>
-          <li>Return <var>promise</var> and perform the remaining steps <a>in
-          parallel</a>.
-          </li>
-          <li>For each <var>paymentMethod</var> tuple in
-          <var>request</var>.<a>[[\serializedMethodData]]</a>:
-            <ol>
-              <li>Let <var>identifier</var> be the first element in the
-              <var>paymentMethod</var> tuple.
-              </li>
-              <li>Let <var>data</var> be the result of <a data-cite=
-              "ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
-              in the <var>paymentMethod</var> tuple.
-              </li>
-              <li>If required by the specification that defines the
-              <var>identifier</var>, then <a data-cite=
-              "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
-              <var>data</var> to an IDL value. Otherwise, <a data-cite=
-              "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
-              <a data-cite="WEBIDL#idl-object">object</a>.
-              </li>
-              <li>If conversion results in an <a data-cite=
-              "WEBIDL#dfn-exception">exception</a> <var>error</var>, reject
-              <var>promise</var> with <var>error</var> and terminate this
-              algorithm.
-              </li>
-              <li>Let <var>handlers</var> be a <a>list</a> of registered
-              <a>payment handlers</a> that are authorized and can handle
-              payment request for <var>identifier</var>.
-              </li>
-              <li>For each <var>handler</var> in <var>handlers</var>:
-                <ol>
-                  <li>Let <var>hasEnrolledInstrument</var> be the result of
-                  running <var>handler</var>'s <a>steps to check if a payment
-                  can be made</a> with <var>data</var>.
-                  </li>
-                  <li>If <var>hasEnrolledInstrument</var> is true, resolve
-                  <var>promise</var> with true, and return.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          <li>Resolve <var>promise</var> with false.
-          </li>
-        </ol>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
         <h2>
@@ -4340,6 +4241,99 @@
       </section>
       <section>
         <h2>
+          Can make payment algorithm
+        </h2>
+        <p>
+          The <dfn>can make payment algorithm</dfn> checks if the <a>user
+          agent</a> supports making payment with a <a>PaymentRequest</a>. It
+          takes a boolean argument, <var>checkForInstruments</var>, that
+          specifies whether the algorithm should check for existence of enrolled
+          instruments in addition to basic support of a <a>payment method</a>.
+        </p>
+        <ol class="algorithm">
+          <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
+          which the method was called.
+          </li>
+          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>",
+          then return <a>a promise rejected with</a> an
+          "<a>InvalidStateError</a>" <a>DOMException</a>.
+          </li>
+          <li data-tests=
+          "payment-request/payment-request-hasenrolledinstrument-method-protection.https.html">
+          If <var>checkForInstruments</var> is true, optionally, at the
+          <a>top-level browsing context</a>'s discretion, return <a>a promise
+          rejected with</a> a "<a>NotAllowedError</a>" <a> DOMException</a>.
+            <p class="note" data-link-for="PaymentRequest">
+              This allows user agents to apply heuristics to detect and prevent
+              abuse of the <a>hasEnrolledInstrument()</a> method for
+              fingerprinting purposes, such as creating <a>PaymentRequest</a>
+              objects with a variety of supported <a>payment methods</a> and
+              calling <a>hasEnrolledInstrument()</a> on them one after the
+              other. For example, a user agent may restrict the number of
+              successful calls that can be made based on the <a>top-level
+              browsing context</a> or the time period in which those calls were
+              made.
+            </p>
+          </li>
+          <li>Let <var>promise</var> be <a>a new promise</a>.
+          </li>
+          <li>Return <var>promise</var>, and perform the remaining
+          steps <a>in parallel</a>.
+          </li>
+          <li>For each <var>paymentMethod</var> tuple in
+          <var>request</var>.<a>[[\serializedMethodData]]</a>:
+            <ol>
+              <li>Let <var>identifier</var> be the first element in the
+              <var>paymentMethod</var> tuple.
+              </li>
+              <li>If <var>checkForInstruments</var> is false, resolve <var>
+              promise</var> with true and terminate this algorithm if either the
+              user agent has a <a>payment handler</a> that supports handling
+              payment requests for <var>identifier</var>, or if it can perform
+              just-in-time installation of a suitable payment handler.
+              </li>
+              <li>If <var>checkForInstruments</var> is true:
+                <ol>
+                  <li>Let <var>data</var> be the result of <a data-cite=
+                  "ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
+                  in the <var>paymentMethod</var> tuple.
+                  </li>
+                  <li>If required by the specification that defines the
+                  <var>identifier</var>, then <a data-cite=
+                  "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
+                  <var>data</var> to an IDL value. Otherwise, <a data-cite=
+                  "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
+                  <a data-cite="WEBIDL#idl-object">object</a>.
+                  </li>
+                  <li>If conversion results in an <a data-cite=
+                  "WEBIDL#dfn-exception">exception</a> <var>error</var>, reject
+                  <var>promise</var> with <var>error</var> and terminate this
+                  algorithm.
+                  </li>
+                  <li>Let <var>handlers</var> be a <a>list</a> of registered
+                  <a>payment handlers</a> that are authorized and can handle
+                  payment request for <var>identifier</var>.
+                  </li>
+                  <li>For each <var>handler</var> in <var>handlers</var>:
+                    <ol>
+                      <li>Let <var>hasEnrolledInstrument</var> be the result of
+                      running <var>handler</var>'s <a>steps to check if a payment
+                      can be made</a> with <var>data</var>.
+                      </li>
+                      <li>If <var>hasEnrolledInstrument</var> is true, resolve
+                      <var>promise</var> with true and terminate this algorithm.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+            </ol>
+          </li>
+          <li>Resolve <var>promise</var> with false.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
           Shipping address changed algorithm
         </h2>
         <p data-tests=
@@ -5339,15 +5333,16 @@
       </section>
       <section>
         <h2>
-          canMakePayment() protections
+          canMakePayment and hasEnrolledInstrument() protections
         </h2>
         <p data-link-for="PaymentRequest">
-          The <a>canMakePayment()</a> method enables the payee to call
-          <a>show()</a> if the user is ready to take advantage of the API, or
-          to fall back to a legacy checkout experience if not. Because this
-          method shares some information with the payee, user agents are
-          expected to protect the user from abuse of the method, for example,
-          by restricting the number or frequency of calls.
+          The <a>canMakePayment()</a> and <a>hasEnrolledInstrument()</a> methods
+          enable the payee to check if the user is ready to take advantage of
+          the API before calling <a>show()</a> so that it can fall back to a
+          legacy checkout experience if not. Because this method shares some
+          information with the payee, user agents are expected to protect the
+          user from abuse of the method, for example, by restricting the number
+          or frequency of calls.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -4263,7 +4263,7 @@
           "payment-request-hasenrolledinstrument-method-protection.https.html, payment-request-canmakepayment-method-protection.https.html">
           Optionally, at the <a>top-level browsing context</a>'s discretion,
           return <a>a promise rejected with</a> a "<a>NotAllowedError</a>"
-          <a> DOMException</a>.
+          <a>DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
               abuse of the calling method for fingerprinting purposes, such as

--- a/index.html
+++ b/index.html
@@ -4245,7 +4245,7 @@
         </h2>
         <p>
           The <dfn>can make payment algorithm</dfn> checks if the <a>user
-          agent</a> supports making payment with a <a>PaymentRequest</a>. It
+          agent</a> supports making payment with the <a>payment methods</a> with which the <a>PaymentRequest</a> was constructed. It
           takes a boolean argument, <var>checkForInstruments</var>, that
           specifies whether the algorithm checks for existence of enrolled
           instruments in addition to supporting <a>payment method</a>.

--- a/index.html
+++ b/index.html
@@ -1329,7 +1329,7 @@
           to determine if the <a>user agent</a> has support for one of the
           desired <a>payment methods</a> and if a <a>payment handler</a> has an
           instrument ready for payment. See
-          <a href="#canMakePayment-privacy">privacy considerations</a>.
+          <a href="#canmakepayment-protections"></a>.
         </p>
         <p data-tests="payment-request-hasenrolledinstrument-method.https.html">
           The <a>hasEnrolledInstrument()</a> method MUST run the <a>can make

--- a/index.html
+++ b/index.html
@@ -4245,10 +4245,11 @@
         </h2>
         <p>
           The <dfn>can make payment algorithm</dfn> checks if the <a>user
-          agent</a> supports making payment with the <a>payment methods</a> with which the <a>PaymentRequest</a> was constructed. It
-          takes a boolean argument, <var>checkForInstruments</var>, that
-          specifies whether the algorithm checks for existence of enrolled
-          instruments in addition to supporting <a>payment method</a>.
+          agent</a> supports making payment with the <a>payment methods</a> with
+          which the <a>PaymentRequest</a> was constructed. It takes a boolean
+          argument, <var>checkForInstruments</var>, that specifies whether the
+          algorithm checks for existence of enrolled instruments in addition to
+          supporting <a>payment method</a>.
         </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
@@ -4259,20 +4260,19 @@
           "<a>InvalidStateError</a>" <a>DOMException</a>.
           </li>
           <li data-tests=
-          "payment-request/payment-request-hasenrolledinstrument-method-protection.https.html">
-          If <var>checkForInstruments</var> is true, optionally, at the
-          <a>top-level browsing context</a>'s discretion, return <a>a promise
-          rejected with</a> a "<a>NotAllowedError</a>" <a> DOMException</a>.
+          "payment-request-hasenrolledinstrument-method-protection.https.html, payment-request-canmakepayment-method-protection.https.html">
+          Optionally, at the <a>top-level browsing context</a>'s discretion,
+          return <a>a promise rejected with</a> a "<a>NotAllowedError</a>"
+          <a> DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
-              abuse of the calling method for
-              fingerprinting purposes, such as creating <a>PaymentRequest</a>
-              objects with a variety of supported <a>payment methods</a> and
-              calling <a>hasEnrolledInstrument()</a> on them one after the
-              other. For example, a user agent may restrict the number of
-              successful calls that can be made based on the <a>top-level
-              browsing context</a> or the time period in which those calls were
-              made.
+              abuse of the calling method for fingerprinting purposes, such as
+              creating <a>PaymentRequest</a> objects with a variety of supported
+              <a>payment methods</a> and triggering the <a>can make payment
+              algorithm</a> on them one after the other. For example, a user
+              agent may restrict the number of successful calls that can be made
+              based on the <a>top-level browsing context</a> or the time period
+              in which those calls were made.
             </p>
           </li>
           <li>Let <var>promise</var> be <a>a new promise</a>.
@@ -4286,11 +4286,17 @@
               <li>Let <var>identifier</var> be the first element in the
               <var>paymentMethod</var> tuple.
               </li>
-              <li>If <var>checkForInstruments</var> is false, resolve <var>
-              promise</var> with true and terminate this algorithm if either the
-              user agent has a <a>payment handler</a> that supports handling
-              payment requests for <var>identifier</var>, or if it can perform
-              just-in-time installation of a suitable payment handler.
+              <li>If <var>checkForInstruments</var> is false:
+                <ol>
+                  <li>If the user agent has a <a>payment handler</a> that
+                  supports handling payment requests for <var>identifier</var>,
+                  resolve <var>promise</var> with true and terminate this
+                  algorithm.
+                  </li>
+                  <li>If the user agent does not have a suitable <a>payment
+                  handler</a>, resolve <var>promise</var> with false and
+                  terminate this algorithm.</li>
+                </ol>
               </li>
               <li>If <var>checkForInstruments</var> is true:
                 <ol>
@@ -5333,15 +5339,16 @@
       </section>
       <section>
         <h2>
-          hasEnrolledInstrument() protections
+          canMakePayment() and hasEnrolledInstrument() protections
         </h2>
         <p data-link-for="PaymentRequest">
-          The <a>hasEnrolledInstrument()</a> method enables the payee to check
-          if the user is ready to take advantage of the API before calling
-          <a>show()</a> so that it can fall back to a legacy checkout experience
-          if not. Because this method shares some information with the payee,
-          user agents are expected to protect the user from abuse of the method,
-          for example, by restricting the number or frequency of calls.
+          The <a>canMakePayment()</a> and <a>hasEnrolledInstrument()</a> methods
+          enable the payee to check if the user is ready to take advantage of
+          the API before calling <a>show()</a> so that it can fall back to a
+          legacy checkout experience if not. Because this method shares some
+          information with the payee, user agents are expected to protect the
+          user from abuse of the method, for example, by restricting the number
+          or frequency of calls.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1300,17 +1300,21 @@
         <h2>
           <dfn>canMakePayment()</dfn> method
         </h2>
-        <p class="note">
-          The <a>canMakePayment()</a> method can be used by the developer to
-          determine if the <a>PaymentRequest</a> object can be used to make a
-          payment, before they call <a>show()</a>. It returns a <a>Promise</a>
-          that will be fulfilled with true if the <a>user agent</a> supports
-          any of the desired <a>payment methods</a> supplied to the
-          <a>PaymentRequest</a> constructor, and false if none are supported.
-          If the method is called too often, the user agent might instead
-          return <a>a promise rejected with</a> a "<a>NotAllowedError</a>"
-          <a>DOMException</a>, at its discretion.
-        </p>
+        <div class="note">
+          <p>
+            The <a>canMakePayment()</a> method can be used by the developer to
+            determine if the <a>PaymentRequest</a> object can be used to make a
+            payment, before they call <a>show()</a>. It returns a <a>Promise</a>
+            that will be fulfilled with true if the <a>user agent</a> supports
+            any of the desired <a>payment methods</a> supplied to the
+            <a>PaymentRequest</a> constructor, and false if none are supported.
+          </p>
+          <p>
+            A true result from <a>canMakePayment()</a> does not imply that the
+            user has an provisioned instrument ready for payment. For that, use
+            <a>hasEnrolledInstrument()</a> instead.
+          </p>
+        </div>
         <p data-tests="payment-request-canmakepayment-method.https.html">
           The <a>canMakePayment()</a> method MUST act as follows:
         </p>
@@ -1321,22 +1325,6 @@
           <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>",
           then return <a>a promise rejected with</a> an
           "<a>InvalidStateError</a>" <a>DOMException</a>.
-          </li>
-          <li data-tests=
-          "payment-request/payment-request-canmakepayment-method-protection.https.html">
-          Optionally, at the <a>top-level browsing context</a>'s discretion,
-          return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
-            DOMException</a>.
-            <p class="note" data-link-for="PaymentRequest">
-              This allows user agents to apply heuristics to detect and prevent
-              abuse of the <a>canMakePayment()</a> method for fingerprinting
-              purposes, such as creating <a>PaymentRequest</a> objects with a
-              variety of supported <a>payment methods</a> and calling
-              <a>canMakePayment()</a> on them one after the other. For example,
-              a user agent may restrict the number of successful calls that can
-              be made based on the <a>top-level browsing context</a> or the
-              time period in which those calls were made.
-            </p>
           </li>
           <li>Let <var>hasHandlerPromise</var> be <a>a new promise</a>.
           </li>
@@ -1349,14 +1337,103 @@
               <li>Let <var>identifier</var> be the first element in the
               <var>paymentMethod</var> tuple.
               </li>
-              <li>If there user agent has a <a>payment handler</a> that support
-              handling payment requests for <var>identifier</var>, resolve
-              <var>hasHandlerPromise</var> with true and terminate this
+              <li>If the user agent has a <a>payment handler</a> that support
+              handling payment requests for <var>identifier</var>, or if it can
+              perform just-in-time installation of a suitable payment handler,
+              resolve <var>hasHandlerPromise</var> with true and terminate this
               algorithm.
               </li>
             </ol>
           </li>
           <li>Resolve <var>hasHandlerPromise</var> with false.
+          </li>
+        </ol>
+      </section>
+      <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
+        <h2>
+          <dfn>hasEnrolledInstrument()</dfn> method
+        </h2>
+        <p class="note">
+          The <a>hasEnrolledInstrument()</a> method can be used by the developer
+          to determine if the <a>user agent</a> not only has support for one of
+          the desired <a>payment methods</a> but is also "ready for payment", (
+          e.g. when showing a "buy now" button). If the method is called too
+          often, the user agent might instead return <a>a promise rejected
+          with </a> a "<a>NotAllowedError</a>" <a>DOMException</a>, at its
+          discretion.
+        </p>
+        <p data-tests="payment-request-hasenrolledinstrument-method.https.html">
+          The <a>hasEnrolledInstrument()</a> method MUST act as follows:
+        </p>
+        <ol class="algorithm">
+          <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
+          which the method was called.
+          </li>
+          <li>If <var>request</var>.<a>[[\state]]</a> is not "<a>created</a>",
+          then return <a>a promise rejected with</a> an
+          "<a>InvalidStateError</a>" <a>DOMException</a>.
+          </li>
+          <li data-tests=
+          "payment-request/payment-request-hasenrolledinstrument-method-protection.https.html">
+          Optionally, at the <a>top-level browsing context</a>'s discretion,
+          return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
+          DOMException</a>.
+            <p class="note" data-link-for="PaymentRequest">
+              This allows user agents to apply heuristics to detect and prevent
+              abuse of the <a>hasEnrolledInstrument()</a> method for
+              fingerprinting purposes, such as creating <a>PaymentRequest</a>
+              objects with a variety of supported <a>payment methods</a> and
+              calling <a>hasEnrolledInstrument()</a> on them one after the
+              other. For example, a user agent may restrict the number of
+              successful calls that can be made based on the <a>top-level
+              browsing context</a> or the time period in which those calls were
+              made.
+            </p>
+          </li>
+          <li>Let <var>promise</var> be <a>a new promise</a>.
+          </li>
+          <li>Return <var>promise</var> and perform the remaining steps <a>in
+          parallel</a>.
+          </li>
+          <li>For each <var>paymentMethod</var> tuple in
+          <var>request</var>.<a>[[\serializedMethodData]]</a>:
+            <ol>
+              <li>Let <var>identifier</var> be the first element in the
+              <var>paymentMethod</var> tuple.
+              </li>
+              <li>Let <var>data</var> be the result of <a data-cite=
+              "ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
+              in the <var>paymentMethod</var> tuple.
+              </li>
+              <li>If required by the specification that defines the
+              <var>identifier</var>, then <a data-cite=
+              "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a>
+              <var>data</var> to an IDL value. Otherwise, <a data-cite=
+              "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
+              <a data-cite="WEBIDL#idl-object">object</a>.
+              </li>
+              <li>If conversion results in an <a data-cite=
+              "WEBIDL#dfn-exception">exception</a> <var>error</var>, reject
+              <var>promise</var> with <var>error</var> and terminate this
+              algorithm.
+              </li>
+              <li>Let <var>handlers</var> be a <a>list</a> of registered
+              <a>payment handlers</a> that are authorized and can handle
+              payment request for <var>identifier</var>.
+              </li>
+              <li>For each <var>handler</var> in <var>handlers</var>:
+                <ol>
+                  <li>Let <var>hasEnrolledInstrument</var> be the result of
+                  running <var>handler</var>'s <a>steps to check if a payment
+                  can be made</a> with <var>data</var>.
+                  </li>
+                  <li>If <var>hasEnrolledInstrument</var> is true, resolve
+                  <var>promise</var> with true, and return.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          <li>Resolve <var>promise</var> with false.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -566,6 +566,8 @@
           Promise&lt;void&gt; abort();
           [NewObject]
           Promise&lt;boolean&gt; canMakePayment();
+          [NewObject]
+          Promise&lt;boolean&gt; hasEnrolledInstrument();
 
           readonly attribute DOMString id;
           readonly attribute PaymentAddress? shippingAddress;

--- a/index.html
+++ b/index.html
@@ -1361,7 +1361,7 @@
           the desired <a>payment methods</a> but is also "ready for payment" (
           e.g., when showing a "buy now" button). If the method is called too
           often, the user agent may return <a>a promise rejected
-          with </a> a "<a>NotAllowedError</a>" <a>DOMException</a>, at its
+          with </a> a "<a>NotAllowedError</a>" <a>DOMException</a> at its
           discretion.
         </p>
         <p data-tests="payment-request-hasenrolledinstrument-method.https.html">

--- a/index.html
+++ b/index.html
@@ -5333,16 +5333,15 @@
       </section>
       <section>
         <h2>
-          canMakePayment and hasEnrolledInstrument() protections
+          hasEnrolledInstrument() protections
         </h2>
         <p data-link-for="PaymentRequest">
-          The <a>canMakePayment()</a> and <a>hasEnrolledInstrument()</a> methods
-          enable the payee to check if the user is ready to take advantage of
-          the API before calling <a>show()</a> so that it can fall back to a
-          legacy checkout experience if not. Because this method shares some
-          information with the payee, user agents are expected to protect the
-          user from abuse of the method, for example, by restricting the number
-          or frequency of calls.
+          The <a>hasEnrolledInstrument()</a> method enables the payee to check
+          if the user is ready to take advantage of the API before calling
+          <a>show()</a> so that it can fall back to a legacy checkout experience
+          if not. Because this method shares some information with the payee,
+          user agents are expected to protect the user from abuse of the method,
+          for example, by restricting the number or frequency of calls.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1302,7 +1302,7 @@
         <h2>
           <dfn>canMakePayment()</dfn> method
         </h2>
-        <div class="note">
+        <div class="note" title="canMakePayment() vs hasEnrolledInstrument()">
           <p>
             The <a>canMakePayment()</a> method can be used by the developer to
             determine if the <a>PaymentRequest</a> object can be used to make a

--- a/index.html
+++ b/index.html
@@ -1313,7 +1313,7 @@
           </p>
           <p>
             A true result from <a>canMakePayment()</a> does not imply that the
-            user has an provisioned instrument ready for payment. For that, use
+            user has a provisioned instrument ready for payment. For that, use
             <a>hasEnrolledInstrument()</a> instead.
           </p>
         </div>

--- a/index.html
+++ b/index.html
@@ -1360,7 +1360,7 @@
           to determine if the <a>user agent</a> not only has support for one of
           the desired <a>payment methods</a> but is also "ready for payment", (
           e.g. when showing a "buy now" button). If the method is called too
-          often, the user agent might instead return <a>a promise rejected
+          often, the user agent may return <a>a promise rejected
           with </a> a "<a>NotAllowedError</a>" <a>DOMException</a>, at its
           discretion.
         </p>

--- a/index.html
+++ b/index.html
@@ -4248,7 +4248,7 @@
           agent</a> supports making payment with a <a>PaymentRequest</a>. It
           takes a boolean argument, <var>checkForInstruments</var>, that
           specifies whether the algorithm checks for existence of enrolled
-          instruments in addition to basic support of a <a>payment method</a>.
+          instruments in addition to supporting <a>payment method</a>.
         </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on

--- a/index.html
+++ b/index.html
@@ -1304,12 +1304,10 @@
         </h2>
         <div class="note" title="canMakePayment() vs hasEnrolledInstrument()">
           <p>
-            The <a>canMakePayment()</a> method returns a <a>Promise</a>
-            that is fulfilled with true if the <a>user agent</a> supports
-            any of the <a data-link-for="PaymentMethodData">supportedMethods</a>
-            supplied to the <a>PaymentRequest</a>
-            <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>, or
-            false if none are supported.
+            The <a>canMakePayment()</a> method can be used by the developer to
+            determine if the <a>user agent</a> has support for one of the
+            desired <a>payment methods</a>. See <a href="#canMakePayment-privacy">
+            privacy considerations</a>.
           </p>
           <p>
             A true result from <a>canMakePayment()</a> does not imply that the
@@ -1328,12 +1326,10 @@
         </h2>
         <p class="note">
           The <a>hasEnrolledInstrument()</a> method can be used by the developer
-          to determine if the <a>user agent</a> not only has support for one of
-          the desired <a>payment methods</a> but is also "ready for payment" (
-          e.g., when showing a "buy now" button). If the method is called too
-          often, the user agent may return <a>a promise rejected
-          with </a> a "<a>NotAllowedError</a>" <a>DOMException</a> at its
-          discretion.
+          to determine if the <a>user agent</a> has support for one of the
+          desired <a>payment methods</a> and if a <a>payment handler</a> has an
+          instrument ready for payment. See
+          <a href="#canMakePayment-privacy">privacy considerations</a>.
         </p>
         <p data-tests="payment-request-hasenrolledinstrument-method.https.html">
           The <a>hasEnrolledInstrument()</a> method MUST run the <a>can make
@@ -4249,7 +4245,7 @@
           which the <a>PaymentRequest</a> was constructed. It takes a boolean
           argument, <var>checkForInstruments</var>, that specifies whether the
           algorithm checks for existence of enrolled instruments in addition to
-          supporting <a>payment method</a>.
+          supporting a <a>payment method</a>.
         </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on
@@ -4263,7 +4259,7 @@
           "payment-request-hasenrolledinstrument-method-protection.https.html, payment-request-canmakepayment-method-protection.https.html">
           Optionally, at the <a>top-level browsing context</a>'s discretion,
           return <a>a promise rejected with</a> a "<a>NotAllowedError</a>"
-          <a> DOMException</a>.
+          <a>DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
               abuse of the calling method for fingerprinting purposes, such as
@@ -4303,11 +4299,6 @@
                   <var>data</var> to an IDL value. Otherwise, <a data-cite=
                   "WEBIDL#dfn-convert-ecmascript-to-idl-value">convert</a> to
                   <a data-cite="WEBIDL#idl-object">object</a>.
-                  </li>
-                  <li>If conversion results in an <a data-cite=
-                  "WEBIDL#dfn-exception">exception</a> <var>error</var>, reject
-                  <var>promise</var> with <var>error</var> and terminate this
-                  algorithm.
                   </li>
                   <li>Let <var>handlers</var> be a <a>list</a> of registered
                   <a>payment handlers</a> that are authorized and can handle
@@ -5330,18 +5321,19 @@
           consent.
         </p>
       </section>
-      <section>
+      <section id="canMakePayment-privacy">
         <h2>
-          canMakePayment() and hasEnrolledInstrument() protections
+          <code>canMakePayment()</code> and <code>hasEnrolledInstrument()</code>
+          protections
         </h2>
         <p data-link-for="PaymentRequest">
           The <a>canMakePayment()</a> and <a>hasEnrolledInstrument()</a> methods
-          enable the payee to check if the user is ready to take advantage of
-          the API before calling <a>show()</a> so that it can fall back to a
-          legacy checkout experience if not. Because this method shares some
-          information with the payee, user agents are expected to protect the
-          user from abuse of the method, for example, by restricting the number
-          or frequency of calls.
+          have the potential to expose user information that could be abused for
+          fingerprinting purposes. The API allows the user agent to restrict the
+          number or frequency of calls to reduce the risk of fingerprinting.
+          User agents MAY allow the user to control the response to either
+          method via UI or provide their own means to protection (e.g., always
+          returning with true).
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1359,7 +1359,7 @@
           The <a>hasEnrolledInstrument()</a> method can be used by the developer
           to determine if the <a>user agent</a> not only has support for one of
           the desired <a>payment methods</a> but is also "ready for payment", (
-          e.g. when showing a "buy now" button). If the method is called too
+          e.g., when showing a "buy now" button). If the method is called too
           often, the user agent may return <a>a promise rejected
           with </a> a "<a>NotAllowedError</a>" <a>DOMException</a>, at its
           discretion.

--- a/index.html
+++ b/index.html
@@ -4255,7 +4255,8 @@
               </li>
               <li>If |checkForInstruments| is true:
                 <ol>
-                  <li>Let |data| be the result of <a>JSON-parsing</a> the second
+                  <li>Let |data| be the result of <a data-cite=
+                      "ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second
                   element in the |paymentMethod| tuple.
                   </li>
                   <li>If required by the specification that defines the

--- a/index.html
+++ b/index.html
@@ -1304,12 +1304,12 @@
         </h2>
         <div class="note" title="canMakePayment() vs hasEnrolledInstrument()">
           <p>
-            The <a>canMakePayment()</a> method can be used by the developer to
-            determine if the <a>PaymentRequest</a> object can be used to make a
-            payment, before they call <a>show()</a>. It returns a <a>Promise</a>
-            that will be fulfilled with true if the <a>user agent</a> supports
-            any of the desired <a>payment methods</a> supplied to the
-            <a>PaymentRequest</a> constructor, and false if none are supported.
+            The <a>canMakePayment()</a> method returns a <a>Promise</a>
+            that is fulfilled with true if the <a>user agent</a> supports
+            any of the <a data-link-for="PaymentMethodData">supportedMethods</a>
+            supplied to the <a>PaymentRequest</a>
+            <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>, or
+            false if none are supported.
           </p>
           <p>
             A true result from <a>canMakePayment()</a> does not imply that the

--- a/index.html
+++ b/index.html
@@ -4249,7 +4249,7 @@
           which the <a>PaymentRequest</a> was constructed. It takes a boolean
           argument, <var>checkForInstruments</var>, that specifies whether the
           algorithm checks for existence of enrolled instruments in addition to
-          supporting <a>payment method</a>.
+          supporting a <a>payment method</a>.
         </p>
         <ol class="algorithm">
           <li>Let <var>request</var> be the <a>PaymentRequest</a> object on

--- a/index.html
+++ b/index.html
@@ -4247,7 +4247,7 @@
           The <dfn>can make payment algorithm</dfn> checks if the <a>user
           agent</a> supports making payment with a <a>PaymentRequest</a>. It
           takes a boolean argument, <var>checkForInstruments</var>, that
-          specifies whether the algorithm should check for existence of enrolled
+          specifies whether the algorithm checks for existence of enrolled
           instruments in addition to basic support of a <a>payment method</a>.
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -5332,7 +5332,7 @@
           fingerprinting purposes. The API allows the user agent to restrict the
           number or frequency of calls to reduce the risk of fingerprinting.
           User agents MAY allow the user to control the response to either
-          method via UI or provide their own means to protection (e.g., always
+          method via UI or provide their own means of protection (e.g., always
           returning with true).
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -4265,7 +4265,7 @@
           rejected with</a> a "<a>NotAllowedError</a>" <a> DOMException</a>.
             <p class="note" data-link-for="PaymentRequest">
               This allows user agents to apply heuristics to detect and prevent
-              abuse of the <a>hasEnrolledInstrument()</a> method for
+              abuse of the calling method for
               fingerprinting purposes, such as creating <a>PaymentRequest</a>
               objects with a variety of supported <a>payment methods</a> and
               calling <a>hasEnrolledInstrument()</a> on them one after the

--- a/index.html
+++ b/index.html
@@ -4286,17 +4286,10 @@
               <li>Let <var>identifier</var> be the first element in the
               <var>paymentMethod</var> tuple.
               </li>
-              <li>If <var>checkForInstruments</var> is false:
-                <ol>
-                  <li>If the user agent has a <a>payment handler</a> that
-                  supports handling payment requests for <var>identifier</var>,
-                  resolve <var>promise</var> with true and terminate this
-                  algorithm.
-                  </li>
-                  <li>If the user agent does not have a suitable <a>payment
-                  handler</a>, resolve <var>promise</var> with false and
-                  terminate this algorithm.</li>
-                </ol>
+              <li>If <var>checkForInstruments</var> is false, and the user agent
+                has a <a>payment handler</a> that supports handling payment
+                requests for <var>identifier</var>, resolve <var>promise</var>
+                with true and terminate this algorithm.
               </li>
               <li>If <var>checkForInstruments</var> is true:
                 <ol>

--- a/index.html
+++ b/index.html
@@ -1358,7 +1358,7 @@
         <p class="note">
           The <a>hasEnrolledInstrument()</a> method can be used by the developer
           to determine if the <a>user agent</a> not only has support for one of
-          the desired <a>payment methods</a> but is also "ready for payment", (
+          the desired <a>payment methods</a> but is also "ready for payment" (
           e.g., when showing a "buy now" button). If the method is called too
           often, the user agent may return <a>a promise rejected
           with </a> a "<a>NotAllowedError</a>" <a>DOMException</a>, at its

--- a/index.html
+++ b/index.html
@@ -1339,7 +1339,7 @@
               <li>Let <var>identifier</var> be the first element in the
               <var>paymentMethod</var> tuple.
               </li>
-              <li>If the user agent has a <a>payment handler</a> that support
+              <li>If the user agent has a <a>payment handler</a> that supports
               handling payment requests for <var>identifier</var>, or if it can
               perform just-in-time installation of a suitable payment handler,
               resolve <var>hasHandlerPromise</var> with true and terminate this


### PR DESCRIPTION
closes #830 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests: https://github.com/web-platform-tests/wpt/pull/15306
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [x] [Safari](https://bugs.webkit.org/show_bug.cgi?id=197386)
 * [x] [Chrome](https://crbug.com/915907)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1528663)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?
After this change, `CanMakePaymentEvent` will not be triggered on any payment handler when `canMakePayment()` runs. It will be triggered when `hasEnrolledInstrument()` runs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danyao/payment-request/pull/833.html" title="Last updated on May 3, 2019, 2:50 AM UTC (6faac81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/833/72de3ba...danyao:6faac81.html" title="Last updated on May 3, 2019, 2:50 AM UTC (6faac81)">Diff</a>