### PR TITLE
Editorial: Use respec shorthands instead of `data-lt`

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,8 +644,7 @@
         <p data-link-for="PaymentRequest">
           The <a>shippingAddress</a>, <a>shippingOption</a>, and
           <a>shippingType</a> attributes are populated during processing if the
-          {{PaymentOptions/requestShipping}}
-          member is set.
+          {{PaymentOptions/requestShipping}} member is set.
         </p>
       </div>
       <p>
@@ -683,16 +682,16 @@
         <ol data-link-for="PaymentDetailsBase" class="algorithm">
           <li>If the <a>current settings object</a>'s [=environment settings
           object / responsible document=] is not <a>allowed to use</a> the
-          "[=payment-feature|payment=]" feature, then
-          [=exception/throw=] a {{"SecurityError"}} {{DOMException}}.
+          "[=payment-feature|payment=]" feature, then [=exception/throw=] a
+          {{"SecurityError"}} {{DOMException}}.
           </li>
           <li>Establish the request's id:
             <ol>
               <li data-tests="payment-request-id-attribute.https.html">If
-              |details|.{{PaymentDetailsInit/id}} is missing,
-              add an {{PaymentDetailsInit/id}} member to
-              |details| and set its value to a <abbr title=
-              "Universally Unique Identifier">UUID</abbr> [[RFC4122]].
+              |details|.{{PaymentDetailsInit/id}} is missing, add an
+              {{PaymentDetailsInit/id}} member to |details| and set its value
+              to a <abbr title="Universally Unique Identifier">UUID</abbr>
+              [[RFC4122]].
               </li>
             </ol>
           </li>
@@ -709,16 +708,17 @@
                   <li data-tests=
                   "payment-request-ctor-pmi-handling.https.html">Run the steps
                   to <a>validate a payment method identifier</a> with
-                  |paymentMethod|.{{PaymentMethodData/supportedMethods}. If
-                  it returns false, then throw a {{RangeError}} exception.
+                  |paymentMethod|.{{PaymentMethodData/supportedMethods}. If it
+                  returns false, then throw a {{RangeError}} exception.
                   Optionally, inform the developer that the payment method
                   identifier is invalid.
                   </li>
-                  <li>If the {{PaymentMethodData/data}}
-                  member of |paymentMethod| is missing, let |serializedData| be
-                  null. Otherwise, let |serializedData| be the result of
-                  <a>JSON-serializing</a> |paymentMethod|.{{PaymentMethodData/data}} into a string. Rethrow any
-                  exceptions.
+                  <li>If the {{PaymentMethodData/data}} member of
+                  |paymentMethod| is missing, let |serializedData| be null.
+                  Otherwise, let |serializedData| be the result of
+                  <a>JSON-serializing</a>
+                  |paymentMethod|.{{PaymentMethodData/data}} into a string.
+                  Rethrow any exceptions.
                   </li>
                   <li>If |serializedData| is not null, and if required by the
                   specification that defines the
@@ -730,9 +730,9 @@
                       </li>
                       <li>
                         <p>
-                          [=converted to an IDL value|Convert=]
-                          |object| to an IDL value of the type specified by the
-                          specification that defines the
+                          [=converted to an IDL value|Convert=] |object| to an
+                          IDL value of the type specified by the specification
+                          that defines the
                           |paymentMethod|.<a>supportedMethods</a> (e.g.,
                           {{BasicCardRequest}} in the case of
                           [[[?payment-method-basic-card]]]). Rethrow any
@@ -745,7 +745,8 @@
                       </li>
                     </ol>
                   </li>
-                  <li>Add the tuple (|paymentMethod|.{{PaymentMethodData/supportedMethods}},
+                  <li>Add the tuple
+                  (|paymentMethod|.{{PaymentMethodData/supportedMethods}},
                   |serializedData|) to |serializedMethodData|.
                   </li>
                 </ol>
@@ -757,7 +758,8 @@
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
                 <a>Check and canonicalize total amount</a>
-                |details|.<a>total</a>.{{PaymentItem/amount}}. Rethrow any exceptions.
+                |details|.<a>total</a>.{{PaymentItem/amount}}. Rethrow any
+                exceptions.
               </li>
             </ol>
           </li>
@@ -766,14 +768,15 @@
             <ol>
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
-                <a>Check and canonicalize amount</a> |item|.{{PaymentItem/amount}}. Rethrow any exceptions.
+                <a>Check and canonicalize amount</a>
+                |item|.{{PaymentItem/amount}}. Rethrow any exceptions.
               </li>
             </ol>
           </li>
           <li>Let |selectedShippingOption| be null.
           </li>
-          <li>If the {{PaymentOptions/requestShipping}} member of
-          |options| is present and set to true, process shipping options:
+          <li>If the {{PaymentOptions/requestShipping}} member of |options| is
+          present and set to true, process shipping options:
             <ol>
               <li>Let |options:PaymentShippingOption| be an empty
               <code><a>sequence</a></code>&lt;<a>PaymentShippingOption</a>&gt;.
@@ -788,8 +791,8 @@
                     <ol>
                       <li data-tests=
                       "payment-request-ctor-currency-code-checks.https.html">
-                        <a>Check and canonicalize amount</a> |item|.{{PaymentItem/amount}}. Rethrow any
-                        exceptions.
+                        <a>Check and canonicalize amount</a>
+                        |item|.{{PaymentItem/amount}}. Rethrow any exceptions.
                       </li>
                       <li>If |seenIDs| contains |option|.<a>id</a>, then throw
                       a {{TypeError}}. Optionally, inform the developer that
@@ -823,8 +826,7 @@
                   </li>
                   <li>For each |modifier| of |modifiers|:
                     <ol>
-                      <li>If the {{PaymentDetailsModifier/total}}
-                      member of
+                      <li>If the {{PaymentDetailsModifier/total}} member of
                       |modifier| is present, then:
                         <ol>
                           <li data-tests=
@@ -835,34 +837,39 @@
                           </li>
                         </ol>
                       </li>
-                      <li>If the {{PaymentDetailsModifier/additionalDisplayItems}}
-                      member of |modifier| is present, then for each |item| of
+                      <li>If the
+                      {{PaymentDetailsModifier/additionalDisplayItems}} member
+                      of |modifier| is present, then for each |item| of
                       |modifier|.{{PaymentDetailsModifier/additionalDisplayItems}}:
                         <ol>
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
                             <a>Check and canonicalize amount</a>
-                            |item|.{{PaymentItem/amount}}.
-                            Rethrow any exceptions.
+                            |item|.{{PaymentItem/amount}}. Rethrow any
+                            exceptions.
                           </li>
                         </ol>
                       </li>
                       <li>If the {{PaymentDetailsModifier/data}} member of
                       |modifier| is missing, let |serializedData| be null.
                       Otherwise, let |serializedData| be the result of
-                      <a>JSON-serializing</a> |modifier|.{{PaymentDetailsModifier/data}} into a string.
+                      <a>JSON-serializing</a>
+                      |modifier|.{{PaymentDetailsModifier/data}} into a string.
                       Rethrow any exceptions.
                       </li>
-                      <li>Add the tuple (|modifier|.{{PaymentDetailsModifier/supportedMethods}},
+                      <li>Add the tuple
+                      (|modifier|.{{PaymentDetailsModifier/supportedMethods}},
                       |serializedData|) to |serializedModifierData|.
                       </li>
-                      <li>Remove the {{PaymentDetailsModifier/data}} member of |modifier|, if it is present.
+                      <li>Remove the {{PaymentDetailsModifier/data}} member of
+                      |modifier|, if it is present.
                       </li>
                     </ol>
                   </li>
                 </ol>
               </li>
-              <li>Set |details|.{{PaymentDetailsBase/modifiers}} to |modifiers|.
+              <li>Set |details|.{{PaymentDetailsBase/modifiers}} to
+              |modifiers|.
               </li>
             </ol>
           </li>
@@ -884,15 +891,16 @@
           </li>
           <li>Set |request|.<a>[[\response]]</a> to null.
           </li>
-          <li>Set the value of |request|'s {{PaymentRequest/shippingOption}} attribute to
-          |selectedShippingOption|.
+          <li>Set the value of |request|'s {{PaymentRequest/shippingOption}}
+          attribute to |selectedShippingOption|.
           </li>
-          <li>Set the value of the {{PaymentRequest/shippingAddress}} attribute on |request| to null.
+          <li>Set the value of the {{PaymentRequest/shippingAddress}} attribute
+          on |request| to null.
           </li>
           <li>If |options|.{{PaymentOptions/requestShipping}} is set to true,
-          then set the value of the {{PaymentRequest/shippingType}} attribute on |request|
-          to |options|.{{PaymentOptions/shippingType}}. Otherwise, set it to
-          null.
+          then set the value of the {{PaymentRequest/shippingType}} attribute
+          on |request| to |options|.{{PaymentOptions/shippingType}}. Otherwise,
+          set it to null.
           </li>
           <li>Return |request|.
           </li>
@@ -904,7 +912,8 @@
         </h2>
         <p data-tests="payment-request-id-attribute.https.html">
           When getting, the <a>id</a> attribute returns this
-          {{PaymentRequest}}'s [=PaymentRequest/[[details]]=].{{PaymentDetailsInit/id}}.
+          {{PaymentRequest}}'s
+          [=PaymentRequest/[[details]]=].{{PaymentDetailsInit/id}}.
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
@@ -994,9 +1003,9 @@
             </ol>
             <p class="note">
               This allows the <a>user agent</a> to act as if the user had
-              immediately [=user aborts the payment request|aborted the payment request=], at its discretion. For example, in
-              "private browsing" modes or similar, user agents might take
-              advantage of this step.
+              immediately [=user aborts the payment request|aborted the payment
+              request=], at its discretion. For example, in "private browsing"
+              modes or similar, user agents might take advantage of this step.
             </p>
           </li>
           <li>Set |request|'s <a>payment-relevant browsing context</a>'s
@@ -1018,8 +1027,10 @@
               in the |paymentMethod| tuple.
               </li>
               <li data-cite="WebIDL infra">If required by the specification
-              that defines the |identifier|, then [=converted to an IDL value|convert=] |data| to an IDL value of
-              the type specified there. Otherwise, [=converted to an IDL value|convert=] to {{object}}.
+              that defines the |identifier|, then [=converted to an IDL
+              value|convert=] |data| to an IDL value of the type specified
+              there. Otherwise, [=converted to an IDL value|convert=] to
+              {{object}}.
               </li>
               <li>If conversion results in an <a>exception</a> |error|:
                 <ol>
@@ -1067,17 +1078,17 @@
           <li>
             <p>
               Present a user interface that will allow the user to interact
-              with the |handlers|. The user agent SHOULD prioritize the
-              user's preference when presenting payment methods.
+              with the |handlers|. The user agent SHOULD prioritize the user's
+              preference when presenting payment methods.
             </p>
             <aside class="note" title="Localization of the payment sheet">
               <p>
                 The API does not provide a way for developers to specify the
-                language in which the payment sheet is presented to end
-                users. As such, user agents will generally present the payment
-                sheet using the user agent's default language. The working
-                group is contemplating adding the ability for developers to
-                specify the language of the payment sheet, and of specific
+                language in which the payment sheet is presented to end users.
+                As such, user agents will generally present the payment sheet
+                using the user agent's default language. The working group is
+                contemplating adding the ability for developers to specify the
+                language of the payment sheet, and of specific
                 {{PaymentItems}}, in a future version of this API.
               </p>
             </aside>
@@ -1119,13 +1130,13 @@
           </li>
           <li>
             <p>
-              Pass the [=converted to an IDL value|converted=]
-              second element in the |paymentMethod| tuple and |modifiers|.
-              Optionally, the user agent SHOULD send the appropriate data from
-              |request| to the user-selected <a>payment handler</a> in order to
-              guide the user through the payment process. This includes the
-              various attributes and other internal slots of |request| (some
-              MAY be excluded for privacy reasons where appropriate).
+              Pass the [=converted to an IDL value|converted=] second element
+              in the |paymentMethod| tuple and |modifiers|. Optionally, the
+              user agent SHOULD send the appropriate data from |request| to the
+              user-selected <a>payment handler</a> in order to guide the user
+              through the payment process. This includes the various attributes
+              and other internal slots of |request| (some MAY be excluded for
+              privacy reasons where appropriate).
             </p>
             <p>
               Handling of multiple applicable modifiers in the
@@ -1351,8 +1362,8 @@
           A {{PaymentRequest}}'s <a>shippingType</a> attribute is the type of
           shipping used to fulfill the transaction. Its value is either a
           <a>PaymentShippingType</a> enum value, or null if none is provided by
-          the developer during [=PaymentRequest.PaymentRequest()|construction=] (see
-          <a>PaymentOptions</a>'s {{PaymentOptions/shippingType}} member).
+          the developer during [=PaymentRequest.PaymentRequest()|construction=]
+          (see <a>PaymentOptions</a>'s {{PaymentOptions/shippingType}} member).
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
@@ -1443,10 +1454,11 @@
               "PaymentRequest">[[\serializedModifierData]]</dfn>
             </td>
             <td>
-              A list containing the serialized string form of each {{PaymentDetailsModifier/data}} member for each
-              corresponding item in the sequence
-              [=PaymentRequest/[[details]]=].[=PaymentDetailsBase|modifier=], or null if no such member was
-              present.
+              A list containing the serialized string form of each
+              {{PaymentDetailsModifier/data}} member for each corresponding
+              item in the sequence
+              [=PaymentRequest/[[details]]=].[=PaymentDetailsBase|modifier=],
+              or null if no such member was present.
             </td>
           </tr>
           <tr>
@@ -1457,13 +1469,12 @@
             <td>
               The current <a>PaymentDetailsBase</a> for the payment request
               initially supplied to the constructor and then updated with calls
-              to {{PaymentRequestUpdateEvent/updateWith()}}. Note
-              that all {{PaymentDetailsModifier/data}}
-              members of <a>PaymentDetailsModifier</a> instances contained in
-              the {{PaymentDetailsBase/modifiers}}
-              member will be removed, as they are instead stored in serialized
-              form in the [=PaymentRequest/[[serializedModifierData]]=]
-              internal slot.
+              to {{PaymentRequestUpdateEvent/updateWith()}}. Note that all
+              {{PaymentDetailsModifier/data}} members of
+              <a>PaymentDetailsModifier</a> instances contained in the
+              {{PaymentDetailsBase/modifiers}} member will be removed, as they
+              are instead stored in serialized form in the
+              [=PaymentRequest/[[serializedModifierData]]=] internal slot.
             </td>
           </tr>
           <tr>
@@ -1531,8 +1542,8 @@
             </td>
             <td>
               True if there is a pending
-              {{PaymentRequestUpdateEvent/updateWith()}} call to
-              update the payment request and false otherwise.
+              {{PaymentRequestUpdateEvent/updateWith()}} call to update the
+              payment request and false otherwise.
             </td>
           </tr>
           <tr>
@@ -1540,8 +1551,8 @@
               <dfn>[[\acceptPromise]]</dfn>
             </td>
             <td>
-              The pending {{Promise}} created during {{PaymentRequest/show}} that will be resolved if the user
-              accepts the payment request.
+              The pending {{Promise}} created during {{PaymentRequest/show}}
+              that will be resolved if the user accepts the payment request.
             </td>
           </tr>
           <tr>
@@ -1766,8 +1777,8 @@
             for the payment request that the <a>user agent</a> MAY display.
             <aside class="note">
               It is the developer's responsibility, when generating or updating
-              a {{PaymentRequest}}, to verify that the {{PaymentDetailsInit/total}} amount is the sum of these
-              items.
+              a {{PaymentRequest}}, to verify that the
+              {{PaymentDetailsInit/total}} amount is the sum of these items.
             </aside>
           </dd>
           <dt>
@@ -1780,27 +1791,29 @@
             </p>
             <p data-tests=
             "change-shipping-option-select-last-manual.https.html">
-              If an item in the sequence has the {{PaymentShippingOption/selected}} member set to true,
-              then this is the shipping option that will be used by default and {{PaymentRequest/shippingOption}}
-              will be set to the {{PaymentShippingOption/id}}
-              of this option without running the <a>shipping option changed
-              algorithm</a>. If more than one item in the sequence has
-              {{PaymentShippingOption/selected}} set to
+              If an item in the sequence has the
+              {{PaymentShippingOption/selected}} member set to true, then this
+              is the shipping option that will be used by default and
+              {{PaymentRequest/shippingOption}} will be set to the
+              {{PaymentShippingOption/id}} of this option without running the
+              <a>shipping option changed algorithm</a>. If more than one item
+              in the sequence has {{PaymentShippingOption/selected}} set to
               true, then the <a>user agent</a> selects the last one in the
               sequence.
             </p>
             <p>
               The <a>shippingOptions</a> member is only used if the
               {{PaymentRequest}} was constructed with <a>PaymentOptions</a> and
-              {{PaymentOptions/requestShipping}}
-              set to true.
+              {{PaymentOptions/requestShipping}} set to true.
             </p>
             <aside class="note">
-              If the sequence has an item with the {{PaymentShippingOption/selected}} member set to true,
-              then authors are responsible for ensuring that the {{PaymentDetailsInit/total}} member includes the cost of
-              the shipping option. This is because no
-              <a>shippingoptionchange</a> event will be fired for this option
-              unless the user selects an alternative option first.
+              If the sequence has an item with the
+              {{PaymentShippingOption/selected}} member set to true, then
+              authors are responsible for ensuring that the
+              {{PaymentDetailsInit/total}} member includes the cost of the
+              shipping option. This is because no <a>shippingoptionchange</a>
+              event will be fired for this option unless the user selects an
+              alternative option first.
             </aside>
           </dd>
           <dt>
@@ -1855,7 +1868,8 @@
             <aside class="note">
               Algorithms in this specification that accept a
               <a>PaymentDetailsInit</a> dictionary will throw if the
-              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}} is a negative number.
+              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}}
+              is a negative number.
             </aside>
           </dd>
         </dl>
@@ -1891,22 +1905,25 @@
             A human-readable string that explains why goods cannot be shipped
             to the chosen shipping address, or any other reason why no shipping
             options are available. When the payment request is updated using
-            {{PaymentRequestUpdateEvent/updateWith()}},
-            the <a>PaymentDetailsUpdate</a> can contain a message in the
+            {{PaymentRequestUpdateEvent/updateWith()}}, the
+            <a>PaymentDetailsUpdate</a> can contain a message in the
             <a>error</a> member that will be displayed to the user if the
-            <a>PaymentDetailsUpdate</a> indicates that there are no valid {{PaymentDetailsBase/shippingOptions}}
-            (and the {{PaymentRequest}} was constructed with the {{PaymentOptions/requestShipping}} option set to
-            true).
+            <a>PaymentDetailsUpdate</a> indicates that there are no valid
+            {{PaymentDetailsBase/shippingOptions}} (and the {{PaymentRequest}}
+            was constructed with the {{PaymentOptions/requestShipping}} option
+            set to true).
           </dd>
           <dt>
             <dfn>total</dfn> member
           </dt>
           <dd>
-            A <a>PaymentItem</a> containing a non-negative {{PaymentItem/amount}}.
+            A <a>PaymentItem</a> containing a non-negative
+            {{PaymentItem/amount}}.
             <p class="note">
               Algorithms in this specification that accept a
               <a>PaymentDetailsUpdate</a> dictionary will throw if the
-              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}} is a negative number.
+              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}}
+              is a negative number.
             </p>
           </dd>
           <dt>
