### PR TITLE
Changes resulting from 28 February PING privacy review

### DIFF
--- a/index.html
+++ b/index.html
@@ -5295,7 +5295,7 @@
         <p data-link-for="PaymentRequest">
           The <a>canMakePayment()</a> method enables the payee to determine
           — before calling <a>show()</a> — whether the user agent knows of any <a>payment handlers</a> available to the user that support the  <a>payment methods</a> provided to the <a>PaymentRequest<a> <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>.
-          advantage of the API. This enables the payee to fall back to a legacy
+         If no <a>payment handlers</a> support the <a>payment methods</a>, this enables the payee to fall back to a legacy
           checkout experience. Because this method shares some information with
           the payee, user agents are expected to protect the user from abuse of
           the method. For example, user agents may reduce user fingerprinting

--- a/index.html
+++ b/index.html
@@ -5302,12 +5302,10 @@
           by:
         </p>
         <ul data-link-for="PaymentRequest">
-          <li>allowing the user to configure the user agent to turn off
-          <a>canMakePayment()</a>;
+          <li>Allowing the user to configure the user agent to turn off
+          <a>canMakePayment()</a>.
           </li>
-          <li>informing the user when <a>canMakePayment()</a> is called;
-          </li>
-          <li>rate-limiting the frequency of calls to <a>canMakePayment()</a>
+          <li>Rate-limiting the frequency of calls to <a>canMakePayment()</a>
           with different parameters.
           </li>
         </ul>
@@ -5315,9 +5313,10 @@
           For rate-limiting the user agent might look at repeated calls from:
         </p>
         <ul>
-          <li>the same effective top-level domain plus one (eTLD+1);
+          <li>the same effective top-level domain plus one (eTLD+1).
           </li>
-          <li>the top-level browsing context;
+          <li>the top-level browsing context. Alternatively, the user agent may
+          block access to the API entirely for origins know to be bad actors.
           </li>
           <li>for an iframe, the origin of the iframe content.
           </li>

--- a/index.html
+++ b/index.html
@@ -5318,7 +5318,7 @@
           <li>the top-level browsing context. Alternatively, the user agent may
           block access to the API entirely for origins know to be bad actors.
           </li>
-          <li>for an <a>iframe</a>, the origin of the <a>iframe</a> content.
+          <li>the origin of an <a>iframe</a> or popup window.
           </li>
         </ul>
         <p>

--- a/index.html
+++ b/index.html
@@ -5294,7 +5294,7 @@
         </h2>
         <p data-link-for="PaymentRequest">
           The <a>canMakePayment()</a> method enables the payee to determine
-          —before calling <a>show()</a>— whether the user is ready to take
+          — before calling <a>show()</a> — whether the user agent knows of any <a>payment handlers</a> available to the user that support the  <a>payment methods</a> provided to the <a>PaymentRequest<a> <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>.
           advantage of the API. This enables the payee to fall back to a legacy
           checkout experience. Because this method shares some information with
           the payee, user agents are expected to protect the user from abuse of

--- a/index.html
+++ b/index.html
@@ -5183,7 +5183,7 @@
         </ol>
       </section>
     </section>
-    <section class="informative" id="privacy">
+    <section id="privacy">
       <h2>
         Privacy and Security Considerations
       </h2>
@@ -5263,7 +5263,7 @@
           <a>payment method identifier</a>.
         </p>
       </section>
-      <section class="informative">
+      <section>
         <h2>
           Exposing user information
         </h2>

--- a/index.html
+++ b/index.html
@@ -5305,9 +5305,6 @@
           <li>Allowing the user to configure the user agent to turn off
            <a>canMakePayment()</a>, which would return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>DOMException</a>.
           </li>
-          <li>Informing the user of what data is shared by
-          <a>canMakePayment()</a>;
-          </li>
           <li>Rate-limiting the frequency of calls to <a>canMakePayment()</a>
           with different parameters.
           </li>

--- a/index.html
+++ b/index.html
@@ -5304,7 +5304,6 @@
         <ul data-link-for="PaymentRequest">
           <li>Allowing the user to configure the user agent to turn off
            <a>canMakePayment()</a>, which would return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>DOMException</a>.
-            DOMException</a>.
           </li>
           <li>Informing the user of what data is shared by
           <a>canMakePayment()</a>;

--- a/index.html
+++ b/index.html
@@ -5305,7 +5305,7 @@
           <li>Allowing the user to configure the user agent to turn off
           <a>canMakePayment()</a>.
           </li>
-          <li>informing the user of what data is shared by
+          <li>Informing the user of what data is shared by
           <a>canMakePayment()</a>;
           </li>
           <li>Rate-limiting the frequency of calls to <a>canMakePayment()</a>

