### PR TITLE
Allow incremental request of billing and shipping address

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,7 +891,7 @@
           <li>Set |request|.<a>[[\options]]</a> to |options|.
           </li>
           <li>Set |request|.<a>[[\requestedShippingAddressParts]]</a> to
-          |options|.<a data-lt="PaymentOptions.requestShippingAddressParts">requestShippingAddressParts</a>.
+          |options|.{{PaymentOptions/requestShippingAddressParts}}.
           <li>Set |request|.<a>[[\state]]</a> to "<a>created</a>".
           </li>
           <li>Set |request|.<a>[[\updating]]</a> to false.

--- a/index.html
+++ b/index.html
@@ -2212,7 +2212,7 @@
           parts of the billing address that the payee wishes to receive when the
           <a>requestBillingAddress</a> member is true. An empty list means no
           restriction, i.e. the payee requests the full billing address. This
-          field has no effect if the <a>requestBillingAddress</a> boolean is
+          field has no effect if the <a>requestBillingAddress</a> member is
           false.
           <aside class="note">
             The billing address is part of the payment-method specific response.

--- a/index.html
+++ b/index.html
@@ -2199,7 +2199,7 @@
           method</a> (e.g., the billing address associated with a credit card).
           The <a>user agent</a> returns the billing address as part of the
           {{PaymentMethodChangeEvent}}'s {{PaymentMethodChangeEvent/methodDetails}} attribute and the
-          {{PaymentResponse}}'s <a>details</a> attribute. A payee can use this
+          {{PaymentResponse}}'s {{PaymentResponse/details}} attribute. A payee can use this
           information to, for example, calculate tax in certain jurisdictions
           and update the displayed total. See below for privacy considerations
           regarding <a href="#user-info">exposing user information</a>.

--- a/index.html
+++ b/index.html
@@ -2265,7 +2265,7 @@
           attribute and the {{PaymentResponse}}'s
           {{PaymentResponse/shippingAddress}}
           attribute. The former is subject to a
-          <a data-lt="shipping-redact-list">redact list</a> per the
+          <a>shipping redact list</a> per the
           <a>shipping address changed algorithm</a>.
           <aside class="note">
             <p>

--- a/index.html
+++ b/index.html
@@ -4081,7 +4081,7 @@
           </h2>
           <aside class="note">
             <p>
-              <a>PaymentMethodChangeEvent.requestBillingAddress()</a> allows the
+              The {{PaymentMethodChangeEvent/requestBillingAddress()}} method allows the
               developer to incrementally request additional pieces of the
               billing address that were not initially requested in
               {{ PaymentOptions.requestBillingAddressParts }}.

--- a/index.html
+++ b/index.html
@@ -4076,7 +4076,7 @@
               If a developer wants to incrementally request more granular details
               of the user's shipping address, for example, to re-calculate
               shipping cost, then they can call <a>requestShippingAddress()</a>
-              and provide a list of <a>AddressParts</a>, which will return a
+              and provide a sequence of <a>AddressParts</a>, which will return a
               promise that resolves to an <a>PaymentAddress</a> with the
               requested address fields populated. This method can be called
               repeatedly to incrementally request more parts as needed.

--- a/index.html
+++ b/index.html
@@ -2208,7 +2208,7 @@
           <dfn>requestBillingAddressParts</dfn> member
         </dt>
         <dd>
-          A sequence of <a>AddressParts</a> that specifies which fine-grained
+          A sequence of {{AddressParts}} that specifies which fine-grained
           parts of the billing address that the payee wishes to receive when the
           <a>requestBillingAddress</a> boolean is true. An empty list means no
           restriction, i.e. the payee requests the full billing address. This

--- a/index.html
+++ b/index.html
@@ -1503,7 +1503,7 @@
               the payee-requested shipping address parts, initially supplied to
               the constructor via {{PaymentOptions}}'s
               {{PaymentOptions/requestShippingAddressParts}} and then updated with calls to
-              requestShippingAddress()</a>.
+              {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -2287,7 +2287,7 @@
           restriction, i.e. the <a>user agent</a> will return the full shipping
           address, subject to the
           <a>shipping redact list</a>. This field has no effect if the
-          <a>requestShipping</a> member is false. The payee can request
+          {{PaymentOptions/requestShipping}} member is false. The payee can request
           additional pieces incrementally using {{PaymentRequestUpdateEvent}}'s
           {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
         </dd>

--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,7 @@
               The current <a>sequence</a>&lt;{{AddressParts}}&gt; specifying
               the payee-requested shipping address parts, initially supplied to
               the constructor via {{PaymentOptions}}'s
-              requestShippingAddressParts</a> and then updated with calls to
+              {{PaymentOptions/requestShippingAddressParts}} and then updated with calls to
               <a data-lt="PaymentRequestUpdateEvent.requestShippingAddress">
               requestShippingAddress()</a>.
             </td>

--- a/index.html
+++ b/index.html
@@ -2261,7 +2261,7 @@
           when physical goods need to be shipped by the payee to the user). The
           <a>user agent</a> returns the shipping address in the
           {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}}
-          shippingAddress</a> attribute and the {{PaymentResponse}}'s
+          attribute and the {{PaymentResponse}}'s
           <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
           attribute. The former is subject to a redact list per the <a>shipping
           address changed algorithm</a>.

--- a/index.html
+++ b/index.html
@@ -4087,7 +4087,7 @@
               billing address that were not initially requested in
               {{ PaymentOptions.requestBillingAddressParts }}.
             </p>
-            <pre class="example js" title="how to use `requestBillingAddress()` correct.">
+            <pre class="example js" title="how to use `requestBillingAddress()`.">
               request.onpaymentmethodchange = ev =&gt; {
                 const promiseForUpdatingTax =
                   ev.requestBillingAddress(["country", "postalCode"])

--- a/index.html
+++ b/index.html
@@ -2984,7 +2984,7 @@
           The steps to <dfn>create a `PaymentAddress` from user-provided
           input</dfn> are given by the following algorithm. The algorithm takes
           a <a>list</a> |redactList| and a
-          <a>sequence</a>&lt;<a>AddressParts</a>&gt; |requestedParts|.
+          <a>sequence</a>&lt;{{AddressParts}}&gt; |requestedParts|.
         </p>
         <div class="note" title=
         "Privacy of recipient information (the redactList)">

--- a/index.html
+++ b/index.html
@@ -2262,7 +2262,7 @@
           <a>user agent</a> returns the shipping address in the
           {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}}
           attribute and the {{PaymentResponse}}'s
-          <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
+          {{PaymentResponse/shippingAddress}}
           attribute. The former is subject to a redact list per the <a>shipping
           address changed algorithm</a>.
           <aside class="note">

--- a/index.html
+++ b/index.html
@@ -4037,7 +4037,7 @@
           [SecureContext, Exposed=Window]
           interface PaymentRequestUpdateEvent : Event {
             constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict = {});
-            Promise&lt;PaymentAddress&gt; requestShippingAddress(AddressParts addressParts);
+            Promise&lt;PaymentAddress&gt; requestShippingAddress(sequence<AddressParts> addressParts);
             void updateWith(Promise&lt;PaymentDetailsUpdate&gt; detailsPromise);
           };
         </pre>

--- a/index.html
+++ b/index.html
@@ -892,6 +892,7 @@
           </li>
           <li>Set |request|.<a>[[\requestedShippingAddressParts]]</a> to
           |options|.{{PaymentOptions/requestShippingAddressParts}}.
+          </li>
           <li>Set |request|.<a>[[\state]]</a> to "<a>created</a>".
           </li>
           <li>Set |request|.<a>[[\updating]]</a> to false.
@@ -1140,7 +1141,8 @@
             <p>
               Pass the <a data-lt="converted to an IDL value">converted</a>
               second element in the |paymentMethod| tuple, |modifiers|,
-              |request|.<a>[[\options]]</a>.{{PaymentOptions/requestBillingAddress}} and
+              |request|.<a>[[\options]]</a>.{{PaymentOptions/requestBillingAddress}}
+              and
               |request|.<a>[[\options]]</a>.{{PaymentOptions/requestBillingAddressParts}}.
               Optionally, the user agent SHOULD send the appropriate data from
               |request| to the user-selected <a>payment handler</a> in order to
@@ -1502,7 +1504,8 @@
               The current <a>sequence</a>&lt;{{AddressParts}}&gt; specifying
               the payee-requested shipping address parts, initially supplied to
               the constructor via {{PaymentOptions}}'s
