### PR TITLE
Redact dependentLocality from shippingAddress

### DIFF
--- a/index.html
+++ b/index.html
@@ -4341,9 +4341,9 @@
               <li>
                 <div class="note" title="Privacy of recipient information">
                   <p>
-                    The <var>redactList</var> optionally gives user agents the
-                    possibility to limit the amount of personal information
-                    about the recipient that the API shares with the merchant.
+                    The <var>redactList</var> limits the amount of personal
+                    information about the recipient that the API shares with
+                    the merchant.
                   </p>
                   <p>
                     For merchants, the resulting <a>PaymentAddress</a> object

--- a/index.html
+++ b/index.html
@@ -4357,11 +4357,9 @@
                     some countries postal codes are so fine-grained that they
                     can uniquely identify a recipient.
                   </p>
-                </div>Let <var>redactList</var> be the empty list. set
-                <var>redactList</var> to « "organization", "phone",
-                "recipient", "addressLine", "dependentLocality" ».
+                </div>
               </li>
-              <li>Let <var>redactList</var> be the empty list. Optionally, set
+              <li>Let <var>redactList</var> be the empty list. Set
               <var>redactList</var> to « "organization", "phone", "recipient",
               "addressLine" ».
               </li>

--- a/index.html
+++ b/index.html
@@ -4340,7 +4340,7 @@
                   </p>
                 </div>Let <var>redactList</var> be the empty list. Optionally,
                 set <var>redactList</var> to « "organization", "phone",
-                "recipient", "addressLine" ».
+                "recipient", "addressLine", "dependentLocality" ».
               </li>
               <li>Let <var>address</var> be the result of running the steps to
               <a>create a <code>PaymentAddress</code> from user-provided

--- a/index.html
+++ b/index.html
@@ -4357,8 +4357,8 @@
                     some countries postal codes are so fine-grained that they
                     can uniquely identify a recipient.
                   </p>
-                </div>Let <var>redactList</var> be the empty list. Optionally,
-                set <var>redactList</var> to « "organization", "phone",
+                </div>Let <var>redactList</var> be the empty list. set
+                <var>redactList</var> to « "organization", "phone",
                 "recipient", "addressLine", "dependentLocality" ».
               </li>
               <li>Let <var>redactList</var> be the empty list. Optionally, set


### PR DESCRIPTION
closes #???

This now redacts the dependent locality as part of the "shipping address changed algorithm". This should still allow shipping costs to be calculated, but we need confirmation from folks in countries where this would take effect (e.g., in the UK).  

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [ ] Modified Web platform tests (link)
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/846.html" title="Last updated on Mar 12, 2019, 10:19 PM UTC (f576f36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/846/2b23c2f...f576f36.html" title="Last updated on Mar 12, 2019, 10:19 PM UTC (f576f36)">Diff</a>