--- a/index.html
+++ b/index.html
@@ -5293,17 +5293,22 @@
           <code>canMakePayment()</code> protections
         </h2>
         <p data-link-for="PaymentRequest">
-          The <a>canMakePayment()</a> method enables the payee to determine
-          — before calling <a>show()</a> — whether the user agent knows of any <a>payment handlers</a> available to the user that support the  <a>payment methods</a> provided to the <a>PaymentRequest<a> <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>.
-         If no <a>payment handlers</a> support the <a>payment methods</a>, this enables the payee to fall back to a legacy
-          checkout experience. Because this method shares some potentially unique information with
+          The <a>canMakePayment()</a> method enables the payee to determine —
+          before calling <a>show()</a> — whether the user agent knows of any
+          <a>payment handlers</a> available to the user that support the
+          <a>payment methods</a> provided to the <a>PaymentRequest</a>
+          <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>. If no
+          <a>payment handlers</a> support the <a>payment methods</a>, this
+          enables the payee to fall back to a legacy checkout experience.
+          Because this method shares some potentially unique information with
           the payee, user agents are expected to protect the user from abuse of
           the method. For example, user agents can reduce user fingerprinting
           by:
         </p>
         <ul data-link-for="PaymentRequest">
           <li>Allowing the user to configure the user agent to turn off
-           <a>canMakePayment()</a>, which would return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>DOMException</a>.
+          <a>canMakePayment()</a>, which would return <a>a promise rejected
+          with</a> a "<a>NotAllowedError</a>" <a>DOMException</a>.
           </li>
           <li>Rate-limiting the frequency of calls to <a>canMakePayment()</a>
           with different parameters.

--- a/index.html
+++ b/index.html
@@ -1375,17 +1375,9 @@
           "payment-request/payment-request-canmakepayment-method-protection.https.html">
           Optionally, at the <a>top-level browsing context</a>'s discretion,
           return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
-            DOMException</a>.
-            <p class="note" data-link-for="PaymentRequest">
-              This allows user agents to apply heuristics to detect and prevent
-              abuse of the <a>canMakePayment()</a> method for fingerprinting
-              purposes, such as creating <a>PaymentRequest</a> objects with a
-              variety of supported <a>payment methods</a> and calling
-              <a>canMakePayment()</a> on them one after the other. For example,
-              a user agent may restrict the number of successful calls that can
-              be made based on the <a>top-level browsing context</a> or the
-              time period in which those calls were made.
-            </p>
+            DOMException</a>. As described in section <a href=
+            "#canmakepayment-protections"></a>, the user agent may limit the
+            rate at which a page can call <a>canMakePayment()</a>.
           </li>
           <li>Let <var>hasHandlerPromise</var> be <a>a new promise</a>.
           </li>
@@ -5191,7 +5183,7 @@
         </ol>
       </section>
     </section>
-    <section class="informative">
+    <section class="informative" id="privacy">
       <h2>
         Privacy and Security Considerations
       </h2>
@@ -5271,12 +5263,7 @@
           <a>payment method identifier</a>.
         </p>
       </section>
-    </section>
-    <section id="privacy">
-      <h2>
-        Privacy Considerations
-      </h2>
-      <section>
+      <section class="informative">
         <h2>
           Exposing user information
         </h2>
@@ -5301,17 +5288,45 @@
           consent.
         </p>
       </section>
-      <section>
-        <h2>
+      <section class="informative">
+        <h2 id="canmakepayment-protections">
           canMakePayment() protections
         </h2>
         <p data-link-for="PaymentRequest">
-          The <a>canMakePayment()</a> method enables the payee to call
-          <a>show()</a> if the user is ready to take advantage of the API, or
-          to fall back to a legacy checkout experience if not. Because this
-          method shares some information with the payee, user agents are
-          expected to protect the user from abuse of the method, for example,
-          by restricting the number or frequency of calls.
+          The <a>canMakePayment()</a> method enables the payee to determine
+          —before calling <a>show()</a>— whether the user is ready to take
+          advantage of the API. This enables the payee to fall back to a legacy
+          checkout experience. Because this method shares some information with
+          the payee, user agents are expected to protect the user from abuse of
+          the method. For example, user agents may reduce user fingerprinting
+          by:
+        </p>
+        <ul data-link-for="PaymentRequest">
+          <li>allowing the user to configure the user agent to turn off
+          <a>canMakePayment()</a>;
+          </li>
+          <li>informing the user when <a>canMakePayment()</a> is called;
+          </li>
+          <li>rate-limiting the frequency of calls to <a>canMakePayment()</a>
+          with different parameters.
+          </li>
+        </ul>
+        <p>
+          For rate-limiting the user agent might look at repeated calls from:
+        </p>
+        <ul>
+          <li>the same effective top-level domain plus one (eTLD+1);
+          </li>
+          <li>the top-level browsing context;
+          </li>
+          <li>for an iframe, the origin of the iframe content.
+          </li>
+        </ul>
+        <p>
+          These rate-limiting techniques intend to increase the cost associated
+          with repeated calls, whether it is the cost of managing multiple
+          eTLDs or the user experience friction of opening multiple windows
+          (tabs or pop-ups).
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -5305,6 +5305,9 @@
           <li>Allowing the user to configure the user agent to turn off
           <a>canMakePayment()</a>.
           </li>