@@ -1965,16 +1982,18 @@
           <dfn>total</dfn> member
         </dt>
         <dd>
-          A <a>PaymentItem</a> value that overrides the {{PaymentDetailsInit/total}} member in the
-          <a>PaymentDetailsInit</a> dictionary for the <a>payment method
-          identifiers</a> of the <a>supportedMethods</a> member.
+          A <a>PaymentItem</a> value that overrides the
+          {{PaymentDetailsInit/total}} member in the <a>PaymentDetailsInit</a>
+          dictionary for the <a>payment method identifiers</a> of the
+          <a>supportedMethods</a> member.
         </dd>
         <dt>
           <dfn>additionalDisplayItems</dfn> member
         </dt>
         <dd>
           A sequence of <a>PaymentItem</a> dictionaries provides additional
-          display items that are appended to the {{PaymentDetailsBase/displayItems}} member in the
+          display items that are appended to the
+          {{PaymentDetailsBase/displayItems}} member in the
           <a>PaymentDetailsBase</a> dictionary for the <a>payment method
           identifiers</a> in the <a>supportedMethods</a> member. This member is
           commonly used to add a discount or surcharge line item indicating the
@@ -1982,7 +2001,8 @@
           <a>payment method</a> that the user agent MAY display.
           <p class="note">
             It is the developer's responsibility to verify that the
-            <a>total</a> amount is the sum of the {{PaymentDetailsBase/displayItems}} and the
+            <a>total</a> amount is the sum of the
+            {{PaymentDetailsBase/displayItems}} and the
             <a>additionalDisplayItems</a>.
           </p>
         </dd>
@@ -2290,7 +2310,8 @@
             {{PaymentAddress}}.
             </li>
             <li>Set |address|.<a>[[\addressLine]]</a> to the empty frozen
-            array, and all other [=PaymentAddress slots|internal slots=] to the empty string.
+            array, and all other [=PaymentAddress slots|internal slots=] to the
+            empty string.
             </li>
             <li>If |details| was not passed, return |address|.
             </li>
@@ -2592,7 +2613,8 @@
           };
         </pre>
         <p>
-          An <a>AddressInit</a> is passed when [=PaymentAddress.PaymentAddress()|constructing=] a
+          An <a>AddressInit</a> is passed when
+          [=PaymentAddress.PaymentAddress()|constructing=] a
           {{PaymentAddress}}. Its members are as follows.
         </p>
         <dl data-dfn-for="AddressInit" data-link-for="" data-sort="ascending">
@@ -2904,8 +2926,8 @@
           |details|["<a>sortingCode</a>"] to the user-provided sorting code, or
           to the empty string if none was provided.
           </li>
-          <li>
-            [=PaymentAddress.PaymentAddress()|Internally construct a new `PaymentAddress`=] with |details| and return the result.
+          <li>[=PaymentAddress.PaymentAddress()|Internally construct a new
+          `PaymentAddress`=] with |details| and return the result.
           </li>
         </ol>
       </section>
@@ -2925,8 +2947,9 @@
       <p>
         The <a>PaymentShippingOption</a> dictionary has members describing a
         shipping option. Developers can provide the user with one or more
-        shipping options by calling the {{PaymentRequestUpdateEvent/updateWith()}} method in
-        response to a change event.
+        shipping options by calling the
+        {{PaymentRequestUpdateEvent/updateWith()}} method in response to a
+        change event.
       </p>
       <dl>
         <dt>
