### PR TITLE
fix: set default for optional dictionaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,7 +607,7 @@
         <dfn>PaymentRequest</dfn> interface
       </h2>
       <pre class="idl">
-        [Constructor(sequence&lt;PaymentMethodData&gt; methodData, PaymentDetailsInit details, optional PaymentOptions options),
+        [Constructor(sequence&lt;PaymentMethodData&gt; methodData, PaymentDetailsInit details, optional PaymentOptions options = {}),
         SecureContext, Exposed=Window]
         interface PaymentRequest : EventTarget {
           [NewObject]
@@ -3059,7 +3059,7 @@
           [NewObject]
           Promise&lt;void&gt; complete(optional PaymentComplete result = "unknown");
           [NewObject]
-          Promise&lt;void&gt; retry(optional PaymentValidationErrors errorFields);
+          Promise&lt;void&gt; retry(optional PaymentValidationErrors errorFields = {});
 
           attribute EventHandler onpayerdetailchange;
         };
@@ -3893,7 +3893,7 @@
           <dfn>PaymentMethodChangeEvent</dfn> interface
         </h2>
         <pre class="idl">
-          [Constructor(DOMString type, optional PaymentMethodChangeEventInit eventInitDict), SecureContext, Exposed=Window]
+          [Constructor(DOMString type, optional PaymentMethodChangeEventInit eventInitDict = {}), SecureContext, Exposed=Window]
           interface PaymentMethodChangeEvent : PaymentRequestUpdateEvent {
             readonly attribute DOMString methodName;
             readonly attribute object? methodDetails;
@@ -3953,7 +3953,7 @@
           <dfn>PaymentRequestUpdateEvent</dfn> interface
         </h2>
         <pre class="idl">
-          [Constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict), SecureContext, Exposed=Window]
+          [Constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict = {}), SecureContext, Exposed=Window]
           interface PaymentRequestUpdateEvent : Event {
             void updateWith(Promise&lt;PaymentDetailsUpdate&gt; detailsPromise);
           };

--- a/index.html
+++ b/index.html
@@ -3715,7 +3715,7 @@
           <dfn>MerchantValidationEvent</dfn> interface
         </h2>
         <pre class="idl">
-          [Constructor(DOMString type, optional MerchantValidationEventInit eventInitDict),
+          [Constructor(DOMString type, optional MerchantValidationEventInit eventInitDict = {}),
           SecureContext, Exposed=Window]
           interface MerchantValidationEvent : Event {
             readonly attribute DOMString methodName;


### PR DESCRIPTION
The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [X] Modified Web platform tests - IDL changes will be picked up automatically.
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [X] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1562680)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?
none.

@rsolomakhin, @danyao, the underlying IDL change is tracked at:  https://bugs.chromium.org/p/chromium/issues/detail?id=984949

@aestes, this change is a result from a change to WebIDL that introduces a default dictionary value of `{}` for when dictionaries are optional: https://github.com/heycam/webidl/pull/750

I'm not sure who to ping on the WebKit side about updating the binding layer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/874.html" title="Last updated on Jul 23, 2019, 9:17 PM UTC (3b872fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/874/2f35ff0...3b872fc.html" title="Last updated on Jul 23, 2019, 9:17 PM UTC (3b872fc)">Diff</a>