### PR TITLE
Deprecate allowpaymentrequest attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,11 +608,17 @@
         </p>
         <pre class="example html" title=
         "Using Payment Request API with cross-origin iframes">
-            &lt;iframe
-              src="https://cross-origing.example"
-              allow="payment"&gt;
-            &lt;/iframe&gt;
-          </pre>
+          &lt;iframe
+            src="https://cross-origing.example"
+            allow="payment"&gt;
+          &lt;/iframe&gt;
+        </pre>
+        <p>
+          If the [^iframe^] will be navigated across multiple origins that
+          support the Payment Request API, then one can set [^iframe/allow^] to
+          `"payment *"`. The [[[permissions-policy]]] specification provides
+          further details and examples.
+        </p>
       </section>
     </section>
     <section data-dfn-for="PaymentRequest">

--- a/index.html
+++ b/index.html
@@ -126,7 +126,8 @@
           version are as follows. The complete list of changes, including all
           editorial changes, is viewable in the <a href=
           "https://github.com/w3c/payment-request/commits/gh-pages">commit
-          history</a>.
+          history</a>. Key set of changes are viewable in the <a href=
+          "#changelog">Changelog</a>.
         </p>
         <ul>
           <li>Added support for notification when the user selects a payment
@@ -160,6 +161,8 @@
           <li>Integrated with [[[permissions-policy]]].
           </li>
           <li>Defined handling of multiple applicable modifiers.
+          </li>
+          <li>Deprecated `allowpaymentrequest` attribute.
           </li>
         </ul>
       </section>
@@ -593,6 +596,23 @@
           }
           doPaymentRequest();
         </pre>
+      </section>
+      <section>
+        <h2>
+          Using with cross-origin iframes
+        </h2>
+        <p>
+          To indicate that a cross-origin [^iframe^] is allowed to invoke the
+          payment request API, the [^iframe/allow^] attribute along with the
+          "payment" keyword can be specified on the [^iframe^] element.
+        </p>
+        <pre class="example html" title=
+        "Using Payment Request API with cross-origin iframes">
+            &lt;iframe
+              src="https://cross-origing.example"
+              allow="payment"&gt;
+            &lt;/iframe&gt;
+          </pre>
       </section>
     </section>
     <section data-dfn-for="PaymentRequest">
@@ -3574,18 +3594,6 @@
         </table>
       </section>
     </section>
-    <section class="informative">
-      <h2>
-        <code>PaymentRequest</code> and <code>iframe</code> elements
-      </h2>
-      <p>
-        To indicate that a cross-origin [^iframe^] is allowed to invoke the
-        payment request API, the [^iframe/allowpaymentrequest^] attribute can
-        be specified on the [^iframe^] element. See [[[#permissions-policy]]]
-        for details of how [^iframe/allowoaymentrequest=] and
-        [[[permissions-policy]]] interact.
-      </p>
-    </section>
     <section id="permissions-policy" data-cite="permissions-policy">
       <h2>
         Permissions Policy integration
@@ -3596,7 +3604,7 @@
         "">payment</dfn></code>". Its <a>default allowlist</a> is
         '<code>self</code>'.
       </p>
-      <div class="note">
+      <aside class="note">
         <p>
           A <a>document</a>’s [=Document/permissions policy=] determines
           whether any content in that document is allowed to construct
@@ -3604,17 +3612,7 @@
           in the document will be <a>allowed to use</a> the {{PaymentRequest}}
           constructor (trying to create an instance will throw).
         </p>
-        <p>
-          The [^iframe/allowpaymentrequest^] attribute of the HTML
-          <a>iframe</a> element affects the <a>container policy</a> for any
-          document nested in that iframe. Unless overridden by the
-          [^iframe/allow^] attribute, setting [^iframe/allowpaymentrequest^] on
-          an iframe is equivalent to `&lt;iframe allow="fullscreen *"&gt;`, as
-          described in <a data-cite=
-          "permissions-policy#iframe-allowpaymentrequest-attribute">Permissions
-          Policy §allowpaymentrequest</a>.
-        </p>
-      </div>
+      </aside>
     </section>
     <section>
       <h2>
@@ -5179,7 +5177,7 @@
           It is common for merchants and other payees to delegate checkout and
           other e-commerce activities to payment service providers through an
           <a>iframe</a>. This API supports payee-authorized cross-origin
-          iframes through [[HTML]]'s [^iframe/allowpaymentrequest^] attribute.
+          iframes through [[HTML]]'s [^iframe/allow^] attribute.
         </p>
         <p class="Note">
           <a>Payment handlers</a> have access to both the origin that hosts the


### PR DESCRIPTION
closes #925 

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec errors/warnings.
 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/25560)
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [X] Safari - Never implemented
 * [ ] [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1127988)
 * [X] Firefox - never shipped. 
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?
None.

Waiting on:
https://github.com/whatwg/html/pull/5915
https://github.com/w3c/webappsec-permissions-policy/pull/402


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/928.html" title="Last updated on Sep 17, 2020, 2:25 AM UTC (3ee4119)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/928/222c80b...3ee4119.html" title="Last updated on Sep 17, 2020, 2:25 AM UTC (3ee4119)">Diff</a>