@@ -3098,9 +3121,10 @@
               "PaymentValidationErrors/retry-shows-error-member-manual.https.html">
               If |errorFields|["<a>paymentMethod</a>] member was passed, and if
               required by the specification that defines |response|'s
-              <a>payment method</a>, then [=converted to an IDL value|convert=] |errorFields|'s
-              <a>paymentMethod</a> member to an IDL value of the type specified
-              there. Otherwise, [=converted to an IDL value|convert=] to {{object}}.
+              <a>payment method</a>, then [=converted to an IDL value|convert=]
+              |errorFields|'s <a>paymentMethod</a> member to an IDL value of
+              the type specified there. Otherwise, [=converted to an IDL
+              value|convert=] to {{object}}.
               </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
@@ -3316,8 +3340,8 @@
         </h2>
         <p data-tests=
         "payment-response/shippingAddress-attribute-manual.https.html">
-          If the {{PaymentOptions/requestShipping}} member was set
-          to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
+          If the {{PaymentOptions/requestShipping}} member was set to true in
+          the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
           constructor, then {{PaymentRequest/shippingAddress}} will be the full
           and final shipping address chosen by the user.
         </p>
@@ -3328,11 +3352,11 @@
         </h2>
         <p data-tests=
         "payment-response/shippingOption-attribute-manual.https.html">
-          If the {{PaymentOptions/requestShipping}} member was set
-          to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
+          If the {{PaymentOptions/requestShipping}} member was set to true in
+          the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
           constructor, then {{PaymentRequest/shippingOption}} will be the
-          {{PaymentShippingOption/id}} attribute of the
-          selected shipping option.
+          {{PaymentShippingOption/id}} attribute of the selected shipping
+          option.
         </p>
       </section>
       <section>
@@ -3340,10 +3364,10 @@
           <dfn>payerName</dfn> attribute
         </h2>
         <p data-tests="payment-response/payerName-attribute-manual.https.html">
-          If the {{PaymentOptions/requestPayerName}} member was set
-          to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
-          constructor, then {{PaymentResponse/payerName}} will be the name provided
-          by the user.
+          If the {{PaymentOptions/requestPayerName}} member was set to true in
+          the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
+          constructor, then {{PaymentResponse/payerName}} will be the name
+          provided by the user.
         </p>
       </section>
       <section>
@@ -3352,10 +3376,10 @@
         </h2>
         <p data-tests=
         "payment-response/payerEmail-attribute-manual.https.html">
-          If the {{PaymentOptions/requestPayerEmail}} member was
-          set to true in the <a>PaymentOptions</a> passed to the
-          {{PaymentRequest}} constructor, then {{PaymentResponse/payerEmail}} will be the email address
-          chosen by the user.
+          If the {{PaymentOptions/requestPayerEmail}} member was set to true in
+          the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
+          constructor, then {{PaymentResponse/payerEmail}} will be the email
+          address chosen by the user.
         </p>
       </section>
       <section>
@@ -3364,10 +3388,10 @@
         </h2>
         <p data-tests=
         "payment-response/payerPhone-attribute-manual.https.html">
-          If the {{PaymentOptions/requestPayerPhone}} member was
-          set to true in the <a>PaymentOptions</a> passed to the
-          {{PaymentRequest}} constructor, then {{PaymentResponse/payerPhone}} will be the phone number
-          chosen by the user.
+          If the {{PaymentOptions/requestPayerPhone}} member was set to true in
+          the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
+          constructor, then {{PaymentResponse/payerPhone}} will be the phone
+          number chosen by the user.
         </p>
       </section>
       <section>
@@ -3375,7 +3399,8 @@
           <dfn>requestId</dfn> attribute
         </h2>
         <p data-tests="payment-response/requestId-attribute-manual.https.html">
-          The corresponding payment request {{PaymentRequest/id}} that spawned this payment response.
+          The corresponding payment request {{PaymentRequest/id}} that spawned
+          this payment response.
         </p>
       </section>
       <section data-dfn-for="PaymentResponse" data-link-for="PaymentResponse">
@@ -3685,12 +3710,12 @@
             {{MerchantValidationEvent}} |event|, are as follows:
           </p>
           <ol class="algorithm">
-            <li>Let |base:URL| be the [=context object|event=]’s
-            <a>relevant settings object</a>’s [=environment settings object/api
-            base URL=].
+            <li>Let |base:URL| be the [=context object|event=]’s <a>relevant
+            settings object</a>’s [=environment settings object/api base URL=].
             </li>
             <li data-link-for="MerchantValidationEventInit">Let
-            |validationURL:URL| be the result of [=URL parser|URL parsing=] |eventInitDict|["<a>validationURL</a>"] and |base|.
+            |validationURL:URL| be the result of [=URL parser|URL parsing=]
+            |eventInitDict|["<a>validationURL</a>"] and |base|.
             </li>
             <li>If |validationURL| is failure, throw a {{TypeError}}.
             </li>
@@ -3905,7 +3930,9 @@
           </h3>
           <p data-tests=
           "PaymentRequestUpdateEvent/constructor.https.html, PaymentRequestUpdateEvent/constructor.http.html">
-            The {{PaymentRequestUpdateEvent}}'s {{PaymentRequestUpdateEvent/constructor(type, eventInitDict)}} MUST act as follows:
+            The {{PaymentRequestUpdateEvent}}'s
+            {{PaymentRequestUpdateEvent/constructor(type, eventInitDict)}} MUST
+            act as follows:
           </p>
           <ol class="algorithm">
             <li>Let |event:PaymentRequestUpdateEvent| be the result of calling
@@ -4194,8 +4221,9 @@
                   element in the |paymentMethod| tuple.
                   </li>
                   <li>If required by the specification that defines the
-                  |identifier|, then [=converted to an IDL value|convert=] |data| to an IDL
-                  value. Otherwise, [=converted to an IDL value|convert=] to {{object}}.
+                  |identifier|, then [=converted to an IDL value|convert=]
+                  |data| to an IDL value. Otherwise, [=converted to an IDL
+                  value|convert=] to {{object}}.
                   </li>
                   <li>Let |handlers| be a <a>list</a> of registered <a>payment
                   handlers</a> that are authorized and can handle payment
@@ -4418,7 +4446,8 @@
                   </li>
                 </ol>
               </li>
-              <li>If |payer email| changed and |options|.{{PaymentOptions/requestPayerEmail}} is true:
+              <li>If |payer email| changed and
+              |options|.{{PaymentOptions/requestPayerEmail}} is true:
                 <ol>
                   <li>Set |response|'s <a>payerEmail</a> attribute to |payer
                   email|.
@@ -4478,10 +4507,10 @@
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then if the
-          {{PaymentRequest/shippingAddress}}
-          attribute of |request| is null or if the {{PaymentRequest/shippingOption}} attribute of
-          |request| is null, then terminate this algorithm and take no further
-          action. The <a>user agent</a> SHOULD ensure that this never occurs.
+          {{PaymentRequest/shippingAddress}} attribute of |request| is null or
+          if the {{PaymentRequest/shippingOption}} attribute of |request| is
+          null, then terminate this algorithm and take no further action. The
+          <a>user agent</a> SHOULD ensure that this never occurs.
           </li>
           <li>Let |isRetry:boolean| be true if |request|.<a>[[\response]]</a>
           is not null, false otherwise.
@@ -4497,8 +4526,8 @@
               </li>
               <li>Set |response|.<a>[[\complete]]</a> to false.
               </li>
-              <li>Set the {{PaymentResponse/requestId}}
-              attribute value of |response| to the value of
+              <li>Set the {{PaymentResponse/requestId}} attribute value of
+              |response| to the value of
               |request|.[=PaymentRequest/[[details]]=].{{PaymentDetailsInit/id}}.
               </li>
               <li>Set |request|.<a>[[\response]]</a> to |response|.
@@ -4508,18 +4537,17 @@
           <li>Let |handler:payment handler| be the <a>payment handler</a>
           selected by the user.
           </li>
-          <li>Set the {{PaymentResponse/methodName}}
-          attribute value of |response| to the <a>payment method identifier</a>
-          of |handler|.
+          <li>Set the {{PaymentResponse/methodName}} attribute value of
+          |response| to the <a>payment method identifier</a> of |handler|.
           </li>
-          <li>Set the {{PaymentResponse/details}}
-          attribute value of |response| to an object resulting from running the
-          |handler|'s <a>steps to respond to a payment request</a>.
+          <li>Set the {{PaymentResponse/details}} attribute value of |response|
+          to an object resulting from running the |handler|'s <a>steps to
+          respond to a payment request</a>.
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is false, then set the
-          {{PaymentResponse/shippingAddress}}
-          attribute value of |response| to null. Otherwise:
+          {{PaymentResponse/shippingAddress}} attribute value of |response| to
+          null. Otherwise:
             <ol data-link-for="PaymentResponse">
               <li>Let |redactList:list| be the empty <a>list</a>.
               </li>
@@ -4537,27 +4565,27 @@
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          {{PaymentResponse/shippingOption}}
-          attribute of |response| to the value of the {{PaymentResponse/shippingOption}} attribute of
+          {{PaymentResponse/shippingOption}} attribute of |response| to the
+          value of the {{PaymentResponse/shippingOption}} attribute of
           |request|. Otherwise, set it to null.
           </li>
           <li>If the {{PaymentOptions/requestPayerName}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          {{PaymentResponse/payerName}} attribute of
-          |response| to the payer's name provided by the user, or to null if
-          none was provided. Otherwise, set it to null.
+          {{PaymentResponse/payerName}} attribute of |response| to the payer's
+          name provided by the user, or to null if none was provided.
+          Otherwise, set it to null.
           </li>
           <li>If the {{PaymentOptions/requestPayerEmail}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          {{PaymentResponse/payerEmail}} attribute of
-          |response| to the payer's email address provided by the user, or to
-          null if none was provided. Otherwise, set it to null.
+          {{PaymentResponse/payerEmail}} attribute of |response| to the payer's
+          email address provided by the user, or to null if none was provided.
+          Otherwise, set it to null.
           </li>
           <li>If the {{PaymentOptions/requestPayerPhone}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          {{PaymentResponse/payerPhone}} attribute of
-          |response| to the payer's phone number provided by the user, or to
-          null if none was provided. When setting the {{PaymentResponse/payerPhone}} value, the user agent
+          {{PaymentResponse/payerPhone}} attribute of |response| to the payer's
+          phone number provided by the user, or to null if none was provided.
+          When setting the {{PaymentResponse/payerPhone}} value, the user agent
           SHOULD format the phone number to adhere to [[E.164]].
           </li>
           <li>Set |request|.<a>[[\state]]</a> to "<a>closed</a>".
@@ -4656,10 +4684,10 @@
           <li>
             <a>Upon fulfillment</a> of |detailsPromise| with value |value|:
             <ol data-link-for="PaymentDetailsBase">
-              <li>Let |details| be the result of [=converted to an IDL value|converting=] |value| to a
-              <a>PaymentDetailsUpdate</a> dictionary. If this
-              [=exception/throw=] an exception, <a>abort the update</a> with
-              |request| and with the thrown exception.
+              <li>Let |details| be the result of [=converted to an IDL
+              value|converting=] |value| to a <a>PaymentDetailsUpdate</a>
+              dictionary. If this [=exception/throw=] an exception, <a>abort
+              the update</a> with |request| and with the thrown exception.
               </li>
               <li>Let |serializedModifierData| be an empty list.
               </li>
@@ -4675,9 +4703,9 @@
                     <ol>
                       <li>
                         <a>Check and canonicalize total amount</a>
-                        |details|.<a>total</a>.{{PaymentItem/amount}}. If an exception is
-                        thrown, then <a>abort the update</a> with |request| and
-                        that exception.
+                        |details|.<a>total</a>.{{PaymentItem/amount}}. If an
+                        exception is thrown, then <a>abort the update</a> with
+                        |request| and that exception.
                       </li>
                     </ol>
                   </li>
@@ -4686,7 +4714,8 @@
                   |details|.<a>displayItems</a>:
                     <ol>
                       <li>
-                        <a>Check and canonicalize amount</a> |item|.{{PaymentItem/amount}}. If an exception is
+                        <a>Check and canonicalize amount</a>
+                        |item|.{{PaymentItem/amount}}. If an exception is
                         thrown, then <a>abort the update</a> with |request| and
                         that exception.
                       </li>
@@ -4694,8 +4723,8 @@
                   </li>
                   <li>If the <a>shippingOptions</a> member of |details| is
                   present, and
-                  |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}} is true,
-                  then:
+                  |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}}
+                  is true, then:
                     <ol>
                       <li>Let |seenIDs| be an empty set.
                       </li>
@@ -4710,11 +4739,12 @@
                           </li>
                           <li data-tests=
                           "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
-                          If |seenIDs|[|option|.{{PaymentShippingOption/id}] exists, then
-                          <a>abort the update</a> with |request| and a
-                          {{TypeError}}.
+                          If |seenIDs|[|option|.{{PaymentShippingOption/id}]
+                          exists, then <a>abort the update</a> with |request|
+                          and a {{TypeError}}.
                           </li>
-                          <li>Append |option|.{{PaymentShippingOption/id}} to |seenIDs|.
+                          <li>Append |option|.{{PaymentShippingOption/id}} to
+                          |seenIDs|.
                           </li>
                           <li>Append |option| to |shippingOptions|.
                           </li>
@@ -4740,7 +4770,8 @@
                           <li data-tests=
                           "updateWith-method-pmi-handling-manual.https.html">
                           Run the steps to <a>validate a payment method
-                          identifier</a> with |modifier|.{{PaymentDetailsModifier/supportedMethods}}.
+                          identifier</a> with
+                          |modifier|.{{PaymentDetailsModifier/supportedMethods}}.
                           If it returns false, then <a>abort the update</a>
                           with |request| and a {{RangeError}} exception.
                           Optionally, inform the developer that the payment
@@ -4751,8 +4782,8 @@
                             <ol>
                               <li>
                                 <a>Check and canonicalize total amount</a>
-                                |modifier|.<a>total</a>.{{PaymentItem/amount}}. If an
-                                exception is thrown, then <a>abort the
+                                |modifier|.<a>total</a>.{{PaymentItem/amount}}.
+                                If an exception is thrown, then <a>abort the
                                 update</a> with |request| and that exception.
                               </li>
                             </ol>
@@ -4764,24 +4795,25 @@
                             <ol>
                               <li>
                                 <a>Check and canonicalize amount</a>
-                                |item|.{{PaymentItem/amount}}. If an
-                                exception is thrown, then <a>abort the
-                                update</a> with |request| and that exception.
+                                |item|.{{PaymentItem/amount}}. If an exception
+                                is thrown, then <a>abort the update</a> with
+                                |request| and that exception.
                               </li>
                             </ol>
                           </li>
-                          <li>If the {{PaymentDetailsModifier/data}} member of |modifier| is missing, let
-                            |serializedData| be null. Otherwise, let
-                            |serializedData| be the result of
-                            <a>JSON-serializing</a> |modifier|.{{PaymentDetailsModifier/data}} into a
+                          <li>If the {{PaymentDetailsModifier/data}} member of
+                          |modifier| is missing, let |serializedData| be null.
+                          Otherwise, let |serializedData| be the result of <a>
+                            JSON-serializing</a>
+                            |modifier|.{{PaymentDetailsModifier/data}} into a
                             string. If <a>JSON-serializing</a> throws an
                             exception, then <a>abort the update</a> with
                             |request| and that exception.
                           </li>
                           <li>Add |serializedData| to |serializedModifierData|.
                           </li>
-                          <li>Remove the {{PaymentDetailsModifier/data}} member of
-                          |modifier|, if it is present.
+                          <li>Remove the {{PaymentDetailsModifier/data}} member
+                          of |modifier|, if it is present.
                           </li>
                         </ol>
                       </li>
@@ -4827,15 +4859,16 @@
                   </li>
                   <li>If the <a>shippingOptions</a> member of |details| is
                   present, and
-                  |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}} is true,
-                  then:
+                  |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}}
+                  is true, then:
                     <ol>
                       <li>Set
                       |request|.[=PaymentRequest/[[details]]=].<a>shippingOptions</a>
                       to |shippingOptions|.
                       </li>
-                      <li>Set the value of |request|'s {{PaymentRequest/shippingOption}}
-                      attribute to |selectedShippingOption|.
+                      <li>Set the value of |request|'s
+                      {{PaymentRequest/shippingOption}} attribute to
+                      |selectedShippingOption|.
                       </li>
                     </ol>
                   </li>
@@ -4854,24 +4887,27 @@
                   </li>
                   <li>
                     <p>
-                      If |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}} is
-                      true, and
+                      If
+                      |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}}
+                      is true, and
                       |request|.[=PaymentRequest/[[details]]=].<a>shippingOptions</a>
                       is empty, then the developer has signified that there are
                       no valid shipping options for the currently-chosen
