### PR TITLE
fix: disallow duplicate PMIs when creating request

### DIFF
--- a/index.html
+++ b/index.html
@@ -705,6 +705,8 @@
               [=exception/throw=] a {{TypeError}}, optionally informing the
               developer that at least one <a>payment method</a> is required.
               </li>
+              <li>Let |seenPMIs:Set| be the empty [=set=].
+              </li>
               <li>For each |paymentMethod| of |methodData|:
                 <ol>
                   <li data-tests=
@@ -714,6 +716,21 @@
                   returns false, then throw a {{RangeError}} exception.
                   Optionally, inform the developer that the payment method
                   identifier is invalid.
+                  </li>
+                  <li>Let |pmi| be the result of parsing
+                  |paymentMethod|.{{PaymentMethodData/supportedMethods}} with
+                  [=basic URL parser=]:
+                    <ol>
+                      <li>If failure, set |pmi| to
+                      |paymentMethod|.{{PaymentMethodData/supportedMethods}}.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If |seenPMIs| [=set/contain|contains=] |pmi| throw a
+                  {{RangeError}} {{DOMException}} optionally letting the
+                  developer this [=payment method identifier=] is a duplicate.
+                  </li>
+                  <li>[=set/Append=] |pmi| to |seenPMIs|.
                   </li>
                   <li>If the {{PaymentMethodData/data}} member of
                   |paymentMethod| is missing, let |serializedData| be null.


### PR DESCRIPTION
closes #905

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [X] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/commit/8bdfc7451d7ad917ebabefc3bedab5f49e0eee5d)
 * [X] Modified MDN Docs - edge case, let's not bother. 
 * [X] Has undergone security/privacy review - part of #905
 
Implementation commitment:

 * [x] [Safari](https://bugs.webkit.org/show_bug.cgi?id=220824)
 * [x] [Chrome](https://crbug.com/1085712)
 * [x] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1633344)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?

None.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/908.html" title="Last updated on May 22, 2020, 9:41 AM UTC (af76701)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/908/f868c93...af76701.html" title="Last updated on May 22, 2020, 9:41 AM UTC (af76701)">Diff</a>