### PR TITLE
Remove requirement to reject after document is inactive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1234,9 +1234,6 @@
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
               </li>
-              <li>Reject |acceptPromise| with an "<a>AbortError</a>"
-              <a>DOMException</a>.
-              </li>
             </ol>
           </li>
         </ol>
@@ -3172,19 +3169,18 @@
           affords the end user the ability to retry accepting the payment
           request.
           </li>
-          <li data-tests=
-          "payment-response/rejects_if_not_active-manual.https.html">If
-          |document| stops being <a>fully active</a> while the user interface
-          is being shown, or no longer is by the time this step is reached,
-          then:
+          <li>
+            <span data-tests=
+            "payment-response/rejects_if_not_active-manual.https.html">If
+            |document| stops being <a>fully active</a> while the user interface
+            is being shown, or no longer is by the time this step is reached,
+            then:
+            </span>
             <ol>
               <li>Close down the user interface.
               </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
-              </li>
-              <li>Reject |retryPromise| with an "<a>AbortError</a>"
-              <a>DOMException</a>.
               </li>
             </ol>
           </li>
@@ -3489,9 +3485,6 @@
               </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
-              </li>
-              <li>Reject |promise| with an "<a>AbortError</a>"
-              <a>DOMException</a>.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
closes #872

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests (https://github.com/web-platform-tests/wpt/pull/17920)
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [x] Chrome (http://crbug.com/941271)
 * [ ] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1567641)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec? N/A


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danyao/payment-request/pull/875.html" title="Last updated on Jul 18, 2019, 11:19 PM UTC (f2f8ba4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/875/2f35ff0...danyao:f2f8ba4.html" title="Last updated on Jul 18, 2019, 11:19 PM UTC (f2f8ba4)">Diff</a>