-                      shipping address (given by |request|'s {{PaymentRequest/shippingAddress}}).
+                      shipping address (given by |request|'s
+                      {{PaymentRequest/shippingAddress}}).
                     </p>
                     <p>
                       In this case, the user agent SHOULD display an error
                       indicating this, and MAY indicate that the
                       currently-chosen shipping address is invalid in some way.
-                      The user agent SHOULD use the {{PaymentDetailsUpdate/error}} member of
-                      |details|, if it is present, to give more information
-                      about why there are no valid shipping options for that
-                      address.
+                      The user agent SHOULD use the
+                      {{PaymentDetailsUpdate/error}} member of |details|, if it
+                      is present, to give more information about why there are
+                      no valid shipping options for that address.
                     </p>
                     <p>
-                      Further, if |details|["{{PaymentDetailsUpdate/shippingAddressErrors}}"]
+                      Further, if
+                      |details|["{{PaymentDetailsUpdate/shippingAddressErrors}}"]
                       member is present, the user agent SHOULD display an error
                       specifically for each erroneous field of the shipping
                       address. This is done by matching each present member of
@@ -4882,10 +4918,9 @@
                       Similarly, if |details|["<a>payerErrors</a>"] member is
                       present and |request|.[=PaymentRequest/[[options]]=]'s
                       {{PaymentOptions/requestPayerName}},
-                      {{PaymentOptions/requestPayerEmail}},
-                      or {{PaymentOptions/requestPayerPhone}}
-                      is true, then display an error specifically for each
-                      erroneous field.
+                      {{PaymentOptions/requestPayerEmail}}, or
+                      {{PaymentOptions/requestPayerPhone}} is true, then
+                      display an error specifically for each erroneous field.
                     </p>
                     <p data-link-for="PaymentDetailsUpdate">
                       Likewise, if |details|["<a>paymentMethodErrors</a>"] is
@@ -5139,10 +5174,10 @@
           a developer (e.g., the shipping address) without user consent.
         </p>
         <p>
-          The <a>user agent</a> MUST NOT share the values of the {{PaymentDetailsBase/displayItems}} member or
-          {{PaymentDetailsModifier/additionalDisplayItems}}
-          member with a third-party <a>payment handler</a> without user
-          consent.
+          The <a>user agent</a> MUST NOT share the values of the
+          {{PaymentDetailsBase/displayItems}} member or
+          {{PaymentDetailsModifier/additionalDisplayItems}} member with a
+          third-party <a>payment handler</a> without user consent.
         </p>
         <p>
           The {{PaymentMethodChangeEvent}} enables the payee to update the

--- a/index.html
+++ b/index.html
@@ -1796,14 +1796,12 @@
             </p>
             <p data-tests=
             "change-shipping-option-select-last-manual.https.html">
-              If an item in the sequence has the <a data-lt=
-              "PaymentShippingOption.selected">selected</a> member set to true,
-              then this is the shipping option that will be used by default and
-              <a data-lt="PaymentRequest.shippingOption">shippingOption</a>
-              will be set to the <a data-lt="PaymentShippingOption.id">id</a>
+              If an item in the sequence has the {{PaymentShippingOption/selected}} member set to true,
+              then this is the shipping option that will be used by default and <a data-lt="PaymentRequest.shippingOption">shippingOption</a>
+              will be set to the {{PaymentShippingOption/id}}
               of this option without running the <a>shipping option changed
               algorithm</a>. If more than one item in the sequence has
-              <a data-lt="PaymentShippingOption.selected">selected</a> set to
+              {{PaymentShippingOption/selected}} set to
               true, then the <a>user agent</a> selects the last one in the
               sequence.
             </p>
@@ -1814,8 +1812,7 @@
               set to true.
             </p>
             <aside class="note">
-              If the sequence has an item with the <a data-lt=
-              "PaymentShippingOption.selected">selected</a> member set to true,
+              If the sequence has an item with the {{PaymentShippingOption/selected}} member set to true,
               then authors are responsible for ensuring that the <a data-lt=
               "PaymentDetailsInit.total">total</a> member includes the cost of
               the shipping option. This is because no
@@ -3366,7 +3363,7 @@
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
           constructor, then <a data-lt=
           "PaymentRequest.shippingOption">shippingOption</a> will be the
-          <a data-lt="PaymentShippingOption.id">id</a> attribute of the
+          {{PaymentShippingOption/id}} attribute of the
           selected shipping option.
         </p>
       </section>
@@ -4769,28 +4766,23 @@
                         <ol>
                           <li>
                             <a>Check and canonicalize amount</a>
-                            |option|.<a data-lt=
-                            "PaymentShippingOption.amount">amount</a>. If an
+                            |option|.{{PaymentShippingOption/amount}}. If an
                             exception is thrown, then <a>abort the update</a>
                             with |request| and that exception.
                           </li>
                           <li data-tests=
                           "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
-                          If |seenIDs|[|option|.<a data-lt=
-                          "PaymentShippingOption.id">id</a>] exists, then
+                          If |seenIDs|[|option|.{{PaymentShippingOption/id}] exists, then
                           <a>abort the update</a> with |request| and a
                           {{TypeError}}.
                           </li>
-                          <li>Append |option|.<a data-lt=
-                          "PaymentShippingOption.id">id</a> to |seenIDs|.
+                          <li>Append |option|.{{PaymentShippingOption/id}} to |seenIDs|.
                           </li>
                           <li>Append |option| to |shippingOptions|.
                           </li>
-                          <li>If |option|.<a data-lt=
-                          "PaymentShippingOption.selected">selected</a> is
+                          <li>If |option|.{{PaymentShippingOption/selected}} is
                           true, then set |selectedShippingOption| to
-                          |option|.<a data-lt=
-                          "PaymentShippingOption.id">id</a>.
+                          |option|.{{PaymentShippingOption/id}}.
                           </li>
                         </ol>
                       </li>

--- a/index.html
+++ b/index.html
@@ -1869,8 +1869,7 @@
             <aside class="note">
               Algorithms in this specification that accept a
               <a>PaymentDetailsInit</a> dictionary will throw if the
-              <a>total</a>.{{PaymentItem/amount}}.<a data-lt=
-              "PaymentCurrencyAmount.value">value</a> is a negative number.
+              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}} is a negative number.
             </aside>
           </dd>
         </dl>
@@ -1923,8 +1922,7 @@
             <p class="note">
               Algorithms in this specification that accept a
               <a>PaymentDetailsUpdate</a> dictionary will throw if the
-              <a>total</a>.{{PaymentItem/amount}}.<a data-lt=
-              "PaymentCurrencyAmount.value">value</a> is a negative number.
+              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}} is a negative number.
             </p>
           </dd>
           <dt>

--- a/index.html
+++ b/index.html
@@ -730,7 +730,7 @@
                       </li>
                       <li>
                         <p>
