### PR TITLE
Editorial: use unicode name/code for currencies in note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1677,9 +1677,19 @@
             alphabetic code (i.e., the numeric codes are not supported). Their
             canonical form is upper case. However, the set of combinations of
             currency code for which localized currency symbols are available is
-            implementation dependent. Where a localized currency symbol is not
-            available, a user agent SHOULD use U+00A4 (¤) for formatting. User
-            agents MAY format the display of the
+            implementation dependent.
+          </p>
+          <p>
+            Currency symbols can be ambiguous due to use across a number of
+            different currencies (e.g., "$" could mean any of USD, AUD, NZD,
+            CAD, and so on.). When displaying a monetary value, it is
+            RECOMMENDED that user agents display the currency code.
+          </p>
+          <p>
+            Further, when displaying a monetary value, it is OPTIONAL for user
+            agents to display currency symbols. User agent that display
+            currency symbols MAY use U+00A4 (¤) when a currency symbol is not
+            available. User agents MAY format the display of the
             {{PaymentCurrencyAmount/currency}} member to adhere to OS
             conventions (e.g., for localization purposes).
           </p>

--- a/index.html
+++ b/index.html
@@ -1682,7 +1682,7 @@
           <p>
             When displaying a monetary value, it is RECOMMENDED that user
             agents display the currency code, but it's OPTIONAL for user agents
-            to display a currency symbol. Note that currency symbols can be
+            to display a currency symbol. This is because currency symbols can be
             ambiguous due to use across a number of different currencies (e.g.,
             "$" could mean any of USD, AUD, NZD, CAD, and so on.). User agent
             that display currency symbols MAY use U+00A4 (¤) when a currency

--- a/index.html
+++ b/index.html
@@ -1703,7 +1703,7 @@
               Dollar Sign ($), "GBP" is U+00A3 Pound Sign (£), and the
               non-standard "XBT" could be shown as U+0243 Latin Capital Letter
               B with Stroke (Ƀ)). When a code cannot be matched, the
-              specification recommends browsers show a U+0024 Currency Sign
+              specification recommends browsers show a U+00A4 Currency Sign
               (¤).
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,8 @@
           </p>
           <p>
             Further, when displaying a monetary value, it is OPTIONAL for user
-            agents to display currency symbols. User agent that display
+            agents to display currency symbols (see note below for rationale,
+            currency symbols can be ambiguous). User agent that display
             currency symbols MAY use U+00A4 (¤) when a currency symbol is not
             available. User agents MAY format the display of the
             {{PaymentCurrencyAmount/currency}} member to adhere to OS

--- a/index.html
+++ b/index.html
@@ -1713,7 +1713,7 @@
               Dollar Sign ($), "GBP" is U+00A3 Pound Sign (£), and the
               non-standard "XBT" could be shown as U+0243 Latin Capital Letter
               B with Stroke (Ƀ)). When a code cannot be matched, the
-              specification recommends browsers show a U+00A4 Currency Sign
+              specification recommends showing a U+00A4 Currency Sign
               (¤).
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -1699,10 +1699,12 @@
               [[ISO4217]] list (e.g., XBT, XRP, etc.). If the provided code is
               a currency that the browser knows how to display, then an
               implementation will generally display the appropriate currency
-              symbol in the user interface (e.g., "USD" is shown as "$", "GBP"
-              is "£", and the non-standard "XBT" could be shown as "Ƀ"). When a
-              code cannot be matched, the specification recommends browsers
-              show a scarab "¤".
+              symbol in the user interface (e.g., "USD" is shown as U+0024
+              Dollar Sign ($), "GBP" is U+00A3 Pound Sign (£), and the
+              non-standard "XBT" could be shown as U+0243 Latin Capital Letter
+              B with Stroke (Ƀ)). When a code cannot be matched, the
+              specification recommends browsers show a U+0024 Currency Sign
+              (¤).
             </p>
             <p>
               Efforts are underway at ISO to account for digital currencies,

--- a/index.html
+++ b/index.html
@@ -1687,8 +1687,7 @@
           </p>
           <p>
             Further, when displaying a monetary value, it is OPTIONAL for user
-            agents to display currency symbols (see note below for rationale,
-            currency symbols can be ambiguous). User agent that display
+            agents to display currency symbols. User agent that display
             currency symbols MAY use U+00A4 (¤) when a currency symbol is not
             available. User agents MAY format the display of the
             {{PaymentCurrencyAmount/currency}} member to adhere to OS

--- a/index.html
+++ b/index.html
@@ -1691,7 +1691,7 @@
           <p>
             User agents MAY format the display of the
             {{PaymentCurrencyAmount/currency}} member to adhere to OS
-            conventions (e.g., for localization purposes)
+            conventions (e.g., for localization purposes).
           </p>
           <div class="note" title=
           "Digital currencies and ISO 4217 currency codes">

--- a/index.html
+++ b/index.html
@@ -1680,18 +1680,18 @@
             implementation dependent.
           </p>
           <p>
-            Currency symbols can be ambiguous due to use across a number of
-            different currencies (e.g., "$" could mean any of USD, AUD, NZD,
-            CAD, and so on.). When displaying a monetary value, it is
-            RECOMMENDED that user agents display the currency code.
+            When displaying a monetary value, it is RECOMMENDED that user
+            agents display the currency code, but it's OPTIONAL for user agents
+            to display a currency symbol. Note that currency symbols can be
+            ambiguous due to use across a number of different currencies (e.g.,
+            "$" could mean any of USD, AUD, NZD, CAD, and so on.). User agent
+            that display currency symbols MAY use U+00A4 (¤) when a currency
+            symbol is not available.
           </p>
           <p>
-            Further, when displaying a monetary value, it is OPTIONAL for user
-            agents to display currency symbols. User agent that display
-            currency symbols MAY use U+00A4 (¤) when a currency symbol is not
-            available. User agents MAY format the display of the
+            User agents MAY format the display of the
             {{PaymentCurrencyAmount/currency}} member to adhere to OS
-            conventions (e.g., for localization purposes).
+            conventions (e.g., for localization purposes)
           </p>
           <div class="note" title=
           "Digital currencies and ISO 4217 currency codes">


### PR DESCRIPTION
Begins to address https://github.com/w3c/i18n-activity/issues/1044


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/942.html" title="Last updated on Mar 18, 2021, 12:36 AM UTC (2357b5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/942/62e3ad0...2357b5b.html" title="Last updated on Mar 18, 2021, 12:36 AM UTC (2357b5b)">Diff</a>