### PR TITLE
Consume user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,6 +997,8 @@
           {{"SecurityError"}} {{DOMException}}.
           </li>
           <li>Let |request:PaymentRequest| be [=this=].
+          <li>
+            [=Consume user activation=] of |window|.
           </li>
           <li>Let |document| be |request|'s [=relevant global object=]'s [=
           associated `Document`=].

--- a/index.html
+++ b/index.html
@@ -157,6 +157,9 @@
           </li>
           <li>Deprecated `allowpaymentrequest` attribute.
           </li>
+          <li>Calling {{PaymentRequest/show()}} now consumes the user
+          activation.
+          </li>
         </ul>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -994,7 +994,7 @@
           "payment-request-show-method.https.html, show-method-postmessage-manual.https.html">
           If the [=relevant global object=] of [=this=] does not have
           [=transient activation=], return [=a promise rejected with=] with a
-          {{"SecurityError"}} {{DOMException}}.
+          {{"NotAllowedError"}} {{DOMException}}.
           </li>
           <li>Let |request:PaymentRequest| be [=this=].
           <li>

--- a/index.html
+++ b/index.html
@@ -998,7 +998,8 @@
           [=transient activation=], return [=a promise rejected with=] with a
           {{"NotAllowedError"}} {{DOMException}}.
           </li>
-          <li>[=Consume user activation=] of the [=relevant global object=].
+          <li data-tests="show-consume-activation.https.html">[=Consume user
+          activation=] of the [=relevant global object=].
           </li>
           <li>Let |document| be |request|'s [=relevant global object=]'s
           [=associated `Document`=].

--- a/index.html
+++ b/index.html
@@ -990,18 +990,18 @@
           follows:
         </p>
         <ol class="algorithm">
+          <li>Let |request:PaymentRequest| be [=this=].
+          </li>
           <li data-tests=
           "payment-request-show-method.https.html, show-method-postmessage-manual.https.html">
-          If the [=relevant global object=] of [=this=] does not have
+          If the [=relevant global object=] of [=request=] does not have
           [=transient activation=], return [=a promise rejected with=] with a
           {{"NotAllowedError"}} {{DOMException}}.
           </li>
-          <li>Let |request:PaymentRequest| be [=this=].
-          <li>
-            [=Consume user activation=] of |window|.
+          <li>[=Consume user activation=] of the [=relevant global object=].
           </li>
-          <li>Let |document| be |request|'s [=relevant global object=]'s [=
-          associated `Document`=].
+          <li>Let |document| be |request|'s [=relevant global object=]'s
+          [=associated `Document`=].
           </li>
           <li data-tests="rejects_if_not_active.https.html">If |document| is
           not [=Document/fully active=], then return <a>a promise rejected


### PR DESCRIPTION
closes #886 

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [x] Modified Web platform tests - part of https://github.com/web-platform-tests/wpt/pull/26022
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [x] [Safari](https://bugs.webkit.org/show_bug.cgi?id=217365)
 * [X] [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1130553)
 * [X] [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1645972)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?
None.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/916.html" title="Last updated on Oct 15, 2020, 10:38 PM UTC (cee4c5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/916/f697360...cee4c5c.html" title="Last updated on Oct 15, 2020, 10:38 PM UTC (cee4c5c)">Diff</a>