### PR TITLE
Give AddressInit's members defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -2629,16 +2629,16 @@
         </h2>
         <pre class="idl">
           dictionary AddressInit {
-            DOMString country;
-            sequence&lt;DOMString&gt; addressLine;
-            DOMString region;
-            DOMString city;
-            DOMString dependentLocality;
-            DOMString postalCode;
-            DOMString sortingCode;
-            DOMString organization;
-            DOMString recipient;
-            DOMString phone;
+            DOMString country = "";
+            sequence&lt;DOMString&gt; addressLine = [];
+            DOMString region = "";
+            DOMString city = "";
+            DOMString dependentLocality = "";
+            DOMString postalCode = "";
+            DOMString sortingCode = "";
+            DOMString organization = "";
+            DOMString recipient = "";
+            DOMString phone = "";
           };
         </pre>
         <p>
@@ -2866,13 +2866,11 @@
           </p>
         </div>
         <ol data-link-for="AddressInit">
-          <li>Let |details| be an <a>AddressInit</a> dictionary with no members
-          present.
+          <li>Let |details| be a newly created <a>AddressInit</a> dictionary.
           </li>
           <li>If "addressLine" is not in |redactList|, set
           |details|["<a>addressLine</a>"] to the result of splitting the
-          user-provided address line into a <a>list</a>. If none was provided,
-          set it to the empty <a>list</a>.
+          user-provided address line into a <a>list</a>.
             <aside class="note">
               How to split an address line is locale dependent and beyond the
               scope of this specification.
@@ -2880,12 +2878,10 @@
           </li>
           <li>If "country" is not in |redactList|, set
           |details|["<a>country</a>"] to the user-provided country as an upper
-          case [[ISO3166-1]] alpha-2 code, or to the empty string if none was
-          provided.
+          case [[ISO3166-1]] alpha-2 code.
           </li>
           <li>If "phone" is not in |redactList|, set |details|["<a>phone</a>"]
-          to the user-provided phone number, or to the empty string if none was
-          provided.
+          to the user-provided phone number.
             <aside class="note" title="Privacy of phone number">
               <p>
                 To maintain users' privacy, implementers need to be mindful
@@ -2899,18 +2895,17 @@
           <li>If "city" is not in |redactList|, set |details|["<a>city</a>"] to
           the user-provided city, or to the empty string if none was provided.
           </li>
-          <li>If "dependentLocality" is not in |redactList|, set
-          |details|["<a>dependentLocality</a>"] to the user-provided dependent
-          locality, or to the empty string if none was provided.
+          <li>If "dependentLocality" is not in |redactList|, set |
+          details|["<a>dependentLocality</a>"] to the user-provided dependent
+          locality.
           </li>
           <li>If "organization" is not in |redactList|, set
           |details|["<a>organization</a>"] to the user-provided recipient
-          organization, or to the empty string if none was provided.
+          organization.
           </li>
           <li>If "postalCode" is not in |redactList|, set
-          |details|["<a>postalCode</a>"] to the user-provided postal code, or
-          to the empty string if none was provided. Optionally, redact part of
-          |details|["<a>postalCode</a>"].
+          |details|["<a>postalCode</a>"] to the user-provided postal code.
+          Optionally, redact part of |details|["<a>postalCode</a>"].
             <div class="note" title="Privacy of Postal Codes">
               <p>
                 <a>Postal codes</a> in certain countries can be so specific as
@@ -2926,7 +2921,7 @@
           </li>
           <li>If "recipient" is not in |redactList|, set
           |details|["<a>recipient</a>"] to the user-provided recipient of the
-          transaction, or to the empty string if none was provided.
+          transaction.
           </li>
           <li>
             <p>
@@ -2946,14 +2941,12 @@
               shipping or billing purposes).
             </p>
             <ol>
-              <li>Set |details|["<a>region</a>"] to the user-provided region,
-              or to the empty string if none was provided.
+              <li>Set |details|["<a>region</a>"] to the user-provided region.
               </li>
             </ol>
           </li>
           <li>If "sortingCode" is not in |redactList|, set
-          |details|["<a>sortingCode</a>"] to the user-provided sorting code, or
-          to the empty string if none was provided.
+          |details|["<a>sortingCode</a>"] to the user-provided sorting code.
           </li>
           <li>
             <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a


### PR DESCRIPTION
Closes #853

Based on https://github.com/web-platform-tests/wpt/pull/14271 

This moves what was in the prose (setting members to empty string) to the `AddressInit` IDL. That clarifies some ambiguities around null and undefined - as now these are always the empty string.  

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests - tested already. 
 * [x] Modified MDN Docs - doesn't apply. 
 * [x] Has undergone security/privacy review -  refactor, doesn't apply
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=959393)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1539044)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/852.html" title="Last updated on Apr 27, 2020, 6:35 AM UTC (0e78098)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/852/0157476...0e78098.html" title="Last updated on Apr 27, 2020, 6:35 AM UTC (0e78098)">Diff</a>