### PR TITLE
Editorial: Update links to respec definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3586,7 +3586,7 @@
           <a>iframe</a> element affects the <a>container policy</a> for any
           document nested in that iframe. Unless overridden by the
           [^iframe/allow^] attribute, setting [^iframe/allowpaymentrequest^] on an iframe is equivalent
-          to <code>&lt;iframe allow="fullscreen *"&gt;</code>, as described in
+          to `&lt;iframe allow="fullscreen *"&gt;`, as described in
           <a data-cite=
           "feature-policy#iframe-allowpaymentrequest-attribute">Feature Policy
           §allowpaymentrequest</a>.

--- a/index.html
+++ b/index.html
@@ -1092,8 +1092,9 @@
           <li>Present a user interface that will allow the user to interact
           with the |handlers|. The user agent SHOULD prioritize the preference
           of the user when presenting payment methods. It is RECOMMENDED that
-          the language of the user interface match the [=node/language=] of the <a data-cite=
-          "HTML/dom.html#the-body-element-2">the body element</a> element.
+          the language of the user interface match the [=node/language=] of the
+          <a data-cite="HTML/dom.html#the-body-element-2">the body element</a>
+          element.
           </li>
           <li data-tests=
           "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">
@@ -3325,12 +3326,11 @@
         <aside class="note">
           <p>
             Each <a>standardized payment method identifier</a>, such as
-            [[[?payment-method-basic-card]]],
-            defines its own unique IDL <a>dictionary</a> for use with the
-            <a>details</a> attribute. The shape of this data (i.e., its members
-            and their corresponding types and formats) differs depending on
-            which standardized payment method identifier is selected by the end
-            user.
+            [[[?payment-method-basic-card]]], defines its own unique IDL
+            <a>dictionary</a> for use with the <a>details</a> attribute. The
+            shape of this data (i.e., its members and their corresponding types
+            and formats) differs depending on which standardized payment method
+            identifier is selected by the end user.
           </p>
           <p>
             Similarly, a <a>URL-based payment method identifier</a> defines the
@@ -3585,10 +3585,10 @@
           The {{ HTMLIFrameElement.allowPaymentRequest }} attribute of the HTML
           <a>iframe</a> element affects the <a>container policy</a> for any
           document nested in that iframe. Unless overridden by the
-          [^iframe/allow^]
-          attribute, setting {{ HTMLIFrameElement.allowPaymentRequest }} on an
-          iframe is equivalent to <code>&lt;iframe allow="fullscreen
-          *"&gt;</code>, as described in <a data-cite=
+          [^iframe/allow^] attribute, setting {{
+          HTMLIFrameElement.allowPaymentRequest }} on an iframe is equivalent
+          to <code>&lt;iframe allow="fullscreen *"&gt;</code>, as described in
+          <a data-cite=
           "feature-policy#iframe-allowpaymentrequest-attribute">Feature Policy
           §allowpaymentrequest</a>.
         </p>
@@ -4489,7 +4489,8 @@
               <li>Let |event:PaymentRequestUpdateEvent| be the result of
               <a>creating an event</a> using {{PaymentRequestUpdateEvent}}.
               </li>
-              <li>Initialize |event|'s {{Event/type}} attribute to "<a>payerdetailchange</a>".
+              <li>Initialize |event|'s {{Event/type}} attribute to
+              "<a>payerdetailchange</a>".
               </li>
               <li>
                 <a>Dispatch</a> |event| at |response|.

--- a/index.html
+++ b/index.html
@@ -3585,8 +3585,7 @@
           The {{ HTMLIFrameElement.allowPaymentRequest }} attribute of the HTML
           <a>iframe</a> element affects the <a>container policy</a> for any
           document nested in that iframe. Unless overridden by the
-          <code><a data-cite=
-          "html/iframe-embed-object.html#attr-iframe-allow">allow</a></code>
+          <code>[^iframe/allow^]</code>
           attribute, setting {{ HTMLIFrameElement.allowPaymentRequest }} on an
           iframe is equivalent to <code>&lt;iframe allow="fullscreen
           *"&gt;</code>, as described in <a data-cite=

--- a/index.html
+++ b/index.html
@@ -3585,8 +3585,7 @@
           The {{ HTMLIFrameElement.allowPaymentRequest }} attribute of the HTML
           <a>iframe</a> element affects the <a>container policy</a> for any
           document nested in that iframe. Unless overridden by the
-          [^iframe/allow^] attribute, setting {{
-          HTMLIFrameElement.allowPaymentRequest }} on an iframe is equivalent
+          [^iframe/allow^] attribute, setting [^iframe/allowpaymentrequest^] on an iframe is equivalent
           to <code>&lt;iframe allow="fullscreen *"&gt;</code>, as described in
           <a data-cite=
           "feature-policy#iframe-allowpaymentrequest-attribute">Feature Policy

--- a/index.html
+++ b/index.html
@@ -3325,7 +3325,7 @@
         <aside class="note">
           <p>
             Each <a>standardized payment method identifier</a>, such as
