### PR TITLE
fix: dispatch must set [[waitForUpdate]] to true

### DIFF
--- a/index.html
+++ b/index.html
@@ -4457,6 +4457,9 @@
           of the user interface that could cause another update event to be
           fired.
           </li>
+          <li>Otherwise, set <var>event</var>.<a>[[\waitForUpdate]]</a> to
+          true.
+          </li>
         </ol>
       </section>
       <section>


### PR DESCRIPTION
closes #854

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] [Modified Web platform tests](https://w3c-test.org/payment-request/PaymentRequestUpdateEvent/updateWith-call-immediate-manual.https.html)
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [x] Firefox - already implements this. 
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/855.html" title="Last updated on Mar 25, 2019, 3:56 AM UTC (1b635a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/855/3fd929d...1b635a3.html" title="Last updated on Mar 25, 2019, 3:56 AM UTC (1b635a3)">Diff</a>