-                          <a data-lt="converted to an IDL value">Convert</a>
+                          [=converted to an IDL value|Convert=]
                           |object| to an IDL value of the type specified by the
                           specification that defines the
                           |paymentMethod|.<a>supportedMethods</a> (e.g.,
@@ -1019,10 +1019,8 @@
               in the |paymentMethod| tuple.
               </li>
               <li data-cite="WebIDL infra">If required by the specification
-              that defines the |identifier|, then <a data-lt=
-              "converted to an IDL value">convert</a> |data| to an IDL value of
-              the type specified there. Otherwise, <a data-lt=
-              "converted to an IDL value">convert</a> to {{object}}.
+              that defines the |identifier|, then [=converted to an IDL value|convert=] |data| to an IDL value of
+              the type specified there. Otherwise, [=converted to an IDL value|convert=] to {{object}}.
               </li>
               <li>If conversion results in an <a>exception</a> |error|:
                 <ol>
@@ -1122,7 +1120,7 @@
           </li>
           <li>
             <p>
-              Pass the <a data-lt="converted to an IDL value">converted</a>
+              Pass the [=converted to an IDL value|converted=]
               second element in the |paymentMethod| tuple and |modifiers|.
               Optionally, the user agent SHOULD send the appropriate data from
               |request| to the user-selected <a>payment handler</a> in order to
@@ -3107,11 +3105,9 @@
               "PaymentValidationErrors/retry-shows-error-member-manual.https.html">
               If |errorFields|["<a>paymentMethod</a>] member was passed, and if
               required by the specification that defines |response|'s
-              <a>payment method</a>, then <a data-lt=
-              "converted to an IDL value">convert</a> |errorFields|'s
+              <a>payment method</a>, then [=converted to an IDL value|convert=] |errorFields|'s
               <a>paymentMethod</a> member to an IDL value of the type specified
-              there. Otherwise, <a data-lt=
-              "converted to an IDL value">convert</a> to {{object}}.
+              there. Otherwise, [=converted to an IDL value|convert=] to {{object}}.
               </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
@@ -4211,10 +4207,8 @@
                   element in the |paymentMethod| tuple.
                   </li>
                   <li>If required by the specification that defines the
-                  |identifier|, then <a data-lt=
-                  "converted to an IDL value">convert</a> |data| to an IDL
-                  value. Otherwise, <a data-lt=
-                  "converted to an IDL value">convert</a> to {{object}}.
+                  |identifier|, then [=converted to an IDL value|convert=] |data| to an IDL
+                  value. Otherwise, [=converted to an IDL value|convert=] to {{object}}.
                   </li>
                   <li>Let |handlers| be a <a>list</a> of registered <a>payment
                   handlers</a> that are authorized and can handle payment
@@ -4675,8 +4669,7 @@
           <li>
             <a>Upon fulfillment</a> of |detailsPromise| with value |value|:
             <ol data-link-for="PaymentDetailsBase">
-              <li>Let |details| be the result of <a data-lt=
-              "converted to an IDL value">converting</a> |value| to a
+              <li>Let |details| be the result of [=converted to an IDL value|converting=] |value| to a
               <a>PaymentDetailsUpdate</a> dictionary. If this
               [=exception/throw=] an exception, <a>abort the update</a> with
               |request| and with the thrown exception.
@@ -4814,7 +4807,7 @@
               not null:
                 <ol>
                   <li>If required by the specification that defines the |pmi|,
-                  then <a data-lt="converted to an IDL value">convert</a>
+                  then [=converted to an IDL value|convert=]
                   <a>paymentMethodErrors</a> to an IDL value.
                   </li>
                   <li>If conversion results in a <a>exception</a> |error|, <a>

--- a/index.html
+++ b/index.html
@@ -1462,8 +1462,7 @@
             <td>
               The current <a>PaymentDetailsBase</a> for the payment request
               initially supplied to the constructor and then updated with calls
-              to <a data-lt=
-              "PaymentRequestUpdateEvent.updateWith">updateWith()</a>. Note
+              to {{PaymentRequestUpdateEvent/updateWith()}}. Note
               that all {{PaymentDetailsModifier/data}}
               members of <a>PaymentDetailsModifier</a> instances contained in
               the {{PaymentDetailsBase/modifiers}}
@@ -1536,8 +1535,8 @@
               <dfn>[[\updating]]</dfn>
             </td>
             <td>
-              True if there is a pending <a data-lt=
-              "PaymentRequestUpdateEvent.updateWith">updateWith()</a> call to
+              True if there is a pending
+              {{PaymentRequestUpdateEvent/updateWith()}} call to
               update the payment request and false otherwise.
             </td>
           </tr>
@@ -1883,8 +1882,7 @@
         </pre>
         <p>
           The <a>PaymentDetailsUpdate</a> dictionary is used to update the
-          payment request using <a data-lt=
-          "PaymentRequestUpdateEvent.updateWith">updateWith()</a>.
+          payment request using {{PaymentRequestUpdateEvent/updateWith()}}.
         </p>
         <p>
           In addition to the members inherited from the
@@ -1899,7 +1897,7 @@
             A human-readable string that explains why goods cannot be shipped
             to the chosen shipping address, or any other reason why no shipping
             options are available. When the payment request is updated using
-            <a data-lt="PaymentRequestUpdateEvent.updateWith">updateWith()</a>,
+            {{PaymentRequestUpdateEvent/updateWith()}},
             the <a>PaymentDetailsUpdate</a> can contain a message in the
             <a>error</a> member that will be displayed to the user if the
             <a>PaymentDetailsUpdate</a> indicates that there are no valid {{PaymentDetailsBase/shippingOptions}}
@@ -2936,8 +2934,7 @@
       <p>
         The <a>PaymentShippingOption</a> dictionary has members describing a
         shipping option. Developers can provide the user with one or more
-        shipping options by calling the <a data-lt=
-        "PaymentRequestUpdateEvent.updateWith">updateWith()</a> method in
+        shipping options by calling the {{PaymentRequestUpdateEvent/updateWith()}} method in
         response to a change event.
       </p>
       <dl>

--- a/index.html
+++ b/index.html
@@ -644,7 +644,7 @@
         <p data-link-for="PaymentRequest">
           The <a>shippingAddress</a>, <a>shippingOption</a>, and
           <a>shippingType</a> attributes are populated during processing if the
-          <a data-lt="PaymentOptions.requestShipping">requestShipping</a>
+          {{PaymentOptions/requestShipping}}
           member is set.
         </p>
       </div>
@@ -772,8 +772,7 @@
           </li>
           <li>Let |selectedShippingOption| be null.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> member of
+          <li>If the {{PaymentOptions/requestShipping}} member of
           |options| is present and set to true, process shipping options:
             <ol>
               <li>Let |options:PaymentShippingOption| be an empty
@@ -892,12 +891,10 @@
           <li>Set the value of the <a data-lt="PaymentRequest.shippingAddress">
             shippingAddress</a> attribute on |request| to null.
           </li>
-          <li>If |options|.<a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> is set to true,
+          <li>If |options|.{{PaymentOptions/requestShipping}} is set to true,
           then set the value of the <a data-lt=
           "PaymentRequest.shippingType">shippingType</a> attribute on |request|
-          to |options|.<a data-lt=
-          "PaymentOptions.shippingType">shippingType</a>. Otherwise, set it to
+          to |options|.{{PaymentOptions/shippingType}}. Otherwise, set it to
           null.
           </li>
           <li>Return |request|.
@@ -1362,8 +1359,7 @@
           <a>PaymentShippingType</a> enum value, or null if none is provided by
           the developer during <a data-lt=
           "PaymentRequest.PaymentRequest()">construction</a> (see
-          <a>PaymentOptions</a>'s <a data-lt=
-          "PaymentOptions.shippingType">shippingType</a> member).
+          <a>PaymentOptions</a>'s {{PaymentOptions/shippingType}} member).
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
@@ -1806,7 +1802,7 @@
             <p>
               The <a>shippingOptions</a> member is only used if the
               {{PaymentRequest}} was constructed with <a>PaymentOptions</a> and
-              <a data-lt="PaymentOptions.requestShipping">requestShipping</a>
+              {{PaymentOptions/requestShipping}}
               set to true.
             </p>
             <aside class="note">
@@ -1910,8 +1906,7 @@
             the <a>PaymentDetailsUpdate</a> can contain a message in the
             <a>error</a> member that will be displayed to the user if the
             <a>PaymentDetailsUpdate</a> indicates that there are no valid {{PaymentDetailsBase/shippingOptions}}
-            (and the {{PaymentRequest}} was constructed with the <a data-lt=
-            "PaymentOptions.requestShipping">requestShipping</a> option set to
+            (and the {{PaymentRequest}} was constructed with the {{PaymentOptions/requestShipping}} option set to
             true).
           </dd>
           <dt>
@@ -3338,8 +3333,7 @@
         </h2>
         <p data-tests=
         "payment-response/shippingAddress-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> member was set
+          If the {{PaymentOptions/requestShipping}} member was set
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
           constructor, then <a data-lt=
           "PaymentRequest.shippingAddress">shippingAddress</a> will be the full
@@ -3352,8 +3346,7 @@
         </h2>
         <p data-tests=
         "payment-response/shippingOption-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> member was set
+          If the {{PaymentOptions/requestShipping}} member was set
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
           constructor, then <a data-lt=
           "PaymentRequest.shippingOption">shippingOption</a> will be the
@@ -3366,8 +3359,7 @@
           <dfn>payerName</dfn> attribute
         </h2>
         <p data-tests="payment-response/payerName-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestPayerName">requestPayerName</a> member was set
+          If the {{PaymentOptions/requestPayerName}} member was set
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
           constructor, then <a data-lt=
           "PaymentResponse.payerName">payerName</a> will be the name provided
@@ -3380,8 +3372,7 @@
         </h2>
         <p data-tests=
         "payment-response/payerEmail-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestPayerEmail">requestPayerEmail</a> member was
+          If the {{PaymentOptions/requestPayerEmail}} member was
           set to true in the <a>PaymentOptions</a> passed to the
           {{PaymentRequest}} constructor, then <a data-lt=
           "PaymentResponse.payerEmail">payerEmail</a> will be the email address
@@ -3394,8 +3385,7 @@
         </h2>
         <p data-tests=
         "payment-response/payerPhone-attribute-manual.https.html">
-          If the <a data-lt=
-          "PaymentOptions.requestPayerPhone">requestPayerPhone</a> member was
+          If the {{PaymentOptions/requestPayerPhone}} member was
           set to true in the <a>PaymentOptions</a> passed to the
           {{PaymentRequest}} constructor, then <a data-lt=
           "PaymentResponse.payerPhone">payerPhone</a> will be the phone number
@@ -4461,8 +4451,7 @@
                   </li>
                 </ol>
               </li>
-              <li>If |payer email| changed and |options|.<a data-link-for=
-              "PaymentOptions">requestPayerEmail</a> is true:
+              <li>If |payer email| changed and |options|.{{PaymentOptions/requestPayerEmail}} is true:
                 <ol>
                   <li>Set |response|'s <a>payerEmail</a> attribute to |payer
                   email|.
@@ -4520,9 +4509,7 @@
           terminate this algorithm and take no further action. The <a>user
           agent</a> user interface SHOULD ensure that this never occurs.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> value of
-          |request|.[=PaymentRequest/[[options]]=] is true, then if the
+          <li>If the {{PaymentOptions/requestShipping}} value of
           <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
           attribute of |request| is null or if the <a data-lt=
           "PaymentRequest.shippingOption">shippingOption</a> attribute of
@@ -4562,8 +4549,7 @@
           attribute value of |response| to an object resulting from running the
           |handler|'s <a>steps to respond to a payment request</a>.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> value of
+          <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is false, then set the
           <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
           attribute value of |response| to null. Otherwise:
@@ -4582,30 +4568,26 @@
               </li>
             </ol>
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestShipping">requestShipping</a> value of
+          <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
           <a data-lt="PaymentResponse.shippingOption">shippingOption</a>
           attribute of |response| to the value of the <a data-lt=
           "PaymentRequest.shippingOption">shippingOption</a> attribute of
           |request|. Otherwise, set it to null.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestPayerName">requestPayerName</a> value of
+          <li>If the {{PaymentOptions/requestPayerName}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
           <a data-lt="PaymentResponse.payerName">payerName</a> attribute of
           |response| to the payer's name provided by the user, or to null if
           none was provided. Otherwise, set it to null.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestPayerEmail">requestPayerEmail</a> value of
+          <li>If the {{PaymentOptions/requestPayerEmail}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
           <a data-lt="PaymentResponse.payerEmail">payerEmail</a> attribute of
           |response| to the payer's email address provided by the user, or to
           null if none was provided. Otherwise, set it to null.
           </li>
-          <li>If the <a data-lt=
-          "PaymentOptions.requestPayerPhone">requestPayerPhone</a> value of
+          <li>If the {{PaymentOptions/requestPayerPhone}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
           <a data-lt="PaymentResponse.payerPhone">payerPhone</a> attribute of
           |response| to the payer's phone number provided by the user, or to
@@ -4748,8 +4730,7 @@
                   </li>
                   <li>If the <a>shippingOptions</a> member of |details| is
                   present, and
-                  |request|.[=PaymentRequest/[[options]]=].<a data-lt=
-                  "PaymentOptions.requestShipping">requestShipping</a> is true,
+                  |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}} is true,
                   then:
                     <ol>
                       <li>Let |seenIDs| be an empty set.
@@ -4882,8 +4863,7 @@
                   </li>
                   <li>If the <a>shippingOptions</a> member of |details| is
                   present, and
-                  |request|.[=PaymentRequest/[[options]]=].<a data-lt=
-                  "PaymentOptions.requestShipping">requestShipping</a> is true,
+                  |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}} is true,
                   then:
                     <ol>
                       <li>Set
@@ -4911,8 +4891,7 @@
                   </li>
                   <li>
                     <p>
-                      If |request|.[=PaymentRequest/[[options]]=].<a data-lt=
-                      "PaymentOptions.requestShipping">requestShipping</a> is
+                      If |request|.[=PaymentRequest/[[options]]=].{{PaymentOptions/requestShipping}} is
                       true, and
                       |request|.[=PaymentRequest/[[details]]=].<a>shippingOptions</a>
                       is empty, then the developer has signified that there are
@@ -4942,12 +4921,9 @@
                     <p data-link-for="PaymentDetailsUpdate">
                       Similarly, if |details|["<a>payerErrors</a>"] member is
                       present and |request|.[=PaymentRequest/[[options]]=]'s
-                      <a data-lt=
-                      "PaymentOptions.requestPayerName">requestPayerName</a>,
-                      <a data-lt=
-                      "PaymentOptions.requestPayerEmail">requestPayerEmail</a>,
-                      or <a data-lt=
-                      "PaymentOptions.requestPayerPhone">requestPayerPhone</a>
+                      {{PaymentOptions/requestPayerName}},
+                      {{PaymentOptions/requestPayerEmail}},
+                      or {{PaymentOptions/requestPayerPhone}}
                       is true, then display an error specifically for each
                       erroneous field.
                     </p>

--- a/index.html
+++ b/index.html
@@ -827,24 +827,21 @@
                   </li>
                   <li>For each |modifier| of |modifiers|:
                     <ol>
-                      <li>If the <a data-lt=
-                      "PaymentDetailsModifier.total">total</a> member of
+                      <li>If the {{PaymentDetailsModifier/total}}
+                      member of
                       |modifier| is present, then:
                         <ol>
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
                             <a>Check and canonicalize total amount</a>
-                            |modifier|.<a data-lt=
-                            "PaymentDetailsModifier.total">total</a>.<a data-lt="PaymentItem.amount">amount</a>.
+                            |modifier|.{{PaymentDetailsModifier/total}}.<a data-lt="PaymentItem.amount">amount</a>.
                             Rethrow any exceptions.
                           </li>
                         </ol>
                       </li>
-                      <li>If the <a data-lt=
-                      "PaymentDetailsModifier.additionalDisplayItems">additionalDisplayItems</a>
+                      <li>If the {{PaymentDetailsModifier/additionalDisplayItems}}
                       member of |modifier| is present, then for each |item| of
-                      |modifier|.<a data-lt=
-                      "PaymentDetailsModifier.additionalDisplayItems">additionalDisplayItems</a>:
+                      |modifier|.{{PaymentDetailsModifier/additionalDisplayItems}}:
                         <ol>
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
@@ -854,20 +851,16 @@
                           </li>
                         </ol>
                       </li>
-                      <li>If the <a data-lt=
-                      "PaymentDetailsModifier.data">data</a> member of
+                      <li>If the {{PaymentDetailsModifier/data}} member of
                       |modifier| is missing, let |serializedData| be null.
                       Otherwise, let |serializedData| be the result of
-                      <a>JSON-serializing</a> |modifier|.<a data-lt=
-                      "PaymentDetailsModifier.data">data</a> into a string.
+                      <a>JSON-serializing</a> |modifier|.{{PaymentDetailsModifier/data}} into a string.
                       Rethrow any exceptions.
                       </li>
-                      <li>Add the tuple (|modifier|.<a data-lt=
-                      "PaymentDetailsModifier.supportedMethods">supportedMethods</a>,
+                      <li>Add the tuple (|modifier|.{{PaymentDetailsModifier/supportedMethods}},
                       |serializedData|) to |serializedModifierData|.
                       </li>
-                      <li>Remove the <a data-lt="PaymentDetailsModifier.data">
-                        data</a> member of |modifier|, if it is present.
+                      <li>Remove the {{PaymentDetailsModifier/data}} member of |modifier|, if it is present.
                       </li>
                     </ol>
                   </li>
@@ -1465,8 +1458,7 @@
               "PaymentRequest">[[\serializedModifierData]]</dfn>
             </td>
             <td>
-              A list containing the serialized string form of each <a data-lt=
-              "PaymentDetailsModifier.data">data</a> member for each
+              A list containing the serialized string form of each {{PaymentDetailsModifier/data}} member for each
               corresponding item in the sequence
               [=PaymentRequest/[[details]]=].<a data-lt=
               "PaymentDetailsBase">modifier</a>, or null if no such member was
@@ -1483,7 +1475,7 @@
               initially supplied to the constructor and then updated with calls
               to <a data-lt=
               "PaymentRequestUpdateEvent.updateWith">updateWith()</a>. Note
-              that all <a data-lt="PaymentDetailsModifier.data">data</a>
+              that all {{PaymentDetailsModifier/data}}
               members of <a>PaymentDetailsModifier</a> instances contained in
               the {{PaymentDetailsBase/modifiers}}
               member will be removed, as they are instead stored in serialized
@@ -4826,8 +4818,7 @@
                           <li data-tests=
                           "updateWith-method-pmi-handling-manual.https.html">
                           Run the steps to <a>validate a payment method
-                          identifier</a> with |modifier|.<a data-lt=
-                          "PaymentDetailsModifier.supportedMethods">supportedMethods</a>.
+                          identifier</a> with |modifier|.{{PaymentDetailsModifier/supportedMethods}}.
                           If it returns false, then <a>abort the update</a>
                           with |request| and a {{RangeError}} exception.
                           Optionally, inform the developer that the payment
@@ -4859,20 +4850,17 @@
                               </li>
                             </ol>
                           </li>
-                          <li>If the <a data-lt="PaymentDetailsModifier.data">
-                            data</a> member of |modifier| is missing, let
+                          <li>If the {{PaymentDetailsModifier/data}} member of |modifier| is missing, let
                             |serializedData| be null. Otherwise, let
                             |serializedData| be the result of
-                            <a>JSON-serializing</a> |modifier|.<a data-lt=
-                            "PaymentDetailsModifier.data">data</a> into a
+                            <a>JSON-serializing</a> |modifier|.{{PaymentDetailsModifier/data}} into a
                             string. If <a>JSON-serializing</a> throws an
                             exception, then <a>abort the update</a> with
                             |request| and that exception.
                           </li>
                           <li>Add |serializedData| to |serializedModifierData|.
                           </li>
-                          <li>Remove the <a data-lt=
-                          "PaymentDetailsModifier.data">data</a> member of
+                          <li>Remove the {{PaymentDetailsModifier/data}} member of
                           |modifier|, if it is present.
                           </li>
                         </ol>
@@ -5241,8 +5229,7 @@
         </p>
         <p>
           The <a>user agent</a> MUST NOT share the values of the {{PaymentDetailsBase/displayItems}} member or
-          <a data-lt=
-          "PaymentDetailsModifier.additionalDisplayItems">additionalDisplayItems</a>
+          {{PaymentDetailsModifier/additionalDisplayItems}}
           member with a third-party <a>payment handler</a> without user
           consent.
         </p>

--- a/index.html
+++ b/index.html
@@ -1802,7 +1802,7 @@
               sequence.
             </p>
             <p>
-              The <a>shippingOptions</a> member is only used if the
+              The {{PaymentOptions/shippingOptions}} member is only used if the
               {{PaymentRequest}} was constructed with {{PaymentOptions}} and
               {{PaymentOptions/requestShipping}} set to true.
             </p>
@@ -1868,7 +1868,7 @@
             <aside class="note">
               Algorithms in this specification that accept a
               {{PaymentDetailsInit}} dictionary will throw if the
-              <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}}
+              {{PaymentDetailsInit/total}}.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}}
               is a negative number.
             </aside>
           </dd>

--- a/index.html
+++ b/index.html
@@ -811,8 +811,7 @@
                   </li>
                 </ol>
               </li>
-              <li>Set |details|.<a data-lt=
-              "PaymentDetailsBase.shippingOptions">shippingOptions</a> to
+              <li>Set |details|.{{PaymentDetailsBase/shippingOptions}} to
               |options|.
               </li>
             </ol>