-            <a data-cite="?payment-method-basic-card"></a> ("basic-card"),
+            [[[?payment-method-basic-card]]],
             defines its own unique IDL <a>dictionary</a> for use with the
             <a>details</a> attribute. The shape of this data (i.e., its members
             and their corresponding types and formats) differs depending on

--- a/index.html
+++ b/index.html
@@ -3585,9 +3585,9 @@
           The {{ HTMLIFrameElement.allowPaymentRequest }} attribute of the HTML
           <a>iframe</a> element affects the <a>container policy</a> for any
           document nested in that iframe. Unless overridden by the
-          [^iframe/allow^] attribute, setting [^iframe/allowpaymentrequest^] on an iframe is equivalent
-          to `&lt;iframe allow="fullscreen *"&gt;`, as described in
-          <a data-cite=
+          [^iframe/allow^] attribute, setting [^iframe/allowpaymentrequest^] on
+          an iframe is equivalent to `&lt;iframe allow="fullscreen *"&gt;`, as
+          described in <a data-cite=
           "feature-policy#iframe-allowpaymentrequest-attribute">Feature Policy
           §allowpaymentrequest</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -1092,7 +1092,8 @@
           <li>Present a user interface that will allow the user to interact
           with the |handlers|. The user agent SHOULD prioritize the preference
           of the user when presenting payment methods. It is RECOMMENDED that
-          the language of the user interface match the [=node/language=] of the [^body^] element.
+          the language of the user interface match the [=node/language=] of the <a data-cite=
+          "HTML/dom.html#the-body-element-2">the body element</a> element.
           </li>
           <li data-tests=
           "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">

--- a/index.html
+++ b/index.html
@@ -1092,8 +1092,7 @@
           <li>Present a user interface that will allow the user to interact
           with the |handlers|. The user agent SHOULD prioritize the preference
           of the user when presenting payment methods. It is RECOMMENDED that
-          the language of the user interface match the <a data-cite=
-          "HTML#language">language</a> of the [^body^] element.
+          the language of the user interface match the [=node/language=] of the [^body^] element.
           </li>
           <li data-tests=
           "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">

--- a/index.html
+++ b/index.html
@@ -1093,8 +1093,7 @@
           with the |handlers|. The user agent SHOULD prioritize the preference
           of the user when presenting payment methods. It is RECOMMENDED that
           the language of the user interface match the <a data-cite=
-          "HTML#language">language</a> of <a data-cite=
-          "HTML/dom.html#the-body-element-2">the body element</a>.
+          "HTML#language">language</a> of the [^body^] element.
           </li>
           <li data-tests=
           "show-method-optional-promise-rejects-manual.https.html, show-method-optional-promise-resolves-manual.https.html">

--- a/index.html
+++ b/index.html
@@ -4423,8 +4423,7 @@
           <a>creating an event</a> using the {{PaymentRequestUpdateEvent}}
           interface.
           </li>
-          <li>Initialize |event|'s <code><a data-cite=
-          "DOM#dom-event-type">type</a></code> attribute to |name|.
+          <li>Initialize |event|'s {{Event/type}} attribute to |name|.
           </li>
           <li>
             <a>Dispatch</a> |event| at |request|.
@@ -4492,8 +4491,7 @@
               <li>Let |event:PaymentRequestUpdateEvent| be the result of
               <a>creating an event</a> using {{PaymentRequestUpdateEvent}}.
               </li>
-              <li>Initialize |event|'s <code><a data-cite="DOM#dom-event-type">
-                type</a></code> attribute to "<a>payerdetailchange</a>".
+              <li>Initialize |event|'s {{Event/type}} attribute to "<a>payerdetailchange</a>".
               </li>
               <li>
                 <a>Dispatch</a> |event| at |response|.

--- a/index.html
+++ b/index.html
@@ -3585,7 +3585,7 @@
           The {{ HTMLIFrameElement.allowPaymentRequest }} attribute of the HTML
           <a>iframe</a> element affects the <a>container policy</a> for any
           document nested in that iframe. Unless overridden by the
-          <code>[^iframe/allow^]</code>
+          [^iframe/allow^]
           attribute, setting {{ HTMLIFrameElement.allowPaymentRequest }} on an
           iframe is equivalent to <code>&lt;iframe allow="fullscreen
           *"&gt;</code>, as described in <a data-cite=


### PR DESCRIPTION
Updated all that I can find on respec. I've raised a few PRs to export definitions that payment-request uses. Will update these definitions in separate PRs once they're approved and merged in the other specs.

@marcoscaceres 

PRs to export definitions from other specs
1. [Export iframe `allow` definition](https://github.com/whatwg/html/pull/5193)
2. [Export `language` definition](https://github.com/whatwg/html/pull/5192)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/payment-request/pull/891.html" title="Last updated on Jan 22, 2020, 3:56 AM UTC (de1b265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/891/78aac89...janiceshiu:de1b265.html" title="Last updated on Jan 22, 2020, 3:56 AM UTC (de1b265)">Diff</a>