### PR TITLE
Editorial: describe purpose of retry()

### DIFF
--- a/index.html
+++ b/index.html
@@ -3100,11 +3100,17 @@
             {{PaymentResponse}}, which the end user needs to correct.
           </p>
           <p>
-            However, an end user may decides, upon inspection of the
+            However, an end user may decide, upon inspection of the
             {{PaymentValidationErrors}}, to provide an entirely new set of
             values for the {{PaymentResponse}}. For example, the user might
             switch to a an entirely different payment instrument and/or provide
             an entirely different shipping address.
+          </p>
+          <p>
+            As a {{PaymentResponse}} is inherently tied to a particular
+            [=payment handler=] via a {{PaymentRequest}}, it is not possible
+            for the end user to switch to a different [=payment handler=]
+            during {{PaymentResponse/retry()}}.
           </p>
           <p>
             As such, merchants need to be prepared to completely revalidate a

--- a/index.html
+++ b/index.html
@@ -3089,8 +3089,32 @@
         <h2>
           <dfn>retry()</dfn> method
         </h2>
+        <aside class="note">
+          <p>
+            If a {{PaymentResponse}} is found to be erroneous (e.g., a payment
+            instrument has expired or shipping information is invalid), the
+            {{PaymentResponse/retry()}} method affords the end user the ability
+            to fix input errors and try to get the merchant to processed the
+            payment again. The passed {{PaymentValidationErrors}} serve as
+            hints as to where input errors have occurred in the
+            {{PaymentResponse}}, which the end user needs to correct.
+          </p>
+          <p>
+            However, an end user may decided, upon inspection of the
+            {{PaymentValidationErrors}}, to provide an entirely new set of
+            value for the {{PaymentResponse}}. For example, the user might
+            switch to a an entirely different payment instrument and/or provide
+            an entirely different shipping address.
+          </p>
+          <p>
+            As such, merchants need to be prepared to completely revalidate a
+            {{PaymentResponse}} once the {{PaymentResponse/[[retryPromise]]}}
+            settles.
+          </p>
+        </aside>
         <p data-tests="payment-response/retry-method-manual.https.html">
-          The <code>retry(|errorFields|)</code> method MUST act as follows:
+          The <code>retry(|errorFields:PaymentValidationErrors|)</code> method
+          MUST act as follows:
         </p>
         <ol class="algorithm">
           <li>Let |response:PaymentResponse| be [=this=].

--- a/index.html
+++ b/index.html
@@ -3107,15 +3107,15 @@
             an entirely different shipping address.
           </p>
           <p>
-            As a {{PaymentResponse}} is inherently tied to a particular
-            [=payment handler=] via a {{PaymentRequest}}, it is not possible
-            for the end user to switch to a different [=payment handler=]
-            during {{PaymentResponse/retry()}}.
-          </p>
-          <p>
             As such, merchants need to be prepared to completely revalidate a
             {{PaymentResponse}} once the {{PaymentResponse/[[retryPromise]]}}
             settles.
+          </p>
+          <p>
+            Lastly, as a {{PaymentResponse}} is inherently tied to a particular
+            [=payment handler=] via a {{PaymentRequest}}, it is not possible
+            for the end user to switch to a different [=payment handler=]
+            during {{PaymentResponse/retry()}}.
           </p>
         </aside>
         <p data-tests="payment-response/retry-method-manual.https.html">

--- a/index.html
+++ b/index.html
@@ -3100,9 +3100,9 @@
             {{PaymentResponse}}, which the end user needs to correct.
           </p>
           <p>
-            However, an end user may decided, upon inspection of the
+            However, an end user may decides, upon inspection of the
             {{PaymentValidationErrors}}, to provide an entirely new set of
-            value for the {{PaymentResponse}}. For example, the user might
+            values for the {{PaymentResponse}}. For example, the user might
             switch to a an entirely different payment instrument and/or provide
             an entirely different shipping address.
           </p>


### PR DESCRIPTION
closes #933

Describe's `retry()`'s expected usage + talks about the end user being able to basically change all the things. 

@SECtim, wdyt?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/934.html" title="Last updated on Nov 16, 2020, 12:57 PM UTC (896c727)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/934/e71e17d...896c727.html" title="Last updated on Nov 16, 2020, 12:57 PM UTC (896c727)">Diff</a>