@@ -877,8 +876,7 @@
                   </li>
                 </ol>
               </li>
-              <li>Set |details|.<a data-lt=
-              "PaymentDetailsBase.modifiers">modifiers</a> to |modifiers|.
+              <li>Set |details|.{{PaymentDetailsBase/modifiers}} to |modifiers|.
               </li>
             </ol>
           </li>
@@ -1490,7 +1488,7 @@
               "PaymentRequestUpdateEvent.updateWith">updateWith()</a>. Note
               that all <a data-lt="PaymentDetailsModifier.data">data</a>
               members of <a>PaymentDetailsModifier</a> instances contained in
-              the <a data-lt="PaymentDetailsBase.modifiers">modifiers</a>
+              the {{PaymentDetailsBase/modifiers}}
               member will be removed, as they are instead stored in serialized
               form in the [=PaymentRequest/[[serializedModifierData]]=]
               internal slot.
@@ -1933,8 +1931,7 @@
             <a data-lt="PaymentRequestUpdateEvent.updateWith">updateWith()</a>,
             the <a>PaymentDetailsUpdate</a> can contain a message in the
             <a>error</a> member that will be displayed to the user if the
-            <a>PaymentDetailsUpdate</a> indicates that there are no valid
-            <a data-lt="PaymentDetailsBase.shippingOptions">shippingOptions</a>
+            <a>PaymentDetailsUpdate</a> indicates that there are no valid {{PaymentDetailsBase/shippingOptions}}
             (and the {{PaymentRequest}} was constructed with the <a data-lt=
             "PaymentOptions.requestShipping">requestShipping</a> option set to
             true).
@@ -2019,8 +2016,7 @@
         </dt>
         <dd>
           A sequence of <a>PaymentItem</a> dictionaries provides additional
-          display items that are appended to the <a data-lt=
-          "PaymentDetailsBase.displayItems">displayItems</a> member in the
+          display items that are appended to the {{PaymentDetailsBase/displayItems}} member in the
           <a>PaymentDetailsBase</a> dictionary for the <a>payment method
           identifiers</a> in the <a>supportedMethods</a> member. This member is
           commonly used to add a discount or surcharge line item indicating the
@@ -2028,8 +2024,7 @@
           <a>payment method</a> that the user agent MAY display.
           <p class="note">
             It is the developer's responsibility to verify that the
-            <a>total</a> amount is the sum of the <a data-lt=
-            "PaymentDetailsBase.displayItems">displayItems</a> and the
+            <a>total</a> amount is the sum of the {{PaymentDetailsBase/displayItems}} and the
             <a>additionalDisplayItems</a>.
           </p>
         </dd>
@@ -5248,8 +5243,7 @@
           a developer (e.g., the shipping address) without user consent.
         </p>
         <p>
-          The <a>user agent</a> MUST NOT share the values of the <a data-lt=
-          "PaymentDetailsBase.displayItems">displayItems</a> member or
+          The <a>user agent</a> MUST NOT share the values of the {{PaymentDetailsBase/displayItems}} member or
           <a data-lt=
           "PaymentDetailsModifier.additionalDisplayItems">additionalDisplayItems</a>
           member with a third-party <a>payment handler</a> without user

--- a/index.html
+++ b/index.html
@@ -758,8 +758,8 @@
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
                 <a>Check and canonicalize total amount</a>
-                |details|.{{PaymentDetailsInit/total}}.{{PaymentItem/amount}}. Rethrow any
-                exceptions.
+                |details|.{{PaymentDetailsInit/total}}.{{PaymentItem/amount}}.
+                Rethrow any exceptions.
               </li>
             </ol>
           </li>
@@ -1906,8 +1906,8 @@
             to the chosen shipping address, or any other reason why no shipping
             options are available. When the payment request is updated using
             {{PaymentRequestUpdateEvent/updateWith()}}, the
-            {{PaymentDetailsUpdate}} can contain a message in the
-            <a>error</a> member that will be displayed to the user if the
+            {{PaymentDetailsUpdate}} can contain a message in the <a>error</a>
+            member that will be displayed to the user if the
             <a>PaymentDetailsUpdate</a> indicates that there are no valid
             {{PaymentDetailsBase/shippingOptions}} (and the {{PaymentRequest}}
             was constructed with the {{PaymentOptions/requestShipping}} option

--- a/index.html
+++ b/index.html
@@ -1551,7 +1551,7 @@
               <dfn>[[\acceptPromise]]</dfn>
             </td>
             <td>
-              The pending {{Promise}} created during {{PaymentRequest/show}}
+              The pending {{Promise}} created during {{PaymentRequest/show()}}
               that will be resolved if the user accepts the payment request.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -1802,7 +1802,7 @@
               sequence.
             </p>
             <p>
-              The {{PaymentOptions/shippingOptions}} member is only used if the
+              The {{PaymentDetailsBase/shippingOptions}} member is only used if the
               {{PaymentRequest}} was constructed with {{PaymentOptions}} and
               {{PaymentOptions/requestShipping}} set to true.
             </p>

--- a/index.html
+++ b/index.html
@@ -757,8 +757,7 @@
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
                 <a>Check and canonicalize total amount</a>
-                |details|.<a>total</a>.<a data-lt=
-                "PaymentItem.amount">amount</a>. Rethrow any exceptions.
+                |details|.<a>total</a>.{{PaymentItem/amount}}. Rethrow any exceptions.
               </li>
             </ol>
           </li>
@@ -767,8 +766,7 @@
             <ol>
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
-                <a>Check and canonicalize amount</a> |item|.<a data-lt=
-                "PaymentItem.amount">amount</a>. Rethrow any exceptions.
+                <a>Check and canonicalize amount</a> |item|.{{PaymentItem/amount}}. Rethrow any exceptions.
               </li>
             </ol>
           </li>
@@ -791,8 +789,7 @@
                     <ol>
                       <li data-tests=
                       "payment-request-ctor-currency-code-checks.https.html">
-                        <a>Check and canonicalize amount</a> |item|.<a data-lt=
-                        "PaymentItem.amount">amount</a>. Rethrow any
+                        <a>Check and canonicalize amount</a> |item|.{{PaymentItem/amount}}. Rethrow any
                         exceptions.
                       </li>
                       <li>If |seenIDs| contains |option|.<a>id</a>, then throw
@@ -834,7 +831,7 @@
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
                             <a>Check and canonicalize total amount</a>
-                            |modifier|.{{PaymentDetailsModifier/total}}.<a data-lt="PaymentItem.amount">amount</a>.
+                            |modifier|.{{PaymentDetailsModifier/total}}.{{PaymentItem/amount}}.
                             Rethrow any exceptions.
                           </li>
                         </ol>
@@ -846,7 +843,7 @@
                           <li data-tests=
                           "payment-request-ctor-currency-code-checks.https.html">
                             <a>Check and canonicalize amount</a>
-                            |item|.<a data-lt="PaymentItem.amount">amount</a>.
+                            |item|.{{PaymentItem/amount}}.
                             Rethrow any exceptions.
                           </li>
                         </ol>
@@ -1878,8 +1875,7 @@
             <aside class="note">
               Algorithms in this specification that accept a
               <a>PaymentDetailsInit</a> dictionary will throw if the
-              <a>total</a>.<a data-lt=
-              "PaymentItem.amount">amount</a>.<a data-lt=
+              <a>total</a>.{{PaymentItem/amount}}.<a data-lt=
               "PaymentCurrencyAmount.value">value</a> is a negative number.
             </aside>
           </dd>
@@ -1929,13 +1925,11 @@
             <dfn>total</dfn> member
           </dt>
           <dd>
-            A <a>PaymentItem</a> containing a non-negative <a data-lt=
-            "PaymentItem.amount">amount</a>.
+            A <a>PaymentItem</a> containing a non-negative {{PaymentItem/amount}}.
             <p class="note">
               Algorithms in this specification that accept a
               <a>PaymentDetailsUpdate</a> dictionary will throw if the
-              <a>total</a>.<a data-lt=
-              "PaymentItem.amount">amount</a>.<a data-lt=
+              <a>total</a>.{{PaymentItem/amount}}.<a data-lt=
               "PaymentCurrencyAmount.value">value</a> is a negative number.
             </p>
           </dd>
@@ -4745,8 +4739,7 @@
                     <ol>
                       <li>
                         <a>Check and canonicalize total amount</a>
-                        |details|.<a>total</a>.<a data-lt=
-                        "PaymentItem.amount">amount</a>. If an exception is
+                        |details|.<a>total</a>.{{PaymentItem/amount}}. If an exception is
                         thrown, then <a>abort the update</a> with |request| and
                         that exception.
                       </li>
@@ -4757,8 +4750,7 @@
                   |details|.<a>displayItems</a>:
                     <ol>
                       <li>
-                        <a>Check and canonicalize amount</a> |item|.<a data-lt=
-                        "PaymentItem.amount">amount</a>. If an exception is
+                        <a>Check and canonicalize amount</a> |item|.{{PaymentItem/amount}}. If an exception is
                         thrown, then <a>abort the update</a> with |request| and
                         that exception.
                       </li>
@@ -4829,8 +4821,7 @@
                             <ol>
                               <li>
                                 <a>Check and canonicalize total amount</a>
-                                |modifier|.<a>total</a>.<a data-lt=
-                                "PaymentItem.amount">amount</a>. If an
+                                |modifier|.<a>total</a>.{{PaymentItem/amount}}. If an
                                 exception is thrown, then <a>abort the
                                 update</a> with |request| and that exception.
                               </li>
@@ -4843,8 +4834,7 @@
                             <ol>
                               <li>
                                 <a>Check and canonicalize amount</a>
-                                |item|.<a data-lt=
-                                "PaymentItem.amount">amount</a>. If an
+                                |item|.{{PaymentItem/amount}}. If an
                                 exception is thrown, then <a>abort the
                                 update</a> with |request| and that exception.
                               </li>

--- a/index.html
+++ b/index.html
@@ -753,12 +753,12 @@
               </li>
             </ol>
           </li>
-          <li data-link-for="PaymentDetailsInit">Process the total:
+          <li>Process the total:
             <ol>
               <li data-tests=
               "payment-request-ctor-currency-code-checks.https.html">
                 <a>Check and canonicalize total amount</a>
-                |details|.<a>total</a>.{{PaymentItem/amount}}. Rethrow any
+                |details|.{{PaymentDetailsInit/total}}.{{PaymentItem/amount}}. Rethrow any
                 exceptions.
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -689,8 +689,8 @@
           <li>Establish the request's id:
             <ol>
               <li data-tests="payment-request-id-attribute.https.html">If
-              |details|.<a data-lt="PaymentDetailsInit.id">id</a> is missing,
-              add an <a data-lt="PaymentDetailsInit.id">id</a> member to
+              |details|.{{PaymentDetailsInit/id}} is missing,
+              add an {{PaymentDetailsInit/id}} member to
               |details| and set its value to a <abbr title=
               "Universally Unique Identifier">UUID</abbr> [[RFC4122]].
               </li>
@@ -910,8 +910,7 @@
         </h2>
         <p data-tests="payment-request-id-attribute.https.html">
           When getting, the <a>id</a> attribute returns this
-          {{PaymentRequest}}'s [=PaymentRequest/[[details]]=].<a data-lt=
-          "PaymentDetailsInit.id">id</a>.
+          {{PaymentRequest}}'s [=PaymentRequest/[[details]]=].{{PaymentDetailsInit/id}}.
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
@@ -1781,8 +1780,7 @@
             for the payment request that the <a>user agent</a> MAY display.
             <aside class="note">
               It is the developer's responsibility, when generating or updating
-              a {{PaymentRequest}}, to verify that the <a data-lt=
-              "PaymentDetailsInit.total">total</a> amount is the sum of these
+              a {{PaymentRequest}}, to verify that the {{PaymentDetailsInit/total}} amount is the sum of these
               items.
             </aside>
           </dd>
@@ -1813,8 +1811,7 @@
             </p>
             <aside class="note">
               If the sequence has an item with the {{PaymentShippingOption/selected}} member set to true,
-              then authors are responsible for ensuring that the <a data-lt=
-              "PaymentDetailsInit.total">total</a> member includes the cost of
+              then authors are responsible for ensuring that the {{PaymentDetailsInit/total}} member includes the cost of
               the shipping option. This is because no
               <a>shippingoptionchange</a> event will be fired for this option
               unless the user selects an alternative option first.
@@ -1986,8 +1983,7 @@
           <dfn>total</dfn> member
         </dt>
         <dd>
-          A <a>PaymentItem</a> value that overrides the <a data-lt=
-          "PaymentDetailsInit.total">total</a> member in the
+          A <a>PaymentItem</a> value that overrides the {{PaymentDetailsInit/total}} member in the
           <a>PaymentDetailsInit</a> dictionary for the <a>payment method
           identifiers</a> of the <a>supportedMethods</a> member.
         </dd>
@@ -4551,8 +4547,7 @@
               </li>
               <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
               attribute value of |response| to the value of
-              |request|.[=PaymentRequest/[[details]]=].<a data-lt=
-              "PaymentDetailsInit.id">id</a>.
+              |request|.[=PaymentRequest/[[details]]=].{{PaymentDetailsInit/id}}.
               </li>
               <li>Set |request|.<a>[[\response]]</a> to |response|.
               </li>

--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
         <ol data-link-for="PaymentDetailsBase" class="algorithm">
           <li>If the <a>current settings object</a>'s [=environment settings
           object / responsible document=] is not <a>allowed to use</a> the
-          "<a data-lt="payment-feature">payment</a>" feature, then
+          "[=payment-feature|payment=]" feature, then
           [=exception/throw=] a {{"SecurityError"}} {{DOMException}}.
           </li>
           <li>Establish the request's id:
