### PR TITLE
Updated link to PR API test suite

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       wg: "Web Payments Working Group",
       wgURI: "https://www.w3.org/Payments/WG/",
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/83744/status",
-      testSuiteURI: "https://w3c-test.org/payment-request/",
+      testSuiteURI: "https://wpt.live/payment-request/",
       implementationReportURI:
         "https://w3c.github.io/test-results/payment-request/all.html",
       caniuse: "payment-request",
@@ -113,7 +113,7 @@
         "https://w3c.github.io/test-results/payment-request/all.html">implementation
         report</a>. The report will show two or more independent
         implementations passing each mandatory test in the <a href=
-        "https://w3c-test.org/payment-request/">test suite</a> (i.e., each test
+        "https://wpt.live/payment-request/">test suite</a> (i.e., each test
         corresponds to a MUST requirement of the specification).
       </p>
       <p>


### PR DESCRIPTION
Apparently the PR API test suite is moving to <https://wpt.live/payment-request/>. This pull requests updates the link in the respec metadata and the status section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/892.html" title="Last updated on Jan 7, 2020, 5:46 PM UTC (7d1ba4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/892/78aac89...7d1ba4b.html" title="Last updated on Jan 7, 2020, 5:46 PM UTC (7d1ba4b)">Diff</a>