+          <li>informing the user of what data is shared by
+          <a>canMakePayment()</a>;
+          </li>
           <li>Rate-limiting the frequency of calls to <a>canMakePayment()</a>
           with different parameters.
           </li>

--- a/index.html
+++ b/index.html
@@ -5303,7 +5303,8 @@
         </p>
         <ul data-link-for="PaymentRequest">
           <li>Allowing the user to configure the user agent to turn off
-          <a>canMakePayment()</a>.
+          <a>canMakePayment()</a>, which would cause the user agent to return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
+            DOMException</a>.
           </li>
           <li>Informing the user of what data is shared by
           <a>canMakePayment()</a>;

--- a/index.html
+++ b/index.html
@@ -5321,7 +5321,7 @@
           <li>the top-level browsing context. Alternatively, the user agent may
           block access to the API entirely for origins know to be bad actors.
           </li>
-          <li>for an iframe, the origin of the iframe content.
+          <li>for an <a>iframe</a>, the origin of the <a>iframe</a> content.
           </li>
         </ul>
         <p>

--- a/index.html
+++ b/index.html
@@ -5298,7 +5298,7 @@
          If no <a>payment handlers</a> support the <a>payment methods</a>, this enables the payee to fall back to a legacy
           checkout experience. Because this method shares some potentially unique information with
           the payee, user agents are expected to protect the user from abuse of
-          the method. For example, user agents may reduce user fingerprinting
+          the method. For example, user agents can reduce user fingerprinting
           by:
         </p>
         <ul data-link-for="PaymentRequest">

--- a/index.html
+++ b/index.html
@@ -5296,7 +5296,7 @@
           The <a>canMakePayment()</a> method enables the payee to determine
           — before calling <a>show()</a> — whether the user agent knows of any <a>payment handlers</a> available to the user that support the  <a>payment methods</a> provided to the <a>PaymentRequest<a> <a data-lt="PaymentRequest.PaymentRequest()">constructor</a>.
          If no <a>payment handlers</a> support the <a>payment methods</a>, this enables the payee to fall back to a legacy
-          checkout experience. Because this method shares some information with
+          checkout experience. Because this method shares some potentially unique information with
           the payee, user agents are expected to protect the user from abuse of
           the method. For example, user agents may reduce user fingerprinting
           by:

--- a/index.html
+++ b/index.html
@@ -5303,7 +5303,7 @@
         </p>
         <ul data-link-for="PaymentRequest">
           <li>Allowing the user to configure the user agent to turn off
-          <a>canMakePayment()</a>, which would cause the user agent to return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>
+           <a>canMakePayment()</a>, which would return <a>a promise rejected with</a> a "<a>NotAllowedError</a>" <a>DOMException</a>.
             DOMException</a>.
           </li>
           <li>Informing the user of what data is shared by

--- a/index.html
+++ b/index.html
@@ -5290,7 +5290,7 @@
       </section>
       <section class="informative">
         <h2 id="canmakepayment-protections">
-          canMakePayment() protections
+          <code>canMakePayment()</code> protections
         </h2>
         <p data-link-for="PaymentRequest">
           The <a>canMakePayment()</a> method enables the payee to determine


### PR DESCRIPTION
@rsolomakhin, @danyao, @marcoscaceres,

Based on discussion at the Privacy Interest Group call yesterday, I took an action to propose some changes; see the minutes for details:
 https://www.w3.org/2019/02/28-privacy-minutes

Specifically:

 * Merged the "Privacy and Security Considerations" and "Privacy Considerations" sections into a single section ("Privacy and Security Considerations").

 * Added a forward pointer from 3.5 to the canMakePayment() protections section (in security and privacy considerations). Removed the Note that was in the middle of the algorithm of 3.5, and merged it with the (rewritten) canMakePayment protections section.

 * Expanded the canMakePayment protections section based on PING conversation.

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [ ] Has undergone security/privacy review (link)

NOTE: I will also point PING at the edit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/843.html" title="Last updated on Mar 12, 2019, 10:08 PM UTC (fa87e58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/843/2b23c2f...fa87e58.html" title="Last updated on Mar 12, 2019, 10:08 PM UTC (fa87e58)">Diff</a>