@@ -1351,8 +1351,7 @@
           A {{PaymentRequest}}'s <a>shippingType</a> attribute is the type of
           shipping used to fulfill the transaction. Its value is either a
           <a>PaymentShippingType</a> enum value, or null if none is provided by
-          the developer during <a data-lt=
-          "PaymentRequest.PaymentRequest()">construction</a> (see
+          the developer during [=PaymentRequest.PaymentRequest()|construction=] (see
           <a>PaymentOptions</a>'s {{PaymentOptions/shippingType}} member).
         </p>
       </section>
@@ -1446,8 +1445,7 @@
             <td>
               A list containing the serialized string form of each {{PaymentDetailsModifier/data}} member for each
               corresponding item in the sequence
-              [=PaymentRequest/[[details]]=].<a data-lt=
-              "PaymentDetailsBase">modifier</a>, or null if no such member was
+              [=PaymentRequest/[[details]]=].[=PaymentDetailsBase|modifier=], or null if no such member was
               present.
             </td>
           </tr>
@@ -1845,7 +1843,7 @@
             <aside class="note">
               If an <a>id</a> member is not present, then the <a>user agent</a>
               will generate a unique identifier for the payment request during
-              <a data-lt="PaymentRequest.PaymentRequest()">construction</a>.
+              [=PaymentRequest.PaymentRequest()|construction=]
             </aside>
           </dd>
           <dt>
@@ -2292,8 +2290,7 @@
             {{PaymentAddress}}.
             </li>
             <li>Set |address|.<a>[[\addressLine]]</a> to the empty frozen
-            array, and all other <a data-lt="PaymentAddress slots">internal
-            slots</a> to the empty string.
+            array, and all other [=PaymentAddress slots|internal slots=] to the empty string.
             </li>
             <li>If |details| was not passed, return |address|.
             </li>
@@ -2595,8 +2592,7 @@
           };
         </pre>
         <p>
-          An <a>AddressInit</a> is passed when <a data-lt=
-          "PaymentAddress.PaymentAddress()">constructing</a> a
+          An <a>AddressInit</a> is passed when [=PaymentAddress.PaymentAddress()|constructing=] a
           {{PaymentAddress}}. Its members are as follows.
         </p>
         <dl data-dfn-for="AddressInit" data-link-for="" data-sort="ascending">
@@ -2909,8 +2905,7 @@
           to the empty string if none was provided.
           </li>
           <li>
-            <a data-lt="PaymentAddress.PaymentAddress()">Internally construct a
-            new `PaymentAddress`</a> with |details| and return the result.
+            [=PaymentAddress.PaymentAddress()|Internally construct a new `PaymentAddress`=] with |details| and return the result.
           </li>
         </ol>
       </section>
@@ -3690,7 +3685,7 @@
             {{MerchantValidationEvent}} |event|, are as follows:
           </p>
           <ol class="algorithm">
-            <li>Let |base:URL| be the <a data-lt="context object">event</a>’s
+            <li>Let |base:URL| be the [=context object|event=]’s
             <a>relevant settings object</a>’s [=environment settings object/api
             base URL=].
             </li>

--- a/index.html
+++ b/index.html
@@ -1542,8 +1542,7 @@
               <dfn>[[\acceptPromise]]</dfn>
             </td>
             <td>
-              The pending {{Promise}} created during <a data-lt=
-              "PaymentRequest.show">show</a> that will be resolved if the user
+              The pending {{Promise}} created during {{PaymentRequest/show}} that will be resolved if the user
               accepts the payment request.
             </td>
           </tr>
@@ -4979,7 +4978,7 @@
             Consequently, the {{PaymentRequest}} moves to a "<a>closed</a>"
             state. The error is signaled to the developer through the rejection
             of the <a>[[\acceptPromise]]</a>, i.e., the promise returned by
-            <a data-lt="PaymentRequest.show">show()</a>.
+            {{PaymentRequest/show()}}.
           </p>
           <p data-link-for="PaymentResponse">
             Similarly, <a>abort the update</a> occurring during <a>retry()</a>

--- a/index.html
+++ b/index.html
@@ -1457,7 +1457,7 @@
               A list containing the serialized string form of each
               {{PaymentDetailsModifier/data}} member for each corresponding
               item in the sequence
-              [=PaymentRequest/[[details]]=].[=PaymentDetailsBase|modifier=],
+              [=PaymentRequest/[[details]]=].{{PaymentDetailsBase/modifier}},
               or null if no such member was present.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -670,7 +670,7 @@
         <p>
           The {{PaymentRequest}} is constructed using the supplied sequence of
           <a>PaymentMethodData</a> |methodData| including any <a>payment
-          method</a> specific <a data-lt="PaymentMethodData.data">data</a>, the
+          method</a> specific {{PaymentMethodData/data}}, the
           <a>PaymentDetailsInit</a> |details|, and the <a>PaymentOptions</a>
           |options|.
         </p>
@@ -709,17 +709,15 @@
                   <li data-tests=
                   "payment-request-ctor-pmi-handling.https.html">Run the steps
                   to <a>validate a payment method identifier</a> with
-                  |paymentMethod|.<a data-lt=
-                  "PaymentMethodData.supportedMethods">supportedMethods</a>. If
+                  |paymentMethod|.{{PaymentMethodData/supportedMethods}. If
                   it returns false, then throw a {{RangeError}} exception.
                   Optionally, inform the developer that the payment method
                   identifier is invalid.
                   </li>
-                  <li>If the <a data-lt="PaymentMethodData.data">data</a>
+                  <li>If the {{PaymentMethodData/data}}
                   member of |paymentMethod| is missing, let |serializedData| be
                   null. Otherwise, let |serializedData| be the result of
-                  <a>JSON-serializing</a> |paymentMethod|.<a data-lt=
-                  "PaymentMethodData.data">data</a> into a string. Rethrow any
+                  <a>JSON-serializing</a> |paymentMethod|.{{PaymentMethodData/data}} into a string. Rethrow any
                   exceptions.
                   </li>
                   <li>If |serializedData| is not null, and if required by the
@@ -747,8 +745,7 @@
                       </li>
                     </ol>
                   </li>
-                  <li>Add the tuple (|paymentMethod|.<a data-lt=
-                  "PaymentMethodData.supportedMethods">supportedMethods</a>,
+                  <li>Add the tuple (|paymentMethod|.{{PaymentMethodData/supportedMethods}},
                   |serializedData|) to |serializedMethodData|.
                   </li>
                 </ol>

--- a/index.html
+++ b/index.html
@@ -884,16 +884,13 @@
           </li>
           <li>Set |request|.<a>[[\response]]</a> to null.
           </li>
-          <li>Set the value of |request|'s <a data-lt=
-          "PaymentRequest.shippingOption">shippingOption</a> attribute to
+          <li>Set the value of |request|'s {{PaymentRequest/shippingOption}} attribute to
           |selectedShippingOption|.
           </li>
-          <li>Set the value of the <a data-lt="PaymentRequest.shippingAddress">
-            shippingAddress</a> attribute on |request| to null.
+          <li>Set the value of the {{PaymentRequest/shippingAddress}} attribute on |request| to null.
           </li>
           <li>If |options|.{{PaymentOptions/requestShipping}} is set to true,
-          then set the value of the <a data-lt=
-          "PaymentRequest.shippingType">shippingType</a> attribute on |request|
+          then set the value of the {{PaymentRequest/shippingType}} attribute on |request|
           to |options|.{{PaymentOptions/shippingType}}. Otherwise, set it to
           null.
           </li>
@@ -1791,7 +1788,7 @@
             <p data-tests=
             "change-shipping-option-select-last-manual.https.html">
               If an item in the sequence has the {{PaymentShippingOption/selected}} member set to true,
-              then this is the shipping option that will be used by default and <a data-lt="PaymentRequest.shippingOption">shippingOption</a>
+              then this is the shipping option that will be used by default and {{PaymentRequest/shippingOption}}
               will be set to the {{PaymentShippingOption/id}}
               of this option without running the <a>shipping option changed
               algorithm</a>. If more than one item in the sequence has
@@ -3335,8 +3332,7 @@
         "payment-response/shippingAddress-attribute-manual.https.html">
           If the {{PaymentOptions/requestShipping}} member was set
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
-          constructor, then <a data-lt=
-          "PaymentRequest.shippingAddress">shippingAddress</a> will be the full
+          constructor, then {{PaymentRequest/shippingAddress}} will be the full
           and final shipping address chosen by the user.
         </p>
       </section>
@@ -3348,8 +3344,7 @@
         "payment-response/shippingOption-attribute-manual.https.html">
           If the {{PaymentOptions/requestShipping}} member was set
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
-          constructor, then <a data-lt=
-          "PaymentRequest.shippingOption">shippingOption</a> will be the
+          constructor, then {{PaymentRequest/shippingOption}} will be the
           {{PaymentShippingOption/id}} attribute of the
           selected shipping option.
         </p>
@@ -3394,8 +3389,7 @@
           <dfn>requestId</dfn> attribute
         </h2>
         <p data-tests="payment-response/requestId-attribute-manual.https.html">
-          The corresponding payment request <a data-lt=
-          "PaymentRequest.id">id</a> that spawned this payment response.
+          The corresponding payment request {{PaymentRequest/id}} that spawned this payment response.
         </p>
       </section>
       <section data-dfn-for="PaymentResponse" data-link-for="PaymentResponse">
@@ -4293,8 +4287,7 @@
               steps to <a>create a `PaymentAddress` from user-provided
               input</a> with |redactList|.
               </li>
-              <li>Set the <a data-lt=
-              "PaymentRequest.shippingAddress">shippingAddress</a> attribute on
+              <li>Set the {{PaymentRequest/shippingAddress}} attribute on
               |request| to |address|.
               </li>
               <li>Run the <a>PaymentRequest updated algorithm</a> with
@@ -4321,8 +4314,7 @@
             <a>Queue a task</a> on the <a>user interaction task source</a> to
             run the following steps:
             <ol>
-              <li>Set the <a data-lt=
-              "PaymentRequest.shippingOption">shippingOption</a> attribute on
+              <li>Set the {{PaymentRequest/shippingOption}} attribute on
               |request| to the <code>id</code> string of the
               <a>PaymentShippingOption</a> provided by the user.
               </li>
@@ -4507,9 +4499,8 @@
           agent</a> user interface SHOULD ensure that this never occurs.
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
-          <a data-lt="PaymentRequest.shippingAddress">shippingAddress</a>
-          attribute of |request| is null or if the <a data-lt=
-          "PaymentRequest.shippingOption">shippingOption</a> attribute of
+          {{PaymentRequest/shippingAddress}}
+          attribute of |request| is null or if the {{PaymentRequest/shippingOption}} attribute of
           |request| is null, then terminate this algorithm and take no further
           action. The <a>user agent</a> SHOULD ensure that this never occurs.
           </li>
@@ -4866,8 +4857,7 @@
                       |request|.[=PaymentRequest/[[details]]=].<a>shippingOptions</a>
                       to |shippingOptions|.
                       </li>
-                      <li>Set the value of |request|'s <a data-lt=
-                      "PaymentRequest.shippingOption">shippingOption</a>
+                      <li>Set the value of |request|'s {{PaymentRequest/shippingOption}}
                       attribute to |selectedShippingOption|.
                       </li>
                     </ol>
@@ -4892,8 +4882,7 @@
                       |request|.[=PaymentRequest/[[details]]=].<a>shippingOptions</a>
                       is empty, then the developer has signified that there are
                       no valid shipping options for the currently-chosen
-                      shipping address (given by |request|'s <a data-lt=
-                      "PaymentRequest.shippingAddress">shippingAddress</a>).
+                      shipping address (given by |request|'s {{PaymentRequest/shippingAddress}}).
                     </p>
                     <p>
                       In this case, the user agent SHOULD display an error

--- a/index.html
+++ b/index.html
@@ -3908,9 +3908,7 @@
           </h3>
           <p data-tests=
           "PaymentRequestUpdateEvent/constructor.https.html, PaymentRequestUpdateEvent/constructor.http.html">
-            The <a data-lt=
-            "PaymentRequestUpdateEvent"><code>PaymentRequestUpdateEvent(|type|,
-            |eventInitDict|)</code></a> constructor MUST act as follows:
+            The {{PaymentRequestUpdateEvent}}'s {{PaymentRequestUpdateEvent/constructor(type, eventInitDict)}} MUST act as follows:
           </p>
           <ol class="algorithm">
             <li>Let |event:PaymentRequestUpdateEvent| be the result of calling

--- a/index.html
+++ b/index.html
@@ -4566,8 +4566,7 @@
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
           {{PaymentResponse/payerPhone}} attribute of
           |response| to the payer's phone number provided by the user, or to
-          null if none was provided. When setting the <a data-lt=
-          "PaymentResponse.payerPhone">payerPhone</a> value, the user agent
+          null if none was provided. When setting the {{PaymentResponse/payerPhone}} value, the user agent
           SHOULD format the phone number to adhere to [[E.164]].
           </li>
           <li>Set |request|.<a>[[\state]]</a> to "<a>closed</a>".
@@ -4875,8 +4874,7 @@
                       In this case, the user agent SHOULD display an error
                       indicating this, and MAY indicate that the
                       currently-chosen shipping address is invalid in some way.
-                      The user agent SHOULD use the <a data-lt=
-                      "PaymentDetailsUpdate.error">error</a> member of
+                      The user agent SHOULD use the {{PaymentDetailsUpdate/error}} member of
                       |details|, if it is present, to give more information
                       about why there are no valid shipping options for that
                       address.

--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@
           shipping used to fulfill the transaction. Its value is either a
           <a>PaymentShippingType</a> enum value, or null if none is provided by
           the developer during [=PaymentRequest.PaymentRequest()|construction=]
-          (see <a>PaymentOptions</a>'s {{PaymentOptions/shippingType}} member).
+          (see {{PaymentOptions}}'s {{PaymentOptions/shippingType}} member).
         </p>
       </section>
       <section data-dfn-for="PaymentRequest" data-link-for="PaymentRequest">
@@ -1471,7 +1471,7 @@
               initially supplied to the constructor and then updated with calls
               to {{PaymentRequestUpdateEvent/updateWith()}}. Note that all
               {{PaymentDetailsModifier/data}} members of
-              <a>PaymentDetailsModifier</a> instances contained in the
+              {{PaymentDetailsModifier}} instances contained in the
               {{PaymentDetailsBase/modifiers}} member will be removed, as they
               are instead stored in serialized form in the
               [=PaymentRequest/[[serializedModifierData]]=] internal slot.
@@ -1803,7 +1803,7 @@
             </p>
             <p>
               The <a>shippingOptions</a> member is only used if the
-              {{PaymentRequest}} was constructed with <a>PaymentOptions</a> and
+              {{PaymentRequest}} was constructed with {{PaymentOptions}} and
               {{PaymentOptions/requestShipping}} set to true.
             </p>
             <aside class="note">
@@ -1867,7 +1867,7 @@
             payment request.
             <aside class="note">
               Algorithms in this specification that accept a
-              <a>PaymentDetailsInit</a> dictionary will throw if the
+              {{PaymentDetailsInit}} dictionary will throw if the
               <a>total</a>.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}}
               is a negative number.
             </aside>
@@ -1906,7 +1906,7 @@
             to the chosen shipping address, or any other reason why no shipping
             options are available. When the payment request is updated using
             {{PaymentRequestUpdateEvent/updateWith()}}, the
-            <a>PaymentDetailsUpdate</a> can contain a message in the
+            {{PaymentDetailsUpdate}} can contain a message in the
             <a>error</a> member that will be displayed to the user if the
             <a>PaymentDetailsUpdate</a> indicates that there are no valid
             {{PaymentDetailsBase/shippingOptions}} (and the {{PaymentRequest}}

--- a/index.html
+++ b/index.html
@@ -1906,7 +1906,7 @@
             to the chosen shipping address, or any other reason why no shipping
             options are available. When the payment request is updated using
             {{PaymentRequestUpdateEvent/updateWith()}}, the
-            {{PaymentDetailsUpdate}} can contain a message in the <a>error</a>
+            {{PaymentDetailsUpdate}} can contain a message in the {{PaymentDetailsUpdate/error}}
             member that will be displayed to the user if the
             <a>PaymentDetailsUpdate</a> indicates that there are no valid
             {{PaymentDetailsBase/shippingOptions}} (and the {{PaymentRequest}}

--- a/index.html
+++ b/index.html
@@ -3361,8 +3361,7 @@
         <p data-tests="payment-response/payerName-attribute-manual.https.html">
           If the {{PaymentOptions/requestPayerName}} member was set
           to true in the <a>PaymentOptions</a> passed to the {{PaymentRequest}}
-          constructor, then <a data-lt=
-          "PaymentResponse.payerName">payerName</a> will be the name provided
+          constructor, then {{PaymentResponse/payerName}} will be the name provided
           by the user.
         </p>
       </section>
@@ -3374,8 +3373,7 @@
         "payment-response/payerEmail-attribute-manual.https.html">
           If the {{PaymentOptions/requestPayerEmail}} member was
           set to true in the <a>PaymentOptions</a> passed to the
-          {{PaymentRequest}} constructor, then <a data-lt=
-          "PaymentResponse.payerEmail">payerEmail</a> will be the email address
+          {{PaymentRequest}} constructor, then {{PaymentResponse/payerEmail}} will be the email address
           chosen by the user.
         </p>
       </section>
@@ -3387,8 +3385,7 @@
         "payment-response/payerPhone-attribute-manual.https.html">
           If the {{PaymentOptions/requestPayerPhone}} member was
           set to true in the <a>PaymentOptions</a> passed to the
-          {{PaymentRequest}} constructor, then <a data-lt=
-          "PaymentResponse.payerPhone">payerPhone</a> will be the phone number
+          {{PaymentRequest}} constructor, then {{PaymentResponse/payerPhone}} will be the phone number
           chosen by the user.
         </p>
       </section>
@@ -4530,7 +4527,7 @@
               </li>
               <li>Set |response|.<a>[[\complete]]</a> to false.
               </li>
-              <li>Set the <a data-lt="PaymentResponse.requestId">requestId</a>
+              <li>Set the {{PaymentResponse/requestId}}
               attribute value of |response| to the value of
               |request|.[=PaymentRequest/[[details]]=].{{PaymentDetailsInit/id}}.
               </li>
@@ -4541,17 +4538,17 @@
           <li>Let |handler:payment handler| be the <a>payment handler</a>
           selected by the user.
           </li>
-          <li>Set the <a data-lt="PaymentResponse.methodName">methodName</a>
+          <li>Set the {{PaymentResponse/methodName}}
           attribute value of |response| to the <a>payment method identifier</a>
           of |handler|.
           </li>
-          <li>Set the <a data-lt="PaymentResponse.details">details</a>
+          <li>Set the {{PaymentResponse/details}}
           attribute value of |response| to an object resulting from running the
           |handler|'s <a>steps to respond to a payment request</a>.
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is false, then set the
-          <a data-lt="PaymentResponse.shippingAddress">shippingAddress</a>
+          {{PaymentResponse/shippingAddress}}
           attribute value of |response| to null. Otherwise:
             <ol data-link-for="PaymentResponse">
               <li>Let |redactList:list| be the empty <a>list</a>.
@@ -4570,26 +4567,25 @@
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          <a data-lt="PaymentResponse.shippingOption">shippingOption</a>
-          attribute of |response| to the value of the <a data-lt=
-          "PaymentRequest.shippingOption">shippingOption</a> attribute of
+          {{PaymentResponse/shippingOption}}
+          attribute of |response| to the value of the {{PaymentResponse/shippingOption}} attribute of
           |request|. Otherwise, set it to null.
           </li>
           <li>If the {{PaymentOptions/requestPayerName}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          <a data-lt="PaymentResponse.payerName">payerName</a> attribute of
+          {{PaymentResponse/payerName}} attribute of
           |response| to the payer's name provided by the user, or to null if
           none was provided. Otherwise, set it to null.
           </li>
           <li>If the {{PaymentOptions/requestPayerEmail}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          <a data-lt="PaymentResponse.payerEmail">payerEmail</a> attribute of
+          {{PaymentResponse/payerEmail}} attribute of
           |response| to the payer's email address provided by the user, or to
           null if none was provided. Otherwise, set it to null.
           </li>
           <li>If the {{PaymentOptions/requestPayerPhone}} value of
           |request|.[=PaymentRequest/[[options]]=] is true, then set the
-          <a data-lt="PaymentResponse.payerPhone">payerPhone</a> attribute of
+          {{PaymentResponse/payerPhone}} attribute of
           |response| to the payer's phone number provided by the user, or to
           null if none was provided. When setting the <a data-lt=
           "PaymentResponse.payerPhone">payerPhone</a> value, the user agent

--- a/index.html
+++ b/index.html
@@ -994,8 +994,7 @@
             </ol>
             <p class="note">
               This allows the <a>user agent</a> to act as if the user had
-              immediately <a data-lt="user aborts the payment request">aborted
-              the payment request</a>, at its discretion. For example, in
+              immediately [=user aborts the payment request|aborted payment request=], at its discretion. For example, in
               "private browsing" modes or similar, user agents might take
               advantage of this step.
             </p>
@@ -3697,8 +3696,7 @@
             base URL=].
             </li>
             <li data-link-for="MerchantValidationEventInit">Let
-            |validationURL:URL| be the result of <a data-lt="URL parser">URL
-            parsing</a> |eventInitDict|["<a>validationURL</a>"] and |base|.
+            |validationURL:URL| be the result of [=URL parser|URL parsing=] |eventInitDict|["<a>validationURL</a>"] and |base|.
             </li>
             <li>If |validationURL| is failure, throw a {{TypeError}}.
             </li>

--- a/index.html
+++ b/index.html
@@ -1802,9 +1802,9 @@
               sequence.
             </p>
             <p>
-              The {{PaymentDetailsBase/shippingOptions}} member is only used if the
-              {{PaymentRequest}} was constructed with {{PaymentOptions}} and
-              {{PaymentOptions/requestShipping}} set to true.
+              The {{PaymentDetailsBase/shippingOptions}} member is only used if
+              the {{PaymentRequest}} was constructed with {{PaymentOptions}}
+              and {{PaymentOptions/requestShipping}} set to true.
             </p>
             <aside class="note">
               If the sequence has an item with the
@@ -1906,12 +1906,12 @@
             to the chosen shipping address, or any other reason why no shipping
             options are available. When the payment request is updated using
             {{PaymentRequestUpdateEvent/updateWith()}}, the
-            {{PaymentDetailsUpdate}} can contain a message in the {{PaymentDetailsUpdate/error}}
-            member that will be displayed to the user if the
-            <a>PaymentDetailsUpdate</a> indicates that there are no valid
-            {{PaymentDetailsBase/shippingOptions}} (and the {{PaymentRequest}}
-            was constructed with the {{PaymentOptions/requestShipping}} option
-            set to true).
+            {{PaymentDetailsUpdate}} can contain a message in the
+            {{PaymentDetailsUpdate/error}} member that will be displayed to the
+            user if the <a>PaymentDetailsUpdate</a> indicates that there are no
+            valid {{PaymentDetailsBase/shippingOptions}} (and the
+            {{PaymentRequest}} was constructed with the
+            {{PaymentOptions/requestShipping}} option set to true).
           </dd>
           <dt>
             <dfn>total</dfn> member

--- a/index.html
+++ b/index.html
@@ -4895,8 +4895,7 @@
                       address.
                     </p>
                     <p>
-                      Further, if |details|["<a data-lt=
-                      "PaymentDetailsUpdate.shippingAddressErrors">shippingAddressErrors</a>"]
+                      Further, if |details|["{{PaymentDetailsUpdate/shippingAddressErrors}}"]
                       member is present, the user agent SHOULD display an error
                       specifically for each erroneous field of the shipping
                       address. This is done by matching each present member of

--- a/index.html
+++ b/index.html
@@ -3706,8 +3706,7 @@
             <li>Initialize |event|.<a>methodName</a> attribute to
             |eventInitDict|["<a>methodName</a>"].
             </li>
-            <li>Initialize |event|.<a data-lt=
-            "mechvalidation.waitForUpdate">[[\waitForUpdate]]</a> to false.
+            <li>Initialize |event|.{{[[waitForUpdate]]}} to false.
             </li>
           </ol>
         </section>
@@ -3742,8 +3741,7 @@
             <li>If |event|'s {{ Event.isTrusted }} attribute is false, then
             [=exception/throw=] an {{"InvalidStateError"}} {{DOMException}}.
             </li>
-            <li>If |event|.<a data-lt=
-            "mechvalidation.waitForUpdate">[[\waitForUpdate]]</a> is true, then
+            <li>If |event|.{{[[waitForUpdate]]}} is true, then
             [=exception/throw=] an {{"InvalidStateError"}} {{DOMException}}.
             </li>
             <li>Let |request:PaymentRequest| be |event|'s [=Event/target=].
@@ -3758,8 +3756,7 @@
             <li>Set |event|'s [=Event/stop propagation flag=] and [=Event/stop
             immediate propagation flag=].
             </li>
-            <li>Set |event|.<a data-lt=
-            "mechvalidation.waitForUpdate">[[\waitForUpdate]]</a> to true.
+            <li>Set |event|.{{[[waitForUpdate]]}} to true.
             </li>
             <li>Run the <a>validate merchant's details algorithm</a> with
             |merchantSessionPromise| and |request|.
@@ -3915,7 +3912,7 @@
             the [=Event/constructor=] of {{PaymentRequestUpdateEvent}} with
             |type| and |eventInitDict|.
             </li>
-            <li>Set |event|.<a>[[\waitForUpdate]]</a> to false.
+            <li>Set |event|.{{[[waitForUpdate]]}} to false.
             </li>
             <li>Return |event|.
             </li>

--- a/index.html
+++ b/index.html
@@ -994,7 +994,7 @@
             </ol>
             <p class="note">
               This allows the <a>user agent</a> to act as if the user had
-              immediately [=user aborts the payment request|aborted payment request=], at its discretion. For example, in
+              immediately [=user aborts the payment request|aborted the payment request=], at its discretion. For example, in
               "private browsing" modes or similar, user agents might take
               advantage of this step.
             </p>
@@ -4477,6 +4477,7 @@
           agent</a> user interface SHOULD ensure that this never occurs.
           </li>
           <li>If the {{PaymentOptions/requestShipping}} value of
+          |request|.[=PaymentRequest/[[options]]=] is true, then if the
           {{PaymentRequest/shippingAddress}}
           attribute of |request| is null or if the {{PaymentRequest/shippingOption}} attribute of
           |request| is null, then terminate this algorithm and take no further


### PR DESCRIPTION
Updating the spec using respec [shorthands](https://github.com/w3c/respec/wiki/Shorthands-Guide). Removed all `a data-lt` citations.

141 `a data-lt`citations down to 0!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/payment-request/pull/899.html" title="Last updated on Feb 20, 2020, 3:13 AM UTC (1da4752)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/899/f810dc0...janiceshiu:1da4752.html" title="Last updated on Feb 20, 2020, 3:13 AM UTC (1da4752)">Diff</a>