-              {{PaymentOptions/requestShippingAddressParts}} and then updated with calls to
+              {{PaymentOptions/requestShippingAddressParts}} and then updated
+              with calls to
               {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
             </td>
           </tr>
@@ -1744,8 +1747,8 @@
           the developer that the currency is invalid.
           </li>
           <li>If |amount|.<a>value</a> is not a <a>valid decimal monetary
-          value</a>, throw a {{TypeError}}, optionally informing the
-          developer that the currency is invalid.
+          value</a>, throw a {{TypeError}}, optionally informing the developer
+          that the currency is invalid.
           </li>
           <li>Set |amount|.<a>currency</a> to the result of <a>ASCII
           uppercase</a> |amount|.<a>currency</a>.
@@ -2198,30 +2201,31 @@
           and return the billing address associated with a <a>payment
           method</a> (e.g., the billing address associated with a credit card).
           The <a>user agent</a> returns the billing address as part of the
-          {{PaymentMethodChangeEvent}}'s {{PaymentMethodChangeEvent/methodDetails}} attribute and the
-          {{PaymentResponse}}'s {{PaymentResponse/details}} attribute. A payee can use this
-          information to, for example, calculate tax in certain jurisdictions
-          and update the displayed total. See below for privacy considerations
-          regarding [[[#user-info]]].
+          {{PaymentMethodChangeEvent}}'s
+          {{PaymentMethodChangeEvent/methodDetails}} attribute and the
+          {{PaymentResponse}}'s {{PaymentResponse/details}} attribute. A payee
+          can use this information to, for example, calculate tax in certain
+          jurisdictions and update the displayed total. See below for privacy
+          considerations regarding [[[#user-info]]].
         </dd>
         <dt>
           <dfn>requestBillingAddressParts</dfn> member
         </dt>
         <dd>
           A sequence of {{AddressParts}} that specifies which fine-grained
-          parts of the billing address that the payee wishes to receive when the
-          <a>requestBillingAddress</a> member is true. An empty list means no
-          restriction, i.e. the payee requests the full billing address. The <a>requestBillingAddressParts</a>
-          member has no effect if the <a>requestBillingAddress</a> member is
-          false.
+          parts of the billing address that the payee wishes to receive when
+          the <a>requestBillingAddress</a> member is true. An empty list means
+          no restriction, i.e. the payee requests the full billing address. The
+          <a>requestBillingAddressParts</a> member has no effect if the
+          <a>requestBillingAddress</a> member is false.
           <aside class="note">
-            The billing address is part of the payment-method specific response.
-            The <a>user agent</a> simply passes the payee-specified
+            The billing address is part of the payment-method specific
+            response. The <a>user agent</a> simply passes the payee-specified
             <a>requestBillingAddressParts</a> to the payment handler. It is the
             responsibility of the payment handler to ensure no more than the
             requested pieces is returned. A payment handler may choose to not
-            return some requested pieces (e.g., as a result of applying a <a>
-            redact list</a>). The payee can request additional pieces
+            return some requested pieces (e.g., as a result of applying a
+            <a>redact list</a>). The payee can request additional pieces
             incrementally using {{PaymentMethodChangeEvent}}'s
             {{PaymentMethodChangeEvent/requestBillingAddress()}}.
           </aside>
@@ -2261,19 +2265,18 @@
           and return a shipping address as part of the payment request (e.g.,
           when physical goods need to be shipped by the payee to the user). The
           <a>user agent</a> returns the shipping address in the
-          {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}}
-          attribute and the {{PaymentResponse}}'s
-          {{PaymentResponse/shippingAddress}} attribute. The former is subject
-          to a <a>shipping redact list</a> per the <a>shipping address changed
-          algorithm</a>.
+          {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}} attribute and
+          the {{PaymentResponse}}'s {{PaymentResponse/shippingAddress}}
+          attribute. The former is subject to a <a>shipping redact list</a> per
+          the <a>shipping address changed algorithm</a>.
           <aside class="note">
             <p>
-              A payee may not need the full shipping address of a user until the
-              payment request is completed. For example, just having "country"
-              may be sufficient to calculate shipping cost. A payee sensitive to
-              the user's privacy can use <a>requestShippingAddressParts</a> to
-              restrict the initial set of address parts returned by the
-              <a>user agent</a>.
+              A payee may not need the full shipping address of a user until
+              the payment request is completed. For example, just having
+              "country" may be sufficient to calculate shipping cost. A payee
+              sensitive to the user's privacy can use
+              <a>requestShippingAddressParts</a> to restrict the initial set of
+              address parts returned by the <a>user agent</a>.
             </p>
           </aside>
         </dd>
@@ -2285,10 +2288,11 @@
           parts of the shipping address that the payee wishes to receive when
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
-          address, subject to the
-          <a>shipping redact list</a>. The {{PaymentOptions/requestShippingAddressParts}} member has no effect if the
-          {{PaymentOptions/requestShipping}} member is false. The payee can request
-          additional pieces incrementally using {{PaymentRequestUpdateEvent}}'s
+          address, subject to the <a>shipping redact list</a>. The
+          {{PaymentOptions/requestShippingAddressParts}} member has no effect
+          if the {{PaymentOptions/requestShipping}} member is false. The payee
+          can request additional pieces incrementally using
+          {{PaymentRequestUpdateEvent}}'s
           {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
         </dd>
         <dt>
@@ -3006,9 +3010,9 @@
           </p>
         </div>
         <ol data-link-for="AddressInit">
-          <li>If |requestedParts| is empty, set it to «
-          "addressLine", "city", "country", "dependentLocality", "organization",
-          "phone", "postalCode", "recipient", "region", "sortingCode"».
+          <li>If |requestedParts| is empty, set it to « "addressLine", "city",
+          "country", "dependentLocality", "organization", "phone",
+          "postalCode", "recipient", "region", "sortingCode"».
           </li>
           <li>Let |details:AddressInit| be an <a>AddressInit</a> dictionary
           with no members present.
@@ -3028,8 +3032,8 @@
           was provided.
           </li>
           <li>If "phone" is in |requestedParts| and is not in |redactList|, set
-          |details|["<a>phone</a>"] to the user-provided phone number, or to the
-          empty string if none was provided.
+          |details|["<a>phone</a>"] to the user-provided phone number, or to
+          the empty string if none was provided.
             <aside class="note" title="Privacy of phone number">
               <p>
                 To maintain users' privacy, implementers need to be mindful
@@ -3054,10 +3058,10 @@
           user-provided recipient organization, or to the empty string if none
           was provided.
           </li>
-          <li>If "postalCode" is in |requestedParts| and is not in |redactList|,
-          set |details|["<a>postalCode</a>"] to the user-provided postal code,
-          or to the empty string if none was provided. Optionally, redact part
-          of |details|["<a>postalCode</a>"].
+          <li>If "postalCode" is in |requestedParts| and is not in
+          |redactList|, set |details|["<a>postalCode</a>"] to the user-provided
+          postal code, or to the empty string if none was provided. Optionally,
+          redact part of |details|["<a>postalCode</a>"].
             <div class="note" title="Privacy of Postal Codes">
               <p>
                 <a>Postal codes</a> in certain countries can be so specific as
@@ -3098,9 +3102,10 @@
               </li>
             </ol>
           </li>
-          <li>If "sortingCode" is in |requestedParts| and is not in |redactList|,
-          set |details|["<a>sortingCode</a>"] to the user-provided sorting code,
-          or to the empty string if none was provided.
+          <li>If "sortingCode" is in |requestedParts| and is not in
+          |redactList|, set |details|["<a>sortingCode</a>"] to the
+          user-provided sorting code, or to the empty string if none was
+          provided.
           </li>
           <li>
             <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a
@@ -3714,9 +3719,9 @@
               <dfn>[[\retryPromise]]</dfn>
             </td>
             <td>
-              Null, or a {{Promise}} that resolves when a <a>user accepts
-              the payment request</a> or rejects if the <a>user aborts the
-              payment request</a>.
+              Null, or a {{Promise}} that resolves when a <a>user accepts the
+              payment request</a> or rejects if the <a>user aborts the payment
+              request</a>.
             </td>
           </tr>
         </table>
@@ -4059,9 +4064,8 @@
         </pre>
         <section>
           <h3>
-             <dfn data-lt="PaymentMethodChangeEvent.PaymentMethodChangeEvent()">
-               Constructor
-             </dfn>
+            <dfn data-lt=
+            "PaymentMethodChangeEvent.PaymentMethodChangeEvent()">Constructor</dfn>
           </h3>
           <p>
             The <a data-lt=
@@ -4074,6 +4078,7 @@
             |type| and |eventInitDict|.
             </li>
             <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to false.
+            </li>
             <li>Return |event|.
             </li>
           </ol>
@@ -4100,19 +4105,19 @@
         </section>
         <section>
           <h2>
-            <dfn data-lt="requestBillingAddress(addressParts)">
-              requestBillingAddress()
-            </dfn> method
+            <dfn data-lt=
+            "requestBillingAddress(addressParts)">requestBillingAddress()</dfn>
+            method
           </h2>
           <aside class="note">
             <p>
               The {{PaymentMethodChangeEvent/requestBillingAddress()}} method
-              allows the developer to incrementally request additional pieces of
-              the billing address that were not initially requested in
-              {{ PaymentOptions/requestBillingAddressParts }}.
+              allows the developer to incrementally request additional pieces
+              of the billing address that were not initially requested in {{
+              PaymentOptions/requestBillingAddressParts }}.
             </p>
-            <pre class="example js"
-              title="how to use `requestBillingAddress()` correctly.">
+            <pre class="example js" title=
+            "how to use `requestBillingAddress()` correctly.">
               // ✅ Good: request more address parts to compute new total. The
               // final response will only contain "country" and "postalCode".
               request.onpaymentmethodchange = (ev) =&gt; {
@@ -4181,34 +4186,41 @@
             <li>If any of the following is true, then return <a>a promise
             rejected with</a> an {{"InvalidStateError"}} {{DOMException}}:
               <ul>
-                <li>|event|'s {{ Event/isTrusted }} attribute is false</li>
-                <li>|event|.<a>[[\waitForMethodDetails]]</a> is true</li>
-                <li>|event|.<a>[[\waitForUpdate]]</a> is true</li>
-                <li>|request|.<a>[[\state]]</a> is not "<a>interactive</a>"</li>
+                <li>|event|'s {{ Event/isTrusted }} attribute is false
+                </li>
+                <li>|event|.<a>[[\waitForMethodDetails]]</a> is true
+                </li>
+                <li>|event|.<a>[[\waitForUpdate]]</a> is true
+                </li>
+                <li>|request|.<a>[[\state]]</a> is not "<a>interactive</a>"
+                </li>
               </ul>
             </li>
-            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to true.</li>
-            <li>Let |methodDetailsPromise:Promise| be <a>a new promise</a>.</li>
+            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to true.
+            </li>
+            <li>Let |methodDetailsPromise:Promise| be <a>a new promise</a>.
+            </li>
             <li>Return |methodDetailsPromise|, and perform the remaining steps
             <a>in parallel</a>.
             </li>
             <li>Let |handler| be the <a>payment handler</a> that triggered this
             |event|.
             </li>
-            <li>Use a <a>payment handler</a> specific API to send |addressParts|
-            to |handler| and receive a new <a>object</a> |methodDetails|.
-            <p class="note">
-              It is the responsibility of the payment handler to keep track of
-              successive address parts it is called with and return an
-              appropriate version of the billing address associated with the
-              selected payment instrument, potentially with some
-              <a>redact list</a> applied.
-            </p>
+            <li>Use a <a>payment handler</a> specific API to send
+            |addressParts| to |handler| and receive a new <a>object</a>
+            |methodDetails|.
+              <p class="note">
+                It is the responsibility of the payment handler to keep track
+                of successive address parts it is called with and return an
+                appropriate version of the billing address associated with the
+                selected payment instrument, potentially with some <a>redact
+                list</a> applied.
+              </p>
             </li>
-            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to false.</li>
+            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to false.
+            </li>
             <li>Resolve |methodDetailsPromise| with |methodDetails|.
             </li>
-
           </ol>
         </section>
         <section data-dfn-for="PaymentMethodChangeEventInit" data-link-for=
@@ -4260,8 +4272,8 @@
                 <dfn>[[\waitForMethodDetails]]</dfn>
               </td>
               <td>
-                A boolean indicating whether there is a pending request for
-                a method-specific details object initiated by
+                A boolean indicating whether there is a pending request for a
+                method-specific details object initiated by
                 <a>requestBillingAddress()</a> that has not settled.
               </td>
             </tr>
@@ -4288,8 +4300,7 @@
         <section>
           <h3>
             <dfn data-lt=
-            "PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()">Constructor
-            </dfn>
+            "PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()">Constructor</dfn>
           </h3>
           <p data-tests=
           "PaymentRequestUpdateEvent/constructor.https.html, PaymentRequestUpdateEvent/constructor.http.html">
@@ -4305,22 +4316,23 @@
             <li>Set |event|.<a>[[\waitForUpdate]]</a> to false.
             </li>
             <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to false.
+            </li>
             <li>Return |event|.
             </li>
           </ol>
         </section>
         <section>
           <h2>
-            <dfn data-lt="requestShippingAddress(addressParts)">
-              requestShippingAddress()
-            </dfn> method
+            <dfn data-lt=
+            "requestShippingAddress(addressParts)">requestShippingAddress()</dfn>
+            method
           </h2>
           <aside class="note">
             <p>
               The {{PaymentRequestUpdateEvent/requestShippingAddress()}} method
-              allows the developer to incrementally request additional pieces of
-              the shipping address that were not initially requested in
-              {{ PaymentOptions.requestShippingAddressParts }}.
+              allows the developer to incrementally request additional pieces
+              of the shipping address that were not initially requested in {{
+              PaymentOptions.requestShippingAddressParts }}.
             </p>
             <p>
               The same usage pattern is expected as
@@ -4329,16 +4341,17 @@
             </p>
           </aside>
           <p>
-            The <a>requestShippingAddress(|addressParts|)</a> method MUST act as
-            follows:
+            The <a>requestShippingAddress(|addressParts|)</a> method MUST act
+            as follows:
           </p>
           <ol class="algorithm">
             <li>Let |event:PaymentRequestUpdateEvent| be this
             {{PaymentRequestUpdateEvent}} instance.
             </li>
-            <li>If |event|'s {{ Event/type }} attribute is not <a>
-            shippingaddresschange</a>, then return <a>a promise rejected with
-            </a> a {{TypeError}}.
+            <li>If |event|'s {{ Event/type }} attribute is not
+            <a>shippingaddresschange</a>, then return <a>a promise rejected
+            with</a> a {{TypeError}}.
+            </li>
             <li>Let |request:PaymentRequest| be the value of |event|'s
             [=Event/target=].
             </li>
@@ -4347,28 +4360,35 @@
             <li>If any of the following is true, then return <a>a promise
             rejected with</a> an {{"InvalidStateError"}} {{DOMException}}:
               <ul>
-                <li>|event|'s {{ Event/isTrusted }} attribute is false</li>
-                <li>|event|.<a>[[\waitForShippingAddress]]</a> is true</li>
-                <li>|event|.<a>[[\waitForUpdate]]</a> is true</li>
-                <li>|request|.<a>[[\state]]</a> is not "<a>interactive</a>"</li>
+                <li>|event|'s {{ Event/isTrusted }} attribute is false
+                </li>
+                <li>|event|.<a>[[\waitForShippingAddress]]</a> is true
+                </li>
+                <li>|event|.<a>[[\waitForUpdate]]</a> is true
+                </li>
+                <li>|request|.<a>[[\state]]</a> is not "<a>interactive</a>"
+                </li>
               </ul>
             </li>
-            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to true.</li>
-            <li>Let |addressPromise:Promise| be <a>a new promise</a>.</li>
-            <li>Return |addressPromise|, and perform the remaining steps
-            <a>in parallel</a>.
+            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to true.
             </li>
-            <li>Update |request|.<a>[[\requestedShippingAddressParts]]</a> to be
-            the union of itself and |addressParts|.
+            <li>Let |addressPromise:Promise| be <a>a new promise</a>.
             </li>
-            <li>Let |address:PaymentAddress| be the result of <a>create
-            a `PaymentAddress` from user-provided input</a> with <a>shipping
-            redact list</a> and |request|.<a>[[\requestedShippingAddressParts]]
-            </a>.
+            <li>Return |addressPromise|, and perform the remaining steps <a>in
+            parallel</a>.
+            </li>
+            <li>Update |request|.<a>[[\requestedShippingAddressParts]]</a> to
+            be the union of itself and |addressParts|.
+            </li>
+            <li>Let |address:PaymentAddress| be the result of <a>create a
+            `PaymentAddress` from user-provided input</a> with <a>shipping
+            redact list</a> and
+            |request|.<a>[[\requestedShippingAddressParts]]</a>.
             </li>
             <li>Set |request|.[=PaymentRequest/shippingAddress=] to |address|.
             </li>
-            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to false.</li>
+            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to false.
+            </li>
             <li>Resolve |addressPromise| with |address|.
             </li>
           </ol>
@@ -4688,9 +4708,12 @@
         </ol>
       </section>
       <section>
-        <h2>Shipping redact list</h2>
-        <p>The <dfn>shipping redact list</dfn> is a <a>redact list</a> that
-        includes « "organization", "phone", "recipient", "addressLine" ».
+        <h2>
+          Shipping redact list
+        </h2>
+        <p>
+          The <dfn>shipping redact list</dfn> is a <a>redact list</a> that
+          includes « "organization", "phone", "recipient", "addressLine" ».
         </p>
       </section>
       <section>
@@ -5466,16 +5489,16 @@
         </h2>
         <p>
           The <dfn>validate merchant's details algorithm</dfn> takes a
-          {{Promise}} |opaqueDataPromise| and a {{PaymentRequest}}
-          |request|. The steps are conditional on the |opaqueDataPromise|
-          settling. If |opaqueDataPromise| never settles then the payment
-          request is blocked. The user agent SHOULD provide the user with a
-          means to abort a payment request. Implementations MAY choose to
-          implement a timeout for pending updates if |opaqueDataPromise|
-          doesn't settle in a reasonable amount of time. If an implementation
-          chooses to implement a timeout, they MUST execute the steps listed
-          below in the "upon rejection" path. Such a timeout is a fatal error
-          for the payment request.
+          {{Promise}} |opaqueDataPromise| and a {{PaymentRequest}} |request|.
+          The steps are conditional on the |opaqueDataPromise| settling. If
+          |opaqueDataPromise| never settles then the payment request is
+          blocked. The user agent SHOULD provide the user with a means to abort
+          a payment request. Implementations MAY choose to implement a timeout
+          for pending updates if |opaqueDataPromise| doesn't settle in a
+          reasonable amount of time. If an implementation chooses to implement
+          a timeout, they MUST execute the steps listed below in the "upon
+          rejection" path. Such a timeout is a fatal error for the payment
+          request.
         </p>
         <ol class="algorithm">
           <li>Set |request|.<a>[[\updating]]</a> to true.
@@ -5759,8 +5782,7 @@
         <dd>
           The terms <dfn data-cite=
           "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
-          slot</dfn>,
-          and <code><dfn data-cite=
+          slot</dfn>, and <code><dfn data-cite=
           "ECMASCRIPT#sec-json.stringify">JSON.stringify</dfn></code> are
           defined by [[ECMASCRIPT]].
           <p>
@@ -5795,8 +5817,8 @@
         guard against running out of memory, or to work around
         platform-specific limitations. When an input exceeds
         implementation-specific limit, the user agent MUST throw, or, in the
-        context of a promise, reject with, a {{TypeError}} optionally
-        informing the developer of how a particular input exceeded an
+        context of a promise, reject with, a {{TypeError}} optionally informing
+        the developer of how a particular input exceeded an
         implementation-specific limit.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -1499,7 +1499,7 @@
               <dfn>[[\requestedShippingAddressParts]]</dfn>
             </td>
             <td>
-              The current <a>sequence</a>&lt;<a>AddressParts</a>&gt; specifying
+              The current <a>sequence</a>&lt;{{AddressParts}}&gt; specifying
               the payee-requested shipping address parts, initially supplied to
               the constructor via {{PaymentOptions}}'s
               <a data-lt="PaymentOptions.requestShippingAddressParts">

--- a/index.html
+++ b/index.html
@@ -2285,7 +2285,7 @@
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
           address, subject to any applicable redact list. This field has no
-          effect if the <a>requestShipping</a> boolean is false. The payee can
+          effect if the <a>requestShipping</a> member is false. The payee can
           request additional pieces incrementally using
           {{PaymentRequestUpdateEvent}}'s {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
         </dd>

--- a/index.html
+++ b/index.html
@@ -890,6 +890,8 @@
           </li>
           <li>Set |request|.<a>[[\options]]</a> to |options|.
           </li>
+          <li>Set |request|.<a>[[\requestedShippingAddressParts]]</a> to
+          |options|.<a data-lt="PaymentOptions.requestShippingAddressParts">requestShippingAddressParts</a>.
           <li>Set |request|.<a>[[\state]]</a> to "<a>created</a>".
           </li>
           <li>Set |request|.<a>[[\updating]]</a> to false.
@@ -1137,7 +1139,9 @@
           <li>
             <p>
               Pass the <a data-lt="converted to an IDL value">converted</a>
-              second element in the |paymentMethod| tuple and |modifiers|.
+              second element in the |paymentMethod| tuple, |modifiers|,
+              |request|.<a>[[\options]]</a>.<a data-lt="PaymentOptions.requestBillingAddress">requestBillingAddress</a> and
+              |request|.<a>[[\options]]</a>.<a data-lt="PaymentOptions.requestBillingAddressParts">requestBillingAddressParts</a>.
               Optionally, the user agent SHOULD send the appropriate data from
               |request| to the user-selected <a>payment handler</a> in order to
               guide the user through the payment process. This includes the
@@ -1488,6 +1492,20 @@
             </td>
             <td>
               The <a>PaymentOptions</a> supplied to the constructor.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\requestedShippingAddressParts]]</dfn>
+            </td>
+            <td>
+              The current <a>sequence</a>&lt;<a>AddressParts</a>&gt; specifying
+              the payee-requested shipping address parts, initially supplied to
+              the constructor via {{PaymentOptions}}'s
+              <a data-lt="PaymentOptions.requestShippingAddressParts">
+              requestShippingAddressParts</a> and then updated with calls to
+              <a data-lt="PaymentRequestUpdateEvent.requestShippingAddress">
+              requestShippingAddress()</a>.
             </td>
           </tr>
           <tr>
@@ -2181,27 +2199,32 @@
           A boolean that indicates whether the <a>user agent</a> SHOULD collect
           and return the billing address associated with a <a>payment
           method</a> (e.g., the billing address associated with a credit card).
-          Typically, the user agent will return the billing address as part of
-          the {{PaymentMethodChangeEvent}}'s <a>methodDetails</a>. A merchant
-          can use this information to, for example, calculate tax in certain
-          jurisdictions and update the displayed total. See below for privacy
-          considerations regarding <a href="#user-info">exposing user
-          information</a>.
+          The <a>user agent</a> returns the billing address as part of the
+          {{PaymentMethodChangeEvent}}'s <a>methodDetails</a> attribute and the
+          {{PaymentResponse}}'s <a>details</a> attribute. A payee can use this
+          information to, for example, calculate tax in certain jurisdictions
+          and update the displayed total. See below for privacy considerations
+          regarding <a href="#user-info">exposing user information</a>.
         </dd>
         <dt>
           <dfn>requestBillingAddressParts</dfn> member
         </dt>
         <dd>
-          A sequence of <a>AddressParts</a> that indicates fine-grained parts of
-          the billing address that the <a>user agent</a> SHOULD collect from
-          the user-selected payment handler. Additional pieces can be requested
-          incrementally using <a>PaymentMethodChangeEvent.requestBillingAddress
-          </a>.
+          A sequence of <a>AddressParts</a> that specifies which fine-grained
+          parts of the billing address that the payee wishes to receive when the
+          <a>requestBillingAddress</a> boolean is true. An empty list means no
+          restriction, i.e. the payee requests the full billing address. This
+          field has no effect if the <a>requestBillingAddress</a> boolean is
+          false.
           <aside class="note">
             The billing address is part of the payment-method specific response.
-            The <a>user agent</a> will pass on the merchant requested pieces to
-            the payment handler, but ultimately it is the responsibility of the
-            payment handler to ensure only the requested pieces are returned.
+            The <a>user agent</a> simply passes the payee-specified
+            <a>requestBillingAddressParts</a> to the payment handler. It is the
+            responsibility of the payment handler to ensure no more than the
+            requested pieces is returned. A payment handler may choose to not
+            return some requested pieces (e.g., as a result of applying a redact
+            list). The payee can request additional pieces incrementally using
+            <a>PaymentMethodChangeEvent.requestBillingAddress()</a>.
           </aside>
         </dd>
         <dt>
@@ -2236,19 +2259,22 @@
         </dt>
         <dd>
           A boolean that indicates whether the <a>user agent</a> SHOULD collect
-          and return a shipping address as part of the payment request. For
-          example, this would be set to true when physical goods need to be
-          shipped by the merchant to the user. This would be set to false for
-          the purchase of digital goods.
+          and return a shipping address as part of the payment request (e.g.,
+          when physical goods need to be shipped by the payee to the user). The
+          <a>user agent</a> returns the shipping address in the
+          {{PaymentRequest}}'s <a data-lt="PaymentRequest.shippingAddress">
+          shippingAddress</a> attribute and the {{PaymentResponse}}'s
+          <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
+          attribute. The former is subject to a redact list per the <a>shipping
+          address changed algorithm</a>.
           <aside class="note">
             <p>
-              A developer may not need the full shipping address of a user, for
-              example, just having "country" may be sufficient to calculate
-              shipping cost. To be sensitive to user's privacy, developers should
-              prefer to use <a>requestShippingAddressParts</a> to specify an
-              initial restrictive set of address parts and then use
-              <a>PaymentRequestUpdateEvent.requestShippingAddress()
-              </a> to incrementally request only the address parts they need.
+              A payee may not need the full shipping address of a user until the
+              payment request is completed. For example, just having "country"
+              may be sufficient to calculate shipping cost. A payee sensitive to
+              the user's privacy can use <a>requestShippingAddressParts</a> to
+              restrict the initial set of address parts returned by the
+              <a>user agent</a>.
             </p>
           </aside>
         </dd>
@@ -2256,10 +2282,14 @@
           <dfn>requestShippingAddressParts</dfn> member
         </dt>
         <dd>
-          A sequence of <a>AddressParts</a> that indicates fine-grained parts of
-          the shipping address that the <a>user agent</a> SHOULD collect and
-          return. Additional pieces can be requested incrementally as needed
-          using <a>PaymentRequestUpdateEvent.requestShippingAddress()</a>.
+          A sequence of <a>AddressParts</a> that specifies which fine-grained
+          parts of the shipping address that the payee wishes to receive when
+          the <a>requestShipping</a> boolean is true. An empty list means no
+          restriction, i.e. the <a>user agent</a> will return the full shipping
+          address, subject to any applicable redact list. This field has no
+          effect if the <a>requestShipping</a> boolean is false. The payee can
+          request additional pieces incrementally using
+          <a>PaymentRequestUpdateEvent.requestShippingAddress()</a>.
         </dd>
         <dt>
           <dfn>shippingType</dfn> member
@@ -2403,6 +2433,7 @@
           [SecureContext, Exposed=(Window)]
           interface PaymentAddress {
             [Default] object toJSON();
+            readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
             readonly attribute DOMString city;
             readonly attribute DOMString country;
             readonly attribute DOMString dependentLocality;
@@ -2412,7 +2443,6 @@
             readonly attribute DOMString recipient;
             readonly attribute DOMString region;
             readonly attribute DOMString sortingCode;
-            readonly attribute FrozenArray&lt;DOMString&gt; addressLine;
           };
         </pre>
         <p>
@@ -2532,16 +2562,6 @@
         </section>
         <section>
           <h2>
-            <dfn>country</dfn> attribute
-          </h2>
-          <p data-link-for="">
-            Represents the <a>country</a> of the address. When getting, returns
-            the value of the {{PaymentAddress}}'s <a>[[\country]]</a> internal
-            slot.
-          </p>
-        </section>
-        <section>
-          <h2>
             <dfn>addressLine</dfn> attribute
           </h2>
           <p data-link-for="">
@@ -2552,21 +2572,21 @@
         </section>
         <section>
           <h2>
-            <dfn>region</dfn> attribute
-          </h2>
-          <p data-link-for="">
-            Represents the <a>region</a> of the address. When getting, returns
-            the value of the {{PaymentAddress}}'s <a>[[\region]]</a> internal
-            slot.
-          </p>
-        </section>
-        <section>
-          <h2>
             <dfn>city</dfn> attribute
           </h2>
           <p data-link-for="">
             Represents the <a>city</a> of the address. When getting, returns
             the value of the {{PaymentAddress}}'s <a>[[\city]]</a> internal
+            slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>country</dfn> attribute
+          </h2>
+          <p data-link-for="">
+            Represents the <a>country</a> of the address. When getting, returns
+            the value of the {{PaymentAddress}}'s <a>[[\country]]</a> internal
             slot.
           </p>
         </section>
@@ -2582,32 +2602,32 @@
         </section>
         <section>
           <h2>
-            <dfn>postalCode</dfn> attribute
-          </h2>
-          <p>
-            Represents the <a>postal code</a> of the address. When getting,
-            returns the value of the {{PaymentAddress}}'s
-            <a>[[\postalCode]]</a> internal slot.
-          </p>
-        </section>
-        <section>
-          <h2>
-            <dfn>sortingCode</dfn> attribute
-          </h2>
-          <p>
-            Represents the <a>sorting code</a> of the address. When getting,
-            returns the value of the {{PaymentAddress}}'s
-            <a>[[\sortingCode]]</a> internal slot.
-          </p>
-        </section>
-        <section>
-          <h2>
             <dfn>organization</dfn> attribute
           </h2>
           <p data-link-for="">
             Represents the <a>organization</a> of the address. When getting,
             returns the value of the {{PaymentAddress}}'s
             <a>[[\organization]]</a> internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>phone</dfn> attribute
+          </h2>
+          <p>
+            Represents the <a>phone number</a> of the address. When getting,
+            returns the value of the {{PaymentAddress}}'s <a>[[\phone]]</a>
+            internal slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>postalCode</dfn> attribute
+          </h2>
+          <p>
+            Represents the <a>postal code</a> of the address. When getting,
+            returns the value of the {{PaymentAddress}}'s
+            <a>[[\postalCode]]</a> internal slot.
           </p>
         </section>
         <section>
@@ -2622,12 +2642,22 @@
         </section>
         <section>
           <h2>
-            <dfn>phone</dfn> attribute
+            <dfn>region</dfn> attribute
+          </h2>
+          <p data-link-for="">
+            Represents the <a>region</a> of the address. When getting, returns
+            the value of the {{PaymentAddress}}'s <a>[[\region]]</a> internal
+            slot.
+          </p>
+        </section>
+        <section>
+          <h2>
+            <dfn>sortingCode</dfn> attribute
           </h2>
           <p>
-            Represents the <a>phone number</a> of the address. When getting,
-            returns the value of the {{PaymentAddress}}'s <a>[[\phone]]</a>
-            internal slot.
+            Represents the <a>sorting code</a> of the address. When getting,
+            returns the value of the {{PaymentAddress}}'s
+            <a>[[\sortingCode]]</a> internal slot.
           </p>
         </section>
         <section data-link-for="">
@@ -2738,16 +2768,16 @@
         </h2>
         <pre class="idl">
           dictionary AddressInit {
-            DOMString country;
             sequence&lt;DOMString&gt; addressLine;
-            DOMString region;
             DOMString city;
+            DOMString country;
             DOMString dependentLocality;
-            DOMString postalCode;
-            DOMString sortingCode;
             DOMString organization;
-            DOMString recipient;
             DOMString phone;
+            DOMString postalCode;
+            DOMString recipient;
+            DOMString region;
+            DOMString sortingCode;
           };
         </pre>
         <p>
@@ -2953,7 +2983,8 @@
         <p>
           The steps to <dfn>create a `PaymentAddress` from user-provided
           input</dfn> are given by the following algorithm. The algorithm takes
-          a <a>list</a> |redactList|.
+          a <a>list</a> |redactList| and a
+          <a>sequence</a>&lt;<a>AddressParts</a>&gt; |requestedParts|.
         </p>
         <div class="note" title=
         "Privacy of recipient information (the redactList)">
@@ -2975,26 +3006,30 @@
           </p>
         </div>
         <ol data-link-for="AddressInit">
+          <li>If |requestedParts| is empty, set it to «
+          "addressLine", "city", "country", "dependentLocality", "organization",
+          "phone", "postalCode", "recipient", "region", "sortingCode"».
+          </li>
           <li>Let |details:AddressInit| be an <a>AddressInit</a> dictionary
           with no members present.
           </li>
-          <li>If "addressLine" is not in |redactList|, set
-          |details|["<a>addressLine</a>"] to the result of splitting the
-          user-provided address line into a <a>list</a>. If none was provided,
-          set it to the empty <a>list</a>.
+          <li>If "addressLine" is in |requestedParts| and is not in
+          |redactList|, set |details|["<a>addressLine</a>"] to the result of
+          splitting the user-provided address line into a <a>list</a>. If none
+          was provided, set it to the empty <a>list</a>.
             <aside class="note">
               How to split an address line is locale dependent and beyond the
               scope of this specification.
             </aside>
           </li>
-          <li>If "country" is not in |redactList|, set
-          |details|["<a>country</a>"] to the user-provided country as an upper
-          case [[ISO3166-1]] alpha-2 code, or to the empty string if none was
-          provided.
+          <li>If "country" is in |requestedParts| and is not in |redactList|,
+          set |details|["<a>country</a>"] to the user-provided country as an
+          upper case [[ISO3166-1]] alpha-2 code, or to the empty string if none
+          was provided.
           </li>
-          <li>If "phone" is not in |redactList|, set |details|["<a>phone</a>"]
-          to the user-provided phone number, or to the empty string if none was
-          provided.
+          <li>If "phone" is in |requestedParts| and is not in |redactList|, set
+          |details|["<a>phone</a>"] to the user-provided phone number, or to the
+          empty string if none was provided.
             <aside class="note" title="Privacy of phone number">
               <p>
                 To maintain users' privacy, implementers need to be mindful
@@ -3005,21 +3040,24 @@
               </p>
             </aside>
           </li>
-          <li>If "city" is not in |redactList|, set |details|["<a>city</a>"] to
-          the user-provided city, or to the empty string if none was provided.
+          <li>If "city" is in |requestedParts| and is not in |redactList|, set
+          |details|["<a>city</a>"] to the user-provided city, or to the empty
+          string if none was provided.
           </li>
-          <li>If "dependentLocality" is not in |redactList|, set
-          |details|["<a>dependentLocality</a>"] to the user-provided dependent
-          locality, or to the empty string if none was provided.
+          <li>If "dependentLocality" is in |requestedParts| and is not in
+          |redactList|, set |details|["<a>dependentLocality</a>"] to the
+          user-provided dependent locality, or to the empty string if none was
+          provided.
           </li>
-          <li>If "organization" is not in |redactList|, set
-          |details|["<a>organization</a>"] to the user-provided recipient
-          organization, or to the empty string if none was provided.
+          <li>If "organization" is in |requestedParts| and is not in
+          |redactList|, set |details|["<a>organization</a>"] to the
+          user-provided recipient organization, or to the empty string if none
+          was provided.
           </li>
-          <li>If "postalCode" is not in |redactList|, set
-          |details|["<a>postalCode</a>"] to the user-provided postal code, or
-          to the empty string if none was provided. Optionally, redact part of
-          |details|["<a>postalCode</a>"].
+          <li>If "postalCode" is in |requestedParts| and is not in |redactList|,
+          set |details|["<a>postalCode</a>"] to the user-provided postal code,
+          or to the empty string if none was provided. Optionally, redact part
+          of |details|["<a>postalCode</a>"].
             <div class="note" title="Privacy of Postal Codes">
               <p>
                 <a>Postal codes</a> in certain countries can be so specific as
@@ -3033,13 +3071,13 @@
               </p>
             </div>
           </li>
-          <li>If "recipient" is not in |redactList|, set
-          |details|["<a>recipient</a>"] to the user-provided recipient of the
-          transaction, or to the empty string if none was provided.
+          <li>If "recipient" is in |requsetedParts| and is not in |redactList|,
+          set |details|["<a>recipient</a>"] to the user-provided recipient of
+          the transaction, or to the empty string if none was provided.
           </li>
           <li>
             <p>
-              If "region" is not in |redactList|:
+              If "region" is in |requestedParts| and is not in |redactList|:
             </p>
             <p data-link-for="" class="note" title=
             "Countries where regions are not commonly used">
@@ -3060,9 +3098,9 @@
               </li>
             </ol>
           </li>
-          <li>If "sortingCode" is not in |redactList|, set
-          |details|["<a>sortingCode</a>"] to the user-provided sorting code, or
-          to the empty string if none was provided.
+          <li>If "sortingCode" is n |requestedParts| and is not in |redactList|,
+          set |details|["<a>sortingCode</a>"] to the user-provided sorting code,
+          or to the empty string if none was provided.
           </li>
           <li>
             <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a
@@ -4045,15 +4083,15 @@
           </h2>
           <aside class="note">
             <p>
-              Similar to shipping address, detailed billing address contains
-              sensitive user information. {{requestBillingAddress()}} provides
-              a similar mechanism as <a>PaymentRequestUpdateEvent.requestShippingAddress()</a>
-              for developers to incrementally query pieces as needed.
+              <a>PaymentMethodChangeEvent.requestBillingAddress()</a> allows the
+              developer to incrementally request additional pieces of the
+              billing address that were not initially requested in
+              {{ PaymentOptions.requestBillingAddressParts }}.
             </p>
             <pre class="example js" title="how to use `requestBillingAddress()` correct.">
               request.onpaymentmethodchange = ev =&gt; {
                 const promiseForUpdatingTax =
-                  ev.requestBillingAddress(["country"])
+                  ev.requestBillingAddress(["country", "postalCode"])
                       .then(methodDetails =&gt; {
                         const promiseForUpdate = getNewTotal(methodDetails);
                         return promiseForUpdate;
@@ -4062,6 +4100,48 @@
               };
             </pre>
           </aside>
+          <p>
+            The <a>requestBillingAddress(|addressParts|)</a> method MUST act as
+            follows:
+          </p>
+          <ol class="algorithm">
+            <li>Let |event:PaymentMethodChangeEvent| be this
+            {{PaymentMethodChangeEvent}} instance.
+            </li>
+            <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
+            return <a>a promise rejected with</a> an {{"InvalidStateError"}}
+            {{DOMException}}.
+            </li>
+            <li>Let |request:PaymentRequest| be the value of |event|'s
+            [=Event/target=].
+            </li>
+            <li>Assert: |request| is an instance of {{PaymentRequest}}.
+            </li>
+            <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
+            then return <a>a promise rejected with</a> an {{"InvalidStateError"}}
+            {{DOMException}}.
+            </li>
+            <li>Let |methodDetailsPromise:Promise| be <a>a new promise</a>.</li>
+            <li>Return |methodDetailsPromise|, and perform the remaining steps
+            <a>in parallel</a>.
+            </li>
+            <li>Let |handler| be the <a>payment handler</a> that triggered this
+            |event|.
+            </li>
+            <li>Use a <a>payment handler</a> specific API to send |addressParts|
+            to |handler| and receive a new <a>object</a> |methodDetails|.
+              <p class="note">
+              It is the responsibility of the payment handler to keep track of
+              successive address parts it is called with and return an
+              appropriate version of the billing address associated with the
+              selected payment instrument, potentially with some redact list
+              applied.
+              </p>
+            </li>
+            <li>Resolve |methodDetailsPromise| with |methodDetails|.
+            </li>
+
+          </ol>
         </section>
         <section data-dfn-for="PaymentMethodChangeEventInit" data-link-for=
         "PaymentMethodChangeEventInit">
@@ -4137,10 +4217,10 @@
           <aside class="note">
             <p>
               Detailed shipping address contains sensitive user information.
-              Developers are encouraged to use {{requestShippingAddress()}}
-              to incrementally request pieces they require instead of asking for
-              all up front using the {{PaymentOptions.requestShipping}}
-              boolean. For example, if flat-rate shipping is available in
+              Developers are encouraged to specify a restrictive initial list
+              using {{PaymentOptions.requestShippingAddressParts}} and use
+              {{requestShippingAddress()}} to incrementally request pieces as
+              needed. For example, if flat-rate shipping is available in
               country A but only variable per-region shipping is available in
               country B, a developer should request only "country" first and
               decide if "region" is needed.
@@ -4148,85 +4228,78 @@
             <p>
               A developer can call {{requestShippingAddress()}} repeatedly.
               Each call returns a promise that resolves to a {{PaymentAddress}}
-              with all previously requested address fields populated.
-            </p>
-            <p>
-              If a requested address part is also in the redact list of shipping
-              address, then the returned {{PaymentAddress}} will not have the
-              corresponding field populated.
+              with all previously requested address fields populated, subject to
+              any applicable redact list.
             </p>
             <pre class="example js" title=
             "how to use `requestShippingAddress()` correctly.">
+              // ✅ Good - Request additional address parts to recompute
+              // shipping cost. The final response.shippingAddress will also
+              // only contain "country" and "postalCode".
               request.onshippingaddresschange = ev =&gt; {
                 const promiseForUpdatingShippingCost =
-                    ev.requestShippingAddress(["country", "postal_code"])
+                    ev.requestShippingAddress(["country", "postalCode"])
                         .then(address =&gt; {
                           const promiseForUpdate = getNewDetails(address);
                           return promiseForUpdate;
                         });
                 ev.updateWith(promiseForUpdatingShippingCost);
               };
+
+              // ✅ Good - Request additional addresss parts to be included in
+              // the final response.shippingAddress.
+              request.onshippingaddresschange = ev =&gt; {
+                // Compute shipping cost based on initial coarse address.
+                ev.updateWith(computeShippingCost(ev.target.shippingAddress));
+
+                // Discard the returned promise because the full address is not
+                // needed until the final PaymentResponse. Empty addressParts
+                // means all parts are requested.
+                ev.requestShippingAddress(/* addressParts= */[]);
+              }
             </pre>
           </aside>
           <p>
-            The <a><code>requestShippingAddress(|addressParts|)</code></a> method MUST act as
+            The <a>requestShippingAddress(|addressParts|)</a> method MUST act as
             follows:
           </p>
           <ol class="algorithm">
             <li>Let |event:PaymentRequestUpdateEvent| be this
             {{PaymentRequestUpdateEvent}} instance.
             </li>
+            <li>If |event|'s {{ Event.type }} attribute is not <a>
+            shippingaddresschange</a>, then return <a>a promise rejected with
+            </a> a {{TypeError}}.
+            <li>Let |request:PaymentRequest| be the value of |event|'s
+            [=Event/target=].
+            </li>
+            <li>Assert: |request| is an instance of {{PaymentRequest}}.
+            </li>
             <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
             return <a>a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
-            </li>
-            <li>If |event|'s [=Event/target=] is an instance of
-            <a>PaymentResponse</a>, let |request:PaymentRequest| be |event|'s
-            [=Event/target=].<a>[[\request]]</a>.
-            </li>
-            <li>Otherwise, let |request:PaymentRequest| be the value of
-            |event|'s [=Event/target=].
-            </li>
-            <li>Assert: |request| is an instance of {{PaymentRequest}}.
             </li>
             <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
             then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>
-            <li>Let |shippingAddressPromise:Promise| be <a>a new promise</a>.</li>
-            <li>Return |shippingAddressPromise|, and perform the remaining steps <a>in
-            parallel</a>.
+            <li>Let |addressPromise:Promise| be <a>a new promise</a>.</li>
+            <li>Return |addressPromise|, and perform the remaining steps
+            <a>in parallel</a>.
             </li>
-            <li>Let |shippingAddress:PaymentAddress| be |request|'s
-            [=PaymentRequest/shippingAddress=].
-              <aside class="note">
-                This address should have already been redacted according to the
-                <a>shipping address changed algorithm</a>.
-              </aside>
+            <li>Update |request|.<a>[[\requestedShippingAddressParts]]</a> to be
+            the union of itself and |addressParts|.
             </li>
-            <li>Let |details:AddressInit| be an {{AddressInit}} dictionary with
-            no members present.
+            <li>Let |redactList:list| be the result of <a>get redact list for
+            shipping address changed algorithm</a>.
             </li>
-            <li>For each attribute |attributeName| in |shippingAddress:PaymentAddress|:
-              <ol>
-                <li>Set |details|[|attributeName|] to the value of
-                  |shippingAddress|.[[|attributeName|]] if it is not empty.
-                </li>
-              </ol>
+            <li>Let |address:PaymentAddress| be the result of <a>create
+            a `PaymentAddress` from user-provided input</a> with |redactList|
+            and |request|.<a>[[\requestedShippingAddressParts]]</a>.
             </li>
-            <li>Let |redactList| be the empty list. Set |redactList| to
-            « "organization", "phone", "recipient", "addressLine" ».
+            <li>Set |request|.[=PaymentRequest/shippingAddress=] to |address|.
             </li>
-            <li>For each |addressPart| in |addressParts|:
-              <ol>
-                <li>If |details|[|addresPart|] is already present, continue.</li>
-                <li>If |addressPart| is in |redactList|, continue. </li>
-                <li>Set |details|[|addressPart|] to the user provided value.</li>
-              </ol>
-            </li>
-            <li><a data-lt="PaymentAddress.PaymentAddress()">Internally construct
-            a new <a>PaymentAddress</a> with |details| and resolve
-            |shippingAddressPromise| with the result.
+            <li>Resolve |addressPromise| with |address|.
             </li>
           </ol>
           </p>
@@ -4538,6 +4611,41 @@
       </section>
       <section>
         <h2>
+          <dfn>Get redact list for shipping address changed algorithm</dfn>
+        </h2>
+        <p>This algorithm returns a redact list that should be used on a
+        shipping address returned to the payee during the
+        <a>shippingaddresschange</a> event.
+        </p>
+        <div class="note" title="Privacy of recipient information">
+          <p>
+            The |redactList| limits the amount of personal information
+            about the recipient that the API shares with the merchant before
+            the payment request is completed.
+          </p>
+          <p>
+            For merchants, the resulting {{PaymentAddress}} object
+            provides enough information to, for example, calculate
+            shipping costs, but, in most cases, not enough information
+            to physically locate and uniquely identify the recipient.
+          </p>
+          <p>
+            Unfortunately, even with the |redactList|, recipient
+            anonymity cannot be assured. This is because in some
+            countries postal codes are so fine-grained that they can
+            uniquely identify a recipient.
+          </p>
+        </div>
+        <ol class="algorithm">
+          <li>Let |redactList:list| be the empty list. Set |redactList| to
+          « "organization", "phone", "recipient", "addressLine" ».
+          </li>
+          <li>Return |redactList|.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
           Shipping address changed algorithm
         </h2>
         <p data-tests=
@@ -4553,32 +4661,13 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li>
-                <div class="note" title="Privacy of recipient information">
-                  <p>
-                    The |redactList| limits the amount of personal information
-                    about the recipient that the API shares with the merchant.
-                  </p>
-                  <p>
-                    For merchants, the resulting {{PaymentAddress}} object
-                    provides enough information to, for example, calculate
-                    shipping costs, but, in most cases, not enough information
-                    to physically locate and uniquely identify the recipient.
-                  </p>
-                  <p>
-                    Unfortunately, even with the |redactList|, recipient
-                    anonymity cannot be assured. This is because in some
-                    countries postal codes are so fine-grained that they can
-                    uniquely identify a recipient.
-                  </p>
-                </div>
-              </li>
-              <li>Let |redactList:list| be the empty list. Set |redactList| to
-              « "organization", "phone", "recipient", "addressLine" ».
+              <li>Let |redactList:list| be the result of <a>get redact list for
+              shipping address changed algorithm</a>.
               </li>
               <li>Let |address:PaymentAddress| be the result of running the
               steps to <a>create a `PaymentAddress` from user-provided
-              input</a> with |redactList|.
+              input</a> with |redactList| and
+              |request|.<a>[[\requestedShippingAddressParts]]</a>.
               </li>
               <li>Set the <a data-lt=
               "PaymentRequest.shippingAddress">shippingAddress</a> attribute on
@@ -4847,7 +4936,8 @@
               </li>
               <li>Let |shippingAddress:PaymentAddress| be the result of
               <a>create a `PaymentAddress` from user-provided input</a> with
-              |redactList|.
+              |redactList| and
+              |request|.<a>[[\requestedShippingAddressParts]]</a>.
               </li>
               <li>Set the {{shippingAddress}} attribute value of |response| to
               |shippingAddress|.

--- a/index.html
+++ b/index.html
@@ -4037,7 +4037,7 @@
           [SecureContext, Exposed=Window]
           interface PaymentRequestUpdateEvent : Event {
             constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict = {});
-            Promise&lt;PaymentAddress&gt; requestShippingAddress(sequence<AddressParts> addressParts);
+            Promise&lt;PaymentAddress&gt; requestShippingAddress(sequence&lt;AddressParts&gt; addressParts);
             void updateWith(Promise&lt;PaymentDetailsUpdate&gt; detailsPromise);
           };
         </pre>
@@ -4073,13 +4073,23 @@
           </h2>
           <aside class="note">
             <p>
-              If a developer wants to incrementally request more granular details
-              of the user's shipping address, for example, to re-calculate
-              shipping cost, then they can call <a>requestShippingAddress()</a>
-              and provide a sequence of <a>AddressParts</a>, which will return a
-              promise that resolves to an <a>PaymentAddress</a> with the
-              requested address fields populated. This method can be called
-              repeatedly to incrementally request more parts as needed.
+              Detailed shipping address contains sensitive user information.
+              Developers are encouraged to use <a>requestShippingAddress()</a>
+              to incrementally request pieces they require instead of asking for
+              all up front using the <a>PaymentOptions.requestShipping</a>
+              boolean. For example, if flat-rate shipping is available in
+              country A but only variable per-region shipping is available in
+              country B, a developer should request only "country" first and
+              decide if "region" is needed.
+            </p>
+            <p>
+              A future version of this specification may remove the all-in-one
+              <a>PaymentOptions.requestShipping</a> boolean.
+            </p>
+            <p>
+              A developer can call <a>requestShippingAddress()</a> repeatedly.
+              Each call returns a promise that resolves to a <a>PaymentAddress
+              </a> with all previously requested address fields populated.
             </p>
             <p>
               If a requested address part is also in the redact list of shipping
@@ -4093,12 +4103,70 @@
                     ev.requestShippingAddress(["country", "postal_code"])
                         .then(address =&gt; {
                           const promiseForUpdate = getNewDetails(address);
-                          return promiseForNewDetails;
+                          return promiseForUpdate;
                         });
                 ev.updateWith(promiseForUpdatingShippingCost);
               };
             </pre>
           </aside>
+          <p>
+            The <a><code>requestShippingAddress(|addressParts|)</code></a> method MUST act as
+            follows:
+          </p>
+          <ol class="algorithm">
+            <li>Let |event:PaymentRequestUpdateEvent| be this
+            {{PaymentRequestUpdateEvent}} instance.
+            </li>
+            <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
+            [=exception/throw=] an {{"InvalidStateError"}} {{DOMException}}.
+            </li>
+            <li>If |event|'s [=Event/target=] is an instance of
+            <a>PaymentResponse</a>, let |request:PaymentRequest| be |event|'s
+            [=Event/target=].<a>[[\request]]</a>.
+            </li>
+            <li>Otherwise, let |request:PaymentRequest| be the value of
+            |event|'s [=Event/target=].
+            </li>
+            <li>Assert: |request| is an instance of {{PaymentRequest}}.
+            </li>
+            <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
+            then [=exception/throw=] an {{"InvalidStateError"}}
+            {{DOMException}}.
+            </li>
+            <li>Let |shippingAddress| be the value of |request|'s
+              <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
+              attribute.
+              <aside class="note">
+                This address should have already been redacted according to the
+                <a>shipping address changed algorithm</a>.
+              </aside>
+            </li>
+            <li>Let |details| be an <a>AddressInit</a> dictionary with no
+              members present.
+            </li>
+            <li>For each attribute |attributeName| in |shippingAddress|
+              <ol>
+                <li>Set |details|[|attributeName|] to the value of
+                  |shippingAddress|.[[|attributeName|]] if it is not empty.
+                </li>
+              </ol>
+            </li>
+            <li>Let |redactList| be the empty list. Set |redactList| to
+              « "organization", "phone", "recipient", "addressLine" ».
+            </li>
+            <li>For each |addressPart| in |addressParts|:
+              <ol>
+                <li>If |details|[|addresPart|] is already present, continue. </li>
+                <li>If |addressPart| is not in |redactList|, set |details|[|addressPart|]
+                to the user provided value for this addres part.
+                </li>
+              </ol>
+            </li>
+            <li><a data-lt="PaymentAddress.PaymentAddress()">Internally construct
+            a new <a>PaymentAddress</a> with |details| and return the result.
+            </li>
+          </ol>
+          </p>
         </section>
         <section>
           <h2>

--- a/index.html
+++ b/index.html
@@ -4266,7 +4266,7 @@
             <li>Let |event:PaymentRequestUpdateEvent| be this
             {{PaymentRequestUpdateEvent}} instance.
             </li>
-            <li>If |event|'s {{ Event.type }} attribute is not <a>
+            <li>If |event|'s {{ Event/type }} attribute is not <a>
             shippingaddresschange</a>, then return <a>a promise rejected with
             </a> a {{TypeError}}.
             <li>Let |request:PaymentRequest| be the value of |event|'s

--- a/index.html
+++ b/index.html
@@ -2069,7 +2069,7 @@
         The {{AddressParts}} enum is used to represent individual parts of a
         <a>physical address</a>.
       </p>
-      <dl data-dfn-for="AddressFields">
+      <dl>
         <dt>
           "<dfn>addressLine</dfn>"
         </dt>

--- a/index.html
+++ b/index.html
@@ -4274,7 +4274,7 @@
             </li>
             <li>Assert: |request| is an instance of {{PaymentRequest}}.
             </li>
-            <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
+            <li>If |event|'s {{ Event/isTrusted }} attribute is false, then
             return <a>a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>

--- a/index.html
+++ b/index.html
@@ -4058,6 +4058,27 @@
           };
         </pre>
         <section>
+          <h3>
+             <dfn data-lt="PaymentMethodChangeEvent.PaymentMethodChangeEvent()">
+               Constructor
+             </dfn>
+          </h3>
+          <p>
+            The <a data-lt=
+            "PaymentMethodChangeEvent"><code>PaymentMethodChangeEvent(|type|,
+            |eventInitDict|)</code></a> constructor MUST act as follows:
+          </p>
+          <ol class="algorithm">
+            <li>Let |event:PaymentMethodChangeEvent| be the result of calling
+            the [=Event/constructor=] of {{PaymentMethodChangeEvent}} with
+            |type| and |eventInitDict|.
+            </li>
+            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to false.
+            <li>Return |event|.
+            </li>
+          </ol>
+        </section>
+        <section>
           <h2>
             <dfn>methodDetails</dfn> attribute
           </h2>
@@ -4267,7 +4288,8 @@
         <section>
           <h3>
             <dfn data-lt=
-            "PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()">Constructor</dfn>
+            "PaymentRequestUpdateEvent.PaymentRequestUpdateEvent()">Constructor
+            </dfn>
           </h3>
           <p data-tests=
           "PaymentRequestUpdateEvent/constructor.https.html, PaymentRequestUpdateEvent/constructor.http.html">
@@ -4282,6 +4304,7 @@
             </li>
             <li>Set |event|.<a>[[\waitForUpdate]]</a> to false.
             </li>
+            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to false.
             <li>Return |event|.
             </li>
           </ol>
@@ -4458,6 +4481,14 @@
           </ol>
         </section>
         <section>
+          <h3>
+            <dfn>PaymentRequestUpdateEventInit</dfn> dictionary
+          </h3>
+          <pre class="idl">
+            dictionary PaymentRequestUpdateEventInit : EventInit {};
+          </pre>
+        </section>
+        <section>
           <h2>
             Internal Slots
           </h2>
@@ -4493,14 +4524,6 @@
               </td>
             </tr>
           </table>
-        </section>
-        <section>
-          <h3>
-            <dfn>PaymentRequestUpdateEventInit</dfn> dictionary
-          </h3>
-          <pre class="idl">
-            dictionary PaymentRequestUpdateEventInit : EventInit {};
-          </pre>
         </section>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1141,7 +1141,7 @@
               Pass the <a data-lt="converted to an IDL value">converted</a>
               second element in the |paymentMethod| tuple, |modifiers|,
               |request|.<a>[[\options]]</a>.{{PaymentOptions/requestBillingAddress}} and
-              |request|.<a>[[\options]]</a>.<a data-lt="PaymentOptions.requestBillingAddressParts">requestBillingAddressParts</a>.
+              |request|.<a>[[\options]]</a>.{{PaymentOptions/requestBillingAddressParts}}.
               Optionally, the user agent SHOULD send the appropriate data from
               |request| to the user-selected <a>payment handler</a> in order to
               guide the user through the payment process. This includes the

--- a/index.html
+++ b/index.html
@@ -2211,7 +2211,7 @@
           A sequence of {{AddressParts}} that specifies which fine-grained
           parts of the billing address that the payee wishes to receive when the
           <a>requestBillingAddress</a> member is true. An empty list means no
-          restriction, i.e. the payee requests the full billing address. This
+          restriction, i.e. the payee requests the full billing address. The <a>requestBillingAddressParts</a>
           field has no effect if the <a>requestBillingAddress</a> member is
           false.
           <aside class="note">

--- a/index.html
+++ b/index.html
@@ -2286,7 +2286,7 @@
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
           address, subject to the
-          <a>shipping redact list</a>. This field has no effect if the
+          <a>shipping redact list</a>. The {{PaymentOptions/requestShippingAddressParts}} member has no effect if the
           {{PaymentOptions/requestShipping}} member is false. The payee can request
           additional pieces incrementally using {{PaymentRequestUpdateEvent}}'s
           {{PaymentRequestUpdateEvent/requestShippingAddress()}}.

--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,6 @@
               The current <a>sequence</a>&lt;{{AddressParts}}&gt; specifying
               the payee-requested shipping address parts, initially supplied to
               the constructor via {{PaymentOptions}}'s
-              <a data-lt="PaymentOptions.requestShippingAddressParts">
               requestShippingAddressParts</a> and then updated with calls to
               <a data-lt="PaymentRequestUpdateEvent.requestShippingAddress">
               requestShippingAddress()</a>.

--- a/index.html
+++ b/index.html
@@ -2198,7 +2198,7 @@
           and return the billing address associated with a <a>payment
           method</a> (e.g., the billing address associated with a credit card).
           The <a>user agent</a> returns the billing address as part of the
-          {{PaymentMethodChangeEvent}}'s <a>methodDetails</a> attribute and the
+          {{PaymentMethodChangeEvent}}'s {{PaymentMethodChangeEvent/methodDetails}} attribute and the
           {{PaymentResponse}}'s <a>details</a> attribute. A payee can use this
           information to, for example, calculate tax in certain jurisdictions
           and update the displayed total. See below for privacy considerations

--- a/index.html
+++ b/index.html
@@ -2031,6 +2031,91 @@
         </dd>
       </dl>
     </section>
+    <section data-dfn-for="AddressParts">
+      <h2>
+        <dfn>AddressParts</dfn> enum
+      </h2>
+      <pre class="idl">
+        enum AddressParts {
+          "addressLine",
+          "city",
+          "country",
+          "dependentLocality",
+          "organization",
+          "phone",
+          "postalCode",
+          "recipient",
+          "region",
+          "sortingCode"
+        };
+      </pre>
+      <p>
+        The {{AddressParts}} enum is used to represent individual parts of a
+        <a>physical address</a>.
+      </p>
+      <dl data-dfn-for="AddressFields">
+        <dt>
+          "<dfn>addressLine</dfn>"
+        </dt>
+        <dd>
+          The <a>address line</a>.
+        </dd>
+        <dt>
+          "<dfn>city</dfn>"
+        </dt>
+        <dd>
+          The <a>city</a>.
+        </dd>
+        <dt>
+          "<dfn>country</dfn>"
+        </dt>
+        <dd>
+          The <a>country</a>.
+        </dd>
+        <dt>
+          "<dfn>dependentLocality</dfn>"
+        </dt>
+        <dd>
+          The <a>dependent locality</a>.
+        </dd>
+        <dt>
+          "<dfn>organization</dfn>"
+        </dt>
+        <dd>
+          The <a>organization</a>.
+        </dd>
+        <dt>
+          "<dfn>phone</dfn>"
+        </dt>
+        <dd>
+          The <a>phone number</a>.
+        </dd>
+        <dt>
+          "<dfn>postalCode</dfn>"
+        </dt>
+        <dd>
+          <a>postal code</a>.
+        </dd>
+        <dt>
+          "<dfn>recipient</dfn>"
+        </dt>
+        <dd>
+          The <a>recipient</a>.
+        </dd>
+        <dt>
+          "<dfn>region</dfn>"
+        </dt>
+        <dd>
+          The <a>region</a>.
+        </dd>
+        <dt>
+          "<dfn>sortingCode</dfn>"
+        </dt>
+        <dd>
+          The <a>sorting Code</a>.
+        </dd>
+      </dl>
+    </section>
     <section data-dfn-for="PaymentShippingType">
       <h2>
         <dfn>PaymentShippingType</dfn> enum
@@ -3952,6 +4037,7 @@
           [SecureContext, Exposed=Window]
           interface PaymentRequestUpdateEvent : Event {
             constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict = {});
+            Promise&lt;PaymentAddress&gt; requestShippingAddress(AddressParts addressParts);
             void updateWith(Promise&lt;PaymentDetailsUpdate&gt; detailsPromise);
           };
         </pre>
@@ -3980,6 +4066,39 @@
             <li>Return |event|.
             </li>
           </ol>
+        </section>
+        <section>
+          <h2>
+            <dfn data-lt="requestShippingAddress(addressParts)">requestShippingAddress()</dfn> method
+          </h2>
+          <aside class="note">
+            <p>
+              If a developer wants to incrementally request more granular details
+              of the user's shipping address, for example, to re-calculate
+              shipping cost, then they can call <a>requestShippingAddress()</a>
+              and provide a list of <a>AddressParts</a>, which will return a
+              promise that resolves to an <a>PaymentAddress</a> with the
+              requested address fields populated. This method can be called
+              repeatedly to incrementally request more parts as needed.
+            </p>
+            <p>
+              If a requested address part is also in the redact list of shipping
+              address, then the returned <a>PaymentAddress</a> will not have the
+              corresponding field populated.
+            </p>
+            <pre class="example js" title=
+            "how to use `requestShippingAddress()` correctly.">
+              request.onshippingaddresschange = ev =&gt; {
+                const promiseForUpdatingShippingCost =
+                    ev.requestShippingAddress(["country", "postal_code"])
+                        .then(address =&gt; {
+                          const promiseForUpdate = getNewDetails(address);
+                          return promiseForNewDetails;
+                        });
+                ev.updateWith(promiseForUpdatingShippingCost);
+              };
+            </pre>
+          </aside>
         </section>
         <section>
           <h2>

--- a/index.html
+++ b/index.html
@@ -2160,9 +2160,11 @@
         dictionary PaymentOptions {
           boolean requestPayerName = false;
           boolean requestBillingAddress = false;
+          sequence&lt;AddressParts&gt; requestBillingAddressParts = [];
           boolean requestPayerEmail = false;
           boolean requestPayerPhone = false;
           boolean requestShipping = false;
+          sequence&lt;AddressParts&gt; requestShippingAddressParts = [];
           PaymentShippingType shippingType = "shipping";
         };
       </pre>
@@ -2185,6 +2187,22 @@
           jurisdictions and update the displayed total. See below for privacy
           considerations regarding <a href="#user-info">exposing user
           information</a>.
+        </dd>
+        <dt>
+          <dfn>requestBillingAddressParts</dfn> member
+        </dt>
+        <dd>
+          A sequence of <a>AddressParts</a> that indicates fine-grained parts of
+          the billing address that the <a>user agent</a> SHOULD collect from
+          the user-selected payment handler. Additional pieces can be requested
+          incrementally using <a>PaymentMethodChangeEvent.requestBillingAddress
+          </a>.
+          <aside class="note">
+            The billing address is part of the payment-method specific response.
+            The <a>user agent</a> will pass on the merchant requested pieces to
+            the payment handler, but ultimately it is the responsibility of the
+            payment handler to ensure only the requested pieces are returned.
+          </aside>
         </dd>
         <dt>
           <dfn>requestPayerName</dfn> member
@@ -2227,14 +2245,21 @@
               A developer may not need the full shipping address of a user, for
               example, just having "country" may be sufficient to calculate
               shipping cost. To be sensitive to user's privacy, developers should
-              prefer to use <a>PaymentRequestUpdateEvent.requestShippingAddress()
+              prefer to use <a>requestShippingAddressParts</a> to specify an
+              initial restrictive set of address parts and then use
+              <a>PaymentRequestUpdateEvent.requestShippingAddress()
               </a> to incrementally request only the address parts they need.
             </p>
-            <p>
-              A future version of this specification may remove the all-in-one
-              {{PaymentOptions.requestShipping}} boolean.
-            </p>
           </aside>
+        </dd>
+        <dt>
+          <dfn>requestShippingAddressParts</dfn> member
+        </dt>
+        <dd>
+          A sequence of <a>AddressParts</a> that indicates fine-grained parts of
+          the shipping address that the <a>user agent</a> SHOULD collect and
+          return. Additional pieces can be requested incrementally as needed
+          using <a>PaymentRequestUpdateEvent.requestShippingAddress()</a>.
         </dd>
         <dt>
           <dfn>shippingType</dfn> member
@@ -3991,6 +4016,7 @@
             constructor(DOMString type, optional PaymentMethodChangeEventInit eventInitDict = {});
             readonly attribute DOMString methodName;
             readonly attribute object? methodDetails;
+            Promise&lt;object&gt; requestBillingAddress(sequence&lt;AddressParts&gt; addressParts);
           };
         </pre>
         <section>
@@ -4012,6 +4038,30 @@
             <a>methodName</a> member of <a>PaymentMethodChangeEventInit</a> for
             more information.
           </p>
+        </section>
+        <section>
+          <h2>
+            <dfn data-lt="requestBillingAddress(addressParts)">requestBillingAddress()</dfn> method
+          </h2>
+          <aside class="note">
+            <p>
+              Similar to shipping address, detailed billing address contains
+              sensitive user information. {{requestBillingAddress()}} provides
+              a similar mechanism as <a>PaymentRequestUpdateEvent.requestShippingAddress()</a>
+              for developers to incrementally query pieces as needed.
+            </p>
+            <pre class="example js" title="how to use `requestBillingAddress()` correct.">
+              request.onpaymentmethodchange = ev =&gt; {
+                const promiseForUpdatingTax =
+                  ev.requestBillingAddress(["country"])
+                      .then(methodDetails =&gt; {
+                        const promiseForUpdate = getNewTotal(methodDetails);
+                        return promiseForUpdate;
+                      });
+                  ev.updateWith(promiseForUpdatingTax);
+              };
+            </pre>
+          </aside>
         </section>
         <section data-dfn-for="PaymentMethodChangeEventInit" data-link-for=
         "PaymentMethodChangeEventInit">
@@ -4094,10 +4144,6 @@
               country A but only variable per-region shipping is available in
               country B, a developer should request only "country" first and
               decide if "region" is needed.
-            </p>
-            <p>
-              A future version of this specification may remove the all-in-one
-              {{PaymentOptions.requestShipping}} boolean.
             </p>
             <p>
               A developer can call {{requestShippingAddress()}} repeatedly.

--- a/index.html
+++ b/index.html
@@ -2210,7 +2210,7 @@
         <dd>
           A sequence of {{AddressParts}} that specifies which fine-grained
           parts of the billing address that the payee wishes to receive when the
-          <a>requestBillingAddress</a> boolean is true. An empty list means no
+          <a>requestBillingAddress</a> member is true. An empty list means no
           restriction, i.e. the payee requests the full billing address. This
           field has no effect if the <a>requestBillingAddress</a> boolean is
           false.

--- a/index.html
+++ b/index.html
@@ -2220,9 +2220,10 @@
             <a>requestBillingAddressParts</a> to the payment handler. It is the
             responsibility of the payment handler to ensure no more than the
             requested pieces is returned. A payment handler may choose to not
-            return some requested pieces (e.g., as a result of applying a redact
-            list). The payee can request additional pieces incrementally using
-            {{PaymentMethodChangeEvent}}'s {{PaymentMethodChangeEvent/requestBillingAddres()}}.
+            return some requested pieces (e.g., as a result of applying a <a>
+            redact list</a>). The payee can request additional pieces
+            incrementally using {{PaymentMethodChangeEvent}}'s
+            {{PaymentMethodChangeEvent/requestBillingAddress()}}.
           </aside>
         </dd>
         <dt>
@@ -2263,8 +2264,9 @@
           {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}}
           attribute and the {{PaymentResponse}}'s
           {{PaymentResponse/shippingAddress}}
-          attribute. The former is subject to a redact list per the <a>shipping
-          address changed algorithm</a>.
+          attribute. The former is subject to a
+          <a data-lt="shipping-redact-list">redact list</a> per the
+          <a>shipping address changed algorithm</a>.
           <aside class="note">
             <p>
               A payee may not need the full shipping address of a user until the
@@ -2284,10 +2286,12 @@
           parts of the shipping address that the payee wishes to receive when
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
-          address, subject to any applicable redact list. This field has no
-          effect if the <a>requestShipping</a> member is false. The payee can
+          address, subject to any applicable
+          <a data-lt="shipping-redact-list">redact list</a>. This field has
+          no effect if the <a>requestShipping</a> member is false. The payee can
           request additional pieces incrementally using
-          {{PaymentRequestUpdateEvent}}'s {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
+          {{PaymentRequestUpdateEvent}}'s
+          {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
         </dd>
         <dt>
           <dfn>shippingType</dfn> member
@@ -4077,7 +4081,9 @@
         </section>
         <section>
           <h2>
-            <dfn data-lt="requestBillingAddress(addressParts)">requestBillingAddress()</dfn> method
+            <dfn data-lt="requestBillingAddress(addressParts)">
+              requestBillingAddress()
+            </dfn> method
           </h2>
           <aside class="note">
             <p>
@@ -4086,7 +4092,7 @@
               billing address that were not initially requested in
               {{ PaymentOptions.requestBillingAddressParts }}.
             </p>
-            <pre class="example js" title="how to use `requestBillingAddress()`.">
+            <pre class="example js" title="how to use `requestBillingAddress()` correctly.">
               request.onpaymentmethodchange = ev =&gt; {
                 const promiseForUpdatingTax =
                   ev.requestBillingAddress(["country", "postalCode"])
@@ -4128,13 +4134,13 @@
             </li>
             <li>Use a <a>payment handler</a> specific API to send |addressParts|
             to |handler| and receive a new <a>object</a> |methodDetails|.
-              <p class="note">
+            <p class="note">
               It is the responsibility of the payment handler to keep track of
               successive address parts it is called with and return an
               appropriate version of the billing address associated with the
-              selected payment instrument, potentially with some redact list
-              applied.
-              </p>
+              selected payment instrument, potentially with some
+              <a>redact list</a> applied.
+            </p>
             </li>
             <li>Resolve |methodDetailsPromise| with |methodDetails|.
             </li>
@@ -4210,7 +4216,9 @@
         </section>
         <section>
           <h2>
-            <dfn data-lt="requestShippingAddress(addressParts)">requestShippingAddress()</dfn> method
+            <dfn data-lt="requestShippingAddress(addressParts)">
+              requestShippingAddress()
+            </dfn> method
           </h2>
           <aside class="note">
             <p>
@@ -4227,7 +4235,7 @@
               A developer can call {{requestShippingAddress()}} repeatedly.
               Each call returns a promise that resolves to a {{PaymentAddress}}
               with all previously requested address fields populated, subject to
-              any applicable redact list.
+              any applicable <a data-lt="shipping-redact-list">redact list</a>.
             </p>
             <pre class="example js" title=
             "how to use `requestShippingAddress()` correctly.">
@@ -4609,7 +4617,9 @@
       </section>
       <section>
         <h2>
-          <dfn>Get redact list for shipping address changed algorithm</dfn>
+          <dfn data-lt="shipping-redact-list">
+            Get redact list for shipping address changed algorithm
+          </dfn>
         </h2>
         <p>This algorithm returns a redact list that should be used on a
         shipping address returned to the payee during the
@@ -5598,11 +5608,11 @@
           <a>payment method</a> and might include:
         </p>
         <ul>
-          <li>Use of a "|redactList|" for <a>physical addresses</a>. The
-          current specification makes use of a "|redactList|" to redact the <a>
-            address line</a>, <a>organization</a>, <a>phone number</a>, and
-            <a>recipient</a> from a <a data-link-for=
-            "PaymentRequest">shippingAddress</a>.
+          <li>Use of a "<dfn data-lt="redact list">redactList</dfn>" for
+          <a>physical addresses</a>. The current specification makes use of a
+          "|redactList|" to redact the <a>address line</a>, <a>organization</a>,
+          <a>phone number</a>, and <a>recipient</a> from a <a data-link-for=
+          "PaymentRequest">shippingAddress</a>.
           </li>
           <li>Support for instructions from the payee identifying specific
           elements to exclude or include from the <a>payment method</a>

--- a/index.html
+++ b/index.html
@@ -2286,7 +2286,7 @@
           parts of the shipping address that the payee wishes to receive when
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
-          address, subject to any applicable
+          address, subject to the
           <a data-lt="shipping-redact-list">redact list</a>. This field has
           no effect if the <a>requestShipping</a> member is false. The payee can
           request additional pieces incrementally using

--- a/index.html
+++ b/index.html
@@ -2260,7 +2260,7 @@
           and return a shipping address as part of the payment request (e.g.,
           when physical goods need to be shipped by the payee to the user). The
           <a>user agent</a> returns the shipping address in the
-          {{PaymentRequest}}'s <a data-lt="PaymentRequest.shippingAddress">
+          {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}}
           shippingAddress</a> attribute and the {{PaymentResponse}}'s
           <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
           attribute. The former is subject to a redact list per the <a>shipping

--- a/index.html
+++ b/index.html
@@ -1140,7 +1140,7 @@
             <p>
               Pass the <a data-lt="converted to an IDL value">converted</a>
               second element in the |paymentMethod| tuple, |modifiers|,
-              |request|.<a>[[\options]]</a>.<a data-lt="PaymentOptions.requestBillingAddress">requestBillingAddress</a> and
+              |request|.<a>[[\options]]</a>.{{PaymentOptions/requestBillingAddress}} and
               |request|.<a>[[\options]]</a>.<a data-lt="PaymentOptions.requestBillingAddressParts">requestBillingAddressParts</a>.
               Optionally, the user agent SHOULD send the appropriate data from
               |request| to the user-selected <a>payment handler</a> in order to

--- a/index.html
+++ b/index.html
@@ -4107,7 +4107,7 @@
             <li>Let |event:PaymentMethodChangeEvent| be this
             {{PaymentMethodChangeEvent}} instance.
             </li>
-            <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
+            <li>If |event|'s {{ Event/isTrusted }} attribute is false, then
             return <a>a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>

--- a/index.html
+++ b/index.html
@@ -4094,13 +4094,13 @@
             </p>
             <pre class="example js" title="how to use `requestBillingAddress()` correctly.">
               request.onpaymentmethodchange = ev =&gt; {
-                const promiseForUpdatingTax =
+                // ✅ Good: request finer-grained address parts inside updateWith()
+                ev.updateWith(new Promise((resolver) =&gt; {
                   ev.requestBillingAddress(["country", "postalCode"])
-                      .then(methodDetails =&gt; {
-                        const promiseForUpdate = getNewTotal(methodDetails);
-                        return promiseForUpdate;
-                      });
-                  ev.updateWith(promiseForUpdatingTax);
+                    .then(methodDetails =&gt; {
+                      resolver(getNewTotal(methodDetails));
+                    });
+                }));
               };
             </pre>
           </aside>
@@ -4123,6 +4123,10 @@
             </li>
             <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
             then return <a>a promise rejected with</a> an {{"InvalidStateError"}}
+            {{DOMException}}.
+            </li>
+            <li>If |event|.<a>[[\waitForUpdate]]</a> is false,
+            then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>
             <li>Let |methodDetailsPromise:Promise| be <a>a new promise</a>.</li>
@@ -4242,27 +4246,45 @@
               // ✅ Good - Request additional address parts to recompute
               // shipping cost. The final response.shippingAddress will also
               // only contain "country" and "postalCode".
-              request.onshippingaddresschange = ev =&gt; {
-                const promiseForUpdatingShippingCost =
-                    ev.requestShippingAddress(["country", "postalCode"])
-                        .then(address =&gt; {
-                          const promiseForUpdate = getNewDetails(address);
-                          return promiseForUpdate;
-                        });
-                ev.updateWith(promiseForUpdatingShippingCost);
+              request.onshippingaddresschange = (ev) =&gt; {
+                ev.updateWith(new Promise((resolver) =&gt; {
+                  ev.requestShippingAddress(["country", "postalCode"])
+                      .then(address =&gt; {
+                        resolver(getNewDetails(address));
+                      });
+                  }));
               };
 
               // ✅ Good - Request additional addresss parts to be included in
               // the final response.shippingAddress.
-              request.onshippingaddresschange = ev =&gt; {
+              request.onshippingaddresschange = (ev) =&gt; {
                 // Compute shipping cost based on initial coarse address.
-                ev.updateWith(computeShippingCost(ev.target.shippingAddress));
+                ev.updateWith(new Promise((resolver) =&gt; {
+                  // Discard the returned promise because the full address is not
+                  // needed until the final PaymentResponse. Empty addressParts
+                  // means all parts are requested.
+                  ev.requestShippingAddress(/* addressParts= */[]);
 
-                // Discard the returned promise because the full address is not
-                // needed until the final PaymentResponse. Empty addressParts
-                // means all parts are requested.
-                ev.requestShippingAddress(/* addressParts= */[]);
+                  // Compute shipping cost using initial partial address.
+                  resolver(computeShippingCost(ev.target.shippingAddress)));
+                });
               }
+
+              // ❌ Bad - this won't work!
+              request.onshippingaddresschange = (ev) =&gt; {
+                ev.updateWith(getPromiseForNewDetails(ev.target.shippingAddress));
+
+                // This will throw InvalidStateError since not inside updateWith().
+                ev.requestShippingAddress([]);
+              };
+
+              // ❌ Bad - this won't work!
+              request.onshippingaddresschange = (ev) =&gt; {
+                // This will throw InvalidStateError since not inside updateWith().
+                ev.requestShippingAddress([]);
+
+                ev.updateWith(getPromiseForNewDetails(ev.target.shippingAddress));
+              };
             </pre>
           </aside>
           <p>
@@ -4286,6 +4308,10 @@
             {{DOMException}}.
             </li>
             <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
+            then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
+            {{DOMException}}.
+            </li>
+            <li>If |event|.<a>[[\waitForUpdate]]</a> is false,
             then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>

--- a/index.html
+++ b/index.html
@@ -2263,10 +2263,9 @@
           <a>user agent</a> returns the shipping address in the
           {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}}
           attribute and the {{PaymentResponse}}'s
-          {{PaymentResponse/shippingAddress}}
-          attribute. The former is subject to a
-          <a>shipping redact list</a> per the
-          <a>shipping address changed algorithm</a>.
+          {{PaymentResponse/shippingAddress}} attribute. The former is subject
+          to a <a>shipping redact list</a> per the <a>shipping address changed
+          algorithm</a>.
           <aside class="note">
             <p>
               A payee may not need the full shipping address of a user until the
@@ -2287,10 +2286,9 @@
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
           address, subject to the
-          <a>shipping redact list</a>. This field has
-          no effect if the <a>requestShipping</a> member is false. The payee can
-          request additional pieces incrementally using
-          {{PaymentRequestUpdateEvent}}'s
+          <a>shipping redact list</a>. This field has no effect if the
+          <a>requestShipping</a> member is false. The payee can request
+          additional pieces incrementally using {{PaymentRequestUpdateEvent}}'s
           {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
         </dd>
         <dt>
@@ -4087,20 +4085,62 @@
           </h2>
           <aside class="note">
             <p>
-              The {{PaymentMethodChangeEvent/requestBillingAddress()}} method allows the
-              developer to incrementally request additional pieces of the
-              billing address that were not initially requested in
+              The {{PaymentMethodChangeEvent/requestBillingAddress()}} method
+              allows the developer to incrementally request additional pieces of
+              the billing address that were not initially requested in
               {{ PaymentOptions.requestBillingAddressParts }}.
             </p>
-            <pre class="example js" title="how to use `requestBillingAddress()` correctly.">
-              request.onpaymentmethodchange = ev =&gt; {
-                // ✅ Good: request finer-grained address parts inside updateWith()
-                ev.updateWith(new Promise((resolver) =&gt; {
-                  ev.requestBillingAddress(["country", "postalCode"])
-                    .then(methodDetails =&gt; {
-                      resolver(getNewTotal(methodDetails));
-                    });
-                }));
+            <pre class="example js"
+              title="how to use `requestBillingAddress()` correctly.">
+              // ✅ Good: request more address parts to compute new total. The
+              // final response will only contain "country" and "postalCode".
+              request.onpaymentmethodchange = (ev) =&gt; {
+                ev.updateWith(
+                    getNewTotalFromAddress(ev, ["country", "postalCode"])
+                );
+
+                async function getNewTotalFromAddress(ev, parts) {
+                  const methodDetails = await ev.requestBillingAddress(parts);
+                  const newTotal = getNewTotal(methodDetails);
+                  return newTotal;
+                }
+              };
+
+              // ✅ Good: chaining is allowed.
+              request.onpaymentmethodchange = (ev) =&gt; {
+                ev.updateWith(getNewTotalFromAddress(ev));
+
+                async function getNewTotalFromAddress(ev) {
+                  let methodDetails = await ev.requestBillingAddress(
+                      ["country"]);
+                  // Assuming for US residents, no postalCode is needed.
+                  if (methodDetails.country != "US") {
+                    methodDetails = await ev.requestBillingAddress(
+                      ["postalCode"]);
+                  }
+                  const newTotal = getNewTotal(methodDetails);
+                  return newTotal;
+                }
+              };
+
+              // ✅ Good: request full billing address to be included in the
+              // final response but don't need it to compute new total.
+              request.onpaymentmethodchange = (ev) =&gt; {
+                ev.requestBillingAddress(/* addressParts= */[]);
+                ev.updateWith(getNewTotal(ev.methodDetails));
+              };
+
+              // ❌ Bad - Interleaving calls not allowed.
+              request.onshippingaddresschange = (ev) =&gt; {
+                ev.requestShippingAddress(["country"]);
+                ev.requestShippingAddress(["postalCode"]);  // Will reject!
+              };
+
+              // ❌ Bad - Calling `requestBillingAddress()` after
+              // `updateWith()` is not allowed.
+              request.onshippingaddresschange = (ev) =&gt; {
+                ev.updateWith(getNewTotal(ev.methodDetails));
+                ev.requestShippingAddress([]);  // Will reject!
               };
             </pre>
           </aside>
@@ -4112,23 +4152,21 @@
             <li>Let |event:PaymentMethodChangeEvent| be this
             {{PaymentMethodChangeEvent}} instance.
             </li>
-            <li>If |event|'s {{ Event/isTrusted }} attribute is false, then
-            return <a>a promise rejected with</a> an {{"InvalidStateError"}}
-            {{DOMException}}.
-            </li>
             <li>Let |request:PaymentRequest| be the value of |event|'s
             [=Event/target=].
             </li>
             <li>Assert: |request| is an instance of {{PaymentRequest}}.
             </li>
-            <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
-            then return <a>a promise rejected with</a> an {{"InvalidStateError"}}
-            {{DOMException}}.
+            <li>If any of the following is true, then return <a>a promise
+            rejected with</a> an {{"InvalidStateError"}} {{DOMException}}:
+              <ul>
+                <li>|event|'s {{ Event/isTrusted }} attribute is false</li>
+                <li>|event|.<a>[[\waitForMethodDetails]]</a> is true</li>
+                <li>|event|.<a>[[\waitForUpdate]]</a> is true</li>
+                <li>|request|.<a>[[\state]]</a> is not "<a>interactive</a>"</li>
+              </ul>
             </li>
-            <li>If |event|.<a>[[\waitForUpdate]]</a> is false,
-            then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
-            {{DOMException}}.
-            </li>
+            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to true.</li>
             <li>Let |methodDetailsPromise:Promise| be <a>a new promise</a>.</li>
             <li>Return |methodDetailsPromise|, and perform the remaining steps
             <a>in parallel</a>.
@@ -4146,6 +4184,7 @@
               <a>redact list</a> applied.
             </p>
             </li>
+            <li>Set |event|.<a>[[\waitForMethodDetails]]</a> to false.</li>
             <li>Resolve |methodDetailsPromise| with |methodDetails|.
             </li>
 
@@ -4177,6 +4216,35 @@
               null.
             </dd>
           </dl>
+        </section>
+        <section>
+          <h2>
+            Internal Slots
+          </h2>
+          <p>
+            Instances of {{PaymentMethodChangeEvent}} are created with the
+            internal slots in the following table:
+          </p>
+          <table>
+            <tr>
+              <th>
+                Internal Slot
+              </th>
+              <th>
+                Description (<em>non-normative</em>)
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\waitForMethodDetails]]</dfn>
+              </td>
+              <td>
+                A boolean indicating whether there is a pending request for
+                a method-specific details object initiated by
+                <a>requestBillingAddress()</a> that has not settled.
+              </td>
+            </tr>
+          </table>
         </section>
       </section>
       <section data-dfn-for="PaymentRequestUpdateEvent" data-link-for=
@@ -4226,66 +4294,16 @@
           </h2>
           <aside class="note">
             <p>
-              Detailed shipping address contains sensitive user information.
-              Developers are encouraged to specify a restrictive initial list
-              using {{PaymentOptions.requestShippingAddressParts}} and use
-              {{requestShippingAddress()}} to incrementally request pieces as
-              needed. For example, if flat-rate shipping is available in
-              country A but only variable per-region shipping is available in
-              country B, a developer should request only "country" first and
-              decide if "region" is needed.
+              The {{PaymentRequestUpdateEvent/requestShippingAddress()}} method
+              allows the developer to incrementally request additional pieces of
+              the shipping address that were not initially requested in
+              {{ PaymentOptions.requestShippingAddressParts }}.
             </p>
             <p>
-              A developer can call {{requestShippingAddress()}} repeatedly.
-              Each call returns a promise that resolves to a {{PaymentAddress}}
-              with all previously requested address fields populated, subject to
-              any applicable <a data-lt="shipping-redact-list">redact list</a>.
+              The same usage pattern is expected as
+              {{PaymentMethodChangeEvent/requestBillingAddress()}}. See code
+              example there.
             </p>
-            <pre class="example js" title=
-            "how to use `requestShippingAddress()` correctly.">
-              // ✅ Good - Request additional address parts to recompute
-              // shipping cost. The final response.shippingAddress will also
-              // only contain "country" and "postalCode".
-              request.onshippingaddresschange = (ev) =&gt; {
-                ev.updateWith(new Promise((resolver) =&gt; {
-                  ev.requestShippingAddress(["country", "postalCode"])
-                      .then(address =&gt; {
-                        resolver(getNewDetails(address));
-                      });
-                  }));
-              };
-
-              // ✅ Good - Request additional addresss parts to be included in
-              // the final response.shippingAddress.
-              request.onshippingaddresschange = (ev) =&gt; {
-                // Compute shipping cost based on initial coarse address.
-                ev.updateWith(new Promise((resolver) =&gt; {
-                  // Discard the returned promise because the full address is not
-                  // needed until the final PaymentResponse. Empty addressParts
-                  // means all parts are requested.
-                  ev.requestShippingAddress(/* addressParts= */[]);
-
-                  // Compute shipping cost using initial partial address.
-                  resolver(computeShippingCost(ev.target.shippingAddress)));
-                });
-              }
-
-              // ❌ Bad - this won't work!
-              request.onshippingaddresschange = (ev) =&gt; {
-                ev.updateWith(getPromiseForNewDetails(ev.target.shippingAddress));
-
-                // This will throw InvalidStateError since not inside updateWith().
-                ev.requestShippingAddress([]);
-              };
-
-              // ❌ Bad - this won't work!
-              request.onshippingaddresschange = (ev) =&gt; {
-                // This will throw InvalidStateError since not inside updateWith().
-                ev.requestShippingAddress([]);
-
-                ev.updateWith(getPromiseForNewDetails(ev.target.shippingAddress));
-              };
-            </pre>
           </aside>
           <p>
             The <a>requestShippingAddress(|addressParts|)</a> method MUST act as
@@ -4303,18 +4321,16 @@
             </li>
             <li>Assert: |request| is an instance of {{PaymentRequest}}.
             </li>
-            <li>If |event|'s {{ Event/isTrusted }} attribute is false, then
-            return <a>a promise rejected with</a> an {{"InvalidStateError"}}
-            {{DOMException}}.
+            <li>If any of the following is true, then return <a>a promise
+            rejected with</a> an {{"InvalidStateError"}} {{DOMException}}:
+              <ul>
+                <li>|event|'s {{ Event/isTrusted }} attribute is false</li>
+                <li>|event|.<a>[[\waitForShippingAddress]]</a> is true</li>
+                <li>|event|.<a>[[\waitForUpdate]]</a> is true</li>
+                <li>|request|.<a>[[\state]]</a> is not "<a>interactive</a>"</li>
+              </ul>
             </li>
-            <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
-            then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
-            {{DOMException}}.
-            </li>
-            <li>If |event|.<a>[[\waitForUpdate]]</a> is false,
-            then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
-            {{DOMException}}.
-            </li>
+            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to true.</li>
             <li>Let |addressPromise:Promise| be <a>a new promise</a>.</li>
             <li>Return |addressPromise|, and perform the remaining steps
             <a>in parallel</a>.
@@ -4322,19 +4338,17 @@
             <li>Update |request|.<a>[[\requestedShippingAddressParts]]</a> to be
             the union of itself and |addressParts|.
             </li>
-            <li>Let |redactList:list| be the result of <a>get redact list for
-            shipping address changed algorithm</a>.
-            </li>
             <li>Let |address:PaymentAddress| be the result of <a>create
-            a `PaymentAddress` from user-provided input</a> with |redactList|
-            and |request|.<a>[[\requestedShippingAddressParts]]</a>.
+            a `PaymentAddress` from user-provided input</a> with <a>shipping
+            redact list</a> and |request|.<a>[[\requestedShippingAddressParts]]
+            </a>.
             </li>
             <li>Set |request|.[=PaymentRequest/shippingAddress=] to |address|.
             </li>
+            <li>Set |event|.<a>[[\waitForShippingAddress]]</a> to false.</li>
             <li>Resolve |addressPromise| with |address|.
             </li>
           </ol>
-          </p>
         </section>
         <section>
           <h2>
@@ -4431,7 +4445,7 @@
             </li>
             <li>Set |event|.<a>[[\waitForUpdate]]</a> to true.
             </li>
-            <li>Let |pmi:URL?| be null.
+            <li>Let |pmi:URL| be null.
             </li>
             <li>If |event| has a <a data-link-for=
             "PaymentMethodChangeEvent">methodName</a> attribute, set |pmi| to
@@ -4467,6 +4481,15 @@
               <td>
                 A boolean indicating whether an <a>updateWith()</a>-initiated
                 update is currently in progress.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>[[\waitForShippingAddress]]</dfn>
+              </td>
+              <td>
+                A boolean indicating whether there is a pending
+                <a>requestShippingAddress()</a> call that has not settled.
               </td>
             </tr>
           </table>
@@ -4642,41 +4665,10 @@
         </ol>
       </section>
       <section>
-        <h2>
-          <dfn data-lt="shipping-redact-list">
-            Get redact list for shipping address changed algorithm
-          </dfn>
-        </h2>
-        <p>This algorithm returns a redact list that should be used on a
-        shipping address returned to the payee during the
-        <a>shippingaddresschange</a> event.
+        <h2>Shipping redact list</h2>
+        <p>The <dfn>shipping redact list</dfn> is a <a>redact list</a> that
+        includes « "organization", "phone", "recipient", "addressLine" ».
         </p>
-        <div class="note" title="Privacy of recipient information">
-          <p>
-            The |redactList| limits the amount of personal information
-            about the recipient that the API shares with the merchant before
-            the payment request is completed.
-          </p>
-          <p>
-            For merchants, the resulting {{PaymentAddress}} object
-            provides enough information to, for example, calculate
-            shipping costs, but, in most cases, not enough information
-            to physically locate and uniquely identify the recipient.
-          </p>
-          <p>
-            Unfortunately, even with the |redactList|, recipient
-            anonymity cannot be assured. This is because in some
-            countries postal codes are so fine-grained that they can
-            uniquely identify a recipient.
-          </p>
-        </div>
-        <ol class="algorithm">
-          <li>Let |redactList:list| be the empty list. Set |redactList| to
-          « "organization", "phone", "recipient", "addressLine" ».
-          </li>
-          <li>Return |redactList|.
-          </li>
-        </ol>
       </section>
       <section>
         <h2>
@@ -4695,12 +4687,9 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li>Let |redactList:list| be the result of <a>get redact list for
-              shipping address changed algorithm</a>.
-              </li>
               <li>Let |address:PaymentAddress| be the result of running the
               steps to <a>create a `PaymentAddress` from user-provided
-              input</a> with |redactList| and
+              input</a> with <a>shipping redact list</a> and
               |request|.<a>[[\requestedShippingAddressParts]]</a>.
               </li>
               <li>Set the <a data-lt=
@@ -5636,9 +5625,8 @@
         <ul>
           <li>Use of a "<dfn data-lt="redact list">redactList</dfn>" for
           <a>physical addresses</a>. The current specification makes use of a
-          "|redactList|" to redact the <a>address line</a>, <a>organization</a>,
-          <a>phone number</a>, and <a>recipient</a> from a <a data-link-for=
-          "PaymentRequest">shippingAddress</a>.
+          <a>shipping redact list</a> to redact detailed address parts from a
+          <a data-link-for="PaymentRequest">shippingAddress</a>.
           </li>
           <li>Support for instructions from the payee identifying specific
           elements to exclude or include from the <a>payment method</a>

--- a/index.html
+++ b/index.html
@@ -2222,7 +2222,7 @@
             requested pieces is returned. A payment handler may choose to not
             return some requested pieces (e.g., as a result of applying a redact
             list). The payee can request additional pieces incrementally using
-            <a>PaymentMethodChangeEvent.requestBillingAddress()</a>.
+            {{PaymentMethodChangeEvent}}'s {{PaymentMethodChangeEvent/requestBillingAddres()}}.
           </aside>
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -2282,7 +2282,7 @@
           <dfn>requestShippingAddressParts</dfn> member
         </dt>
         <dd>
-          A sequence of <a>AddressParts</a> that specifies which fine-grained
+          A sequence of {{AddressParts}} that specifies which fine-grained
           parts of the shipping address that the payee wishes to receive when
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping

--- a/index.html
+++ b/index.html
@@ -2202,7 +2202,7 @@
           {{PaymentResponse}}'s {{PaymentResponse/details}} attribute. A payee can use this
           information to, for example, calculate tax in certain jurisdictions
           and update the displayed total. See below for privacy considerations
-          regarding <a href="#user-info">exposing user information</a>.
+          regarding [[[#user-info]]].
         </dd>
         <dt>
           <dfn>requestBillingAddressParts</dfn> member

--- a/index.html
+++ b/index.html
@@ -2287,7 +2287,7 @@
           the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
           address, subject to the
-          <a data-lt="shipping-redact-list">redact list</a>. This field has
+          <a>shipping redact list</a>. This field has
           no effect if the <a>requestShipping</a> member is false. The payee can
           request additional pieces incrementally using
           {{PaymentRequestUpdateEvent}}'s

--- a/index.html
+++ b/index.html
@@ -2282,7 +2282,7 @@
         <dd>
           A sequence of <a>AddressParts</a> that specifies which fine-grained
           parts of the shipping address that the payee wishes to receive when
-          the <a>requestShipping</a> boolean is true. An empty list means no
+          the <a>requestShipping</a> member is true. An empty list means no
           restriction, i.e. the <a>user agent</a> will return the full shipping
           address, subject to any applicable redact list. This field has no
           effect if the <a>requestShipping</a> boolean is false. The payee can

--- a/index.html
+++ b/index.html
@@ -1503,7 +1503,6 @@
               the payee-requested shipping address parts, initially supplied to
               the constructor via {{PaymentOptions}}'s
               {{PaymentOptions/requestShippingAddressParts}} and then updated with calls to
-              <a data-lt="PaymentRequestUpdateEvent.requestShippingAddress">
               requestShippingAddress()</a>.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -3096,7 +3096,7 @@
               </li>
             </ol>
           </li>
-          <li>If "sortingCode" is n |requestedParts| and is not in |redactList|,
+          <li>If "sortingCode" is in |requestedParts| and is not in |redactList|,
           set |details|["<a>sortingCode</a>"] to the user-provided sorting code,
           or to the empty string if none was provided.
           </li>

--- a/index.html
+++ b/index.html
@@ -2212,7 +2212,7 @@
           parts of the billing address that the payee wishes to receive when the
           <a>requestBillingAddress</a> member is true. An empty list means no
           restriction, i.e. the payee requests the full billing address. The <a>requestBillingAddressParts</a>
-          field has no effect if the <a>requestBillingAddress</a> member is
+          member has no effect if the <a>requestBillingAddress</a> member is
           false.
           <aside class="note">
             The billing address is part of the payment-method specific response.

--- a/index.html
+++ b/index.html
@@ -4109,7 +4109,7 @@
               The {{PaymentMethodChangeEvent/requestBillingAddress()}} method
               allows the developer to incrementally request additional pieces of
               the billing address that were not initially requested in
-              {{ PaymentOptions.requestBillingAddressParts }}.
+              {{ PaymentOptions/requestBillingAddressParts }}.
             </p>
             <pre class="example js"
               title="how to use `requestBillingAddress()` correctly.">

--- a/index.html
+++ b/index.html
@@ -2287,7 +2287,7 @@
           address, subject to any applicable redact list. This field has no
           effect if the <a>requestShipping</a> boolean is false. The payee can
           request additional pieces incrementally using
-          <a>PaymentRequestUpdateEvent.requestShippingAddress()</a>.
+          {{PaymentRequestUpdateEvent}}'s {{PaymentRequestUpdateEvent/requestShippingAddress()}}.
         </dd>
         <dt>
           <dfn>shippingType</dfn> member

--- a/index.html
+++ b/index.html
@@ -2222,6 +2222,19 @@
           example, this would be set to true when physical goods need to be
           shipped by the merchant to the user. This would be set to false for
           the purchase of digital goods.
+          <aside class="note">
+            <p>
+              A developer may not need the full shipping address of a user, for
+              example, just having "country" may be sufficient to calculate
+              shipping cost. To be sensitive to user's privacy, developers should
+              prefer to use <a>PaymentRequestUpdateEvent.requestShippingAddress()
+              </a> to incrementally request only the address parts they need.
+            </p>
+            <p>
+              A future version of this specification may remove the all-in-one
+              {{PaymentOptions.requestShipping}} boolean.
+            </p>
+          </aside>
         </dd>
         <dt>
           <dfn>shippingType</dfn> member
@@ -4074,9 +4087,9 @@
           <aside class="note">
             <p>
               Detailed shipping address contains sensitive user information.
-              Developers are encouraged to use <a>requestShippingAddress()</a>
+              Developers are encouraged to use {{requestShippingAddress()}}
               to incrementally request pieces they require instead of asking for
-              all up front using the <a>PaymentOptions.requestShipping</a>
+              all up front using the {{PaymentOptions.requestShipping}}
               boolean. For example, if flat-rate shipping is available in
               country A but only variable per-region shipping is available in
               country B, a developer should request only "country" first and
@@ -4084,16 +4097,16 @@
             </p>
             <p>
               A future version of this specification may remove the all-in-one
-              <a>PaymentOptions.requestShipping</a> boolean.
+              {{PaymentOptions.requestShipping}} boolean.
             </p>
             <p>
-              A developer can call <a>requestShippingAddress()</a> repeatedly.
-              Each call returns a promise that resolves to a <a>PaymentAddress
-              </a> with all previously requested address fields populated.
+              A developer can call {{requestShippingAddress()}} repeatedly.
+              Each call returns a promise that resolves to a {{PaymentAddress}}
+              with all previously requested address fields populated.
             </p>
             <p>
               If a requested address part is also in the redact list of shipping
-              address, then the returned <a>PaymentAddress</a> will not have the
+              address, then the returned {{PaymentAddress}} will not have the
               corresponding field populated.
             </p>
             <pre class="example js" title=
@@ -4118,7 +4131,8 @@
             {{PaymentRequestUpdateEvent}} instance.
             </li>
             <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
-            [=exception/throw=] an {{"InvalidStateError"}} {{DOMException}}.
+            return <a>a promise rejected with</a> an {{"InvalidStateError"}}
+            {{DOMException}}.
             </li>
             <li>If |event|'s [=Event/target=] is an instance of
             <a>PaymentResponse</a>, let |request:PaymentRequest| be |event|'s
@@ -4130,21 +4144,24 @@
             <li>Assert: |request| is an instance of {{PaymentRequest}}.
             </li>
             <li>If |request|.<a>[[\state]]</a> is not "<a>interactive</a>",
-            then [=exception/throw=] an {{"InvalidStateError"}}
+            then return <a> a promise rejected with</a> an {{"InvalidStateError"}}
             {{DOMException}}.
             </li>
-            <li>Let |shippingAddress| be the value of |request|'s
-              <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
-              attribute.
+            <li>Let |shippingAddressPromise:Promise| be <a>a new promise</a>.</li>
+            <li>Return |shippingAddressPromise|, and perform the remaining steps <a>in
+            parallel</a>.
+            </li>
+            <li>Let |shippingAddress:PaymentAddress| be |request|'s
+            [=PaymentRequest/shippingAddress=].
               <aside class="note">
                 This address should have already been redacted according to the
                 <a>shipping address changed algorithm</a>.
               </aside>
             </li>
-            <li>Let |details| be an <a>AddressInit</a> dictionary with no
-              members present.
+            <li>Let |details:AddressInit| be an {{AddressInit}} dictionary with
+            no members present.
             </li>
-            <li>For each attribute |attributeName| in |shippingAddress|
+            <li>For each attribute |attributeName| in |shippingAddress:PaymentAddress|:
               <ol>
                 <li>Set |details|[|attributeName|] to the value of
                   |shippingAddress|.[[|attributeName|]] if it is not empty.
@@ -4152,18 +4169,18 @@
               </ol>
             </li>
             <li>Let |redactList| be the empty list. Set |redactList| to
-              « "organization", "phone", "recipient", "addressLine" ».
+            « "organization", "phone", "recipient", "addressLine" ».
             </li>
             <li>For each |addressPart| in |addressParts|:
               <ol>
-                <li>If |details|[|addresPart|] is already present, continue. </li>
-                <li>If |addressPart| is not in |redactList|, set |details|[|addressPart|]
-                to the user provided value for this addres part.
-                </li>
+                <li>If |details|[|addresPart|] is already present, continue.</li>
+                <li>If |addressPart| is in |redactList|, continue. </li>
+                <li>Set |details|[|addressPart|] to the user provided value.</li>
               </ol>
             </li>
             <li><a data-lt="PaymentAddress.PaymentAddress()">Internally construct
-            a new <a>PaymentAddress</a> with |details| and return the result.
+            a new <a>PaymentAddress</a> with |details| and resolve
+            |shippingAddressPromise| with the result.
             </li>
           </ol>
           </p>


### PR DESCRIPTION
closes #842

Add the ability for the merchant to request fine-grained parts of billing address and shipping address. This is based on @adrianhopebailie's idea from https://github.com/w3c/payment-method-basic-card/issues/72#issuecomment-481275334.

We are making these changes because merchants (e.g. Netflix) has requested the ability to receive less information (e.g. Netflix).

At a high level, this pull request can be summarized as the following:

- The existing `requestBillingAddress` and `requestShipping` booleans of `PaymentOptions` will live on to provide backward compatibility:
  - The new `requestBillingAddressParts` and `requestShippingAddressParts` will only take effect when the respective boolean flag is true.
  - This provides backward compatibility:
    - old code + new browser: booleans are used, lists default to [] => old behavior
    - new code + old browser: booleans are used, lists are ignored => old behavior
    - new code + new browser: booleans and lists are both considered => new behavior
- `requestBillingAddressParts` and `requestShippingAddressParts` affect both intermediate results (e.g. those returned in `PaymentRequestUpdateEvent` and `PaymentMethodChangeEvent`) and final results in `PaymentResponse`
  - For billing address, the responsibility is on the payment handler. The specifics is left to the payment method specific specs (e.g. Basic Card and Payment Handler API).
  - For shipping address, a new `[[requestedShippingAddressParts]]` internal slot is added to `PaymentRequest` to keep track of the cumulative address parts requested.
    - “Create a PaymentAddress from user-provided input” algorithm is updated to take an additional `requestedAddressParts` argument that callers will set using the new internal slot.
  - A payee that desires full address at the end must explicitly call `requestBillingAddress([])` and/or `requestShippingAddress([])`.
- Implication on event firing:
  - `shippingaddresschange` event (type: `PaymentRequestUpdateEvent`) must be fired at least once if `requestShippingAddressParts` is non-empty to give payee an opportunity to request full shipping address.
  - `paymentmethodchange` event (type: `PaymentMethodChangeEvent`) must be fired at least once if `requestBillingAddressParts` is non-empty to give payee an opportunity to request full billing address.

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] Modified Web platform tests (link)
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danyao/payment-request/pull/873.html" title="Last updated on Sep 14, 2020, 8:37 PM UTC (5f5bbc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/873/c289211...danyao:5f5bbc1.html" title="Last updated on Sep 14, 2020, 8:37 PM UTC (5f5bbc1)">Diff</a>