### PR TITLE
Derive direction from document element too

### DIFF
--- a/index.html
+++ b/index.html
@@ -1145,15 +1145,17 @@
               {{Document/dir}} attribute, if any, or an appropriate fallback
               locale if that is not available.
             </p>
-            <aside class="note" title="Localization of the payment sheet">
+            <aside class="note" title=
+            "Localization of the payments user interface">
               <p>
                 The API does not currently provide a way for developers to
                 specify the language and base direction in which the payment
-                sheet is presented to end users. As such, user agents will
-                generally present the payment sheet using the user agent's
-                default language. Future versions of this specification may add
-                support for language and direction metadata via mechanism
-                specified in [[STRING-META]] and [[INTERNATIONAL-SPECS]].
+                sheet is presented to end users. Instead, the API relies on
+                localization information inherited from the document. The
+                working group is considering support for fine-grained
+                localization of the user interface and of individual
+                {{PaymentItems}} and user-facing error messages in a future
+                version of this API.
               </p>
             </aside>
           </li>

--- a/index.html
+++ b/index.html
@@ -1139,20 +1139,21 @@
               Present a user interface that will allow the user to interact
               with the |handlers|. The user agent SHOULD prioritize the user's
               preference when presenting payment methods. The user interface
-              SHOULD be presented using the language and locale-based
-              formatting that matches the |document|'s [=document
-              element|document element's=] [=Node/language=], if any, or an
-              appropriate fallback locale if that is not available.
+              SHOULD be presented using the language, base direction, and
+              locale-based formatting that matches the |document|'s [=document
+              element|document element's=] [=Node/language=] and
+              {{Document/dir}} attribute, if any, or an appropriate fallback
+              locale if that is not available.
             </p>
             <aside class="note" title="Localization of the payment sheet">
               <p>
-                The API does not provide a way for developers to specify the
-                language in which the payment sheet is presented to end users.
-                As such, user agents will generally present the payment sheet
-                using the user agent's default language. The working group is
-                contemplating adding the ability for developers to specify the
-                language of the payment sheet, and of specific
-                {{PaymentItems}}, in a future version of this API.
+                The API does not currently provide a way for developers to
+                specify the language and base direction in which the payment
+                sheet is presented to end users. As such, user agents will
+                generally present the payment sheet using the user agent's
+                default language. Future versions of this specification may add
+                support for language and direction metadata via mechanism
+                specified in [[STRING-META]] and [[INTERNATIONAL-SPECS]].
               </p>
             </aside>
           </li>

--- a/index.html
+++ b/index.html
@@ -1152,7 +1152,7 @@
                 specify the language and base direction in which the payment
                 sheet is presented to end users. Instead, the API relies on
                 localization information inherited from the document. The
-                working group is considering support for fine-grained
+                working group is considering support for requesting specific
                 localization of the user interface and of individual
                 {{PaymentItems}} and user-facing error messages in a future
                 version of this API.

--- a/index.html
+++ b/index.html
@@ -1139,11 +1139,10 @@
               Present a user interface that will allow the user to interact
               with the |handlers|. The user agent SHOULD prioritize the user's
               preference when presenting payment methods. The user interface
-              SHOULD be presented using the language, base direction, and
-              locale-based formatting that matches the |document|'s [=document
-              element|document element's=] [=Node/language=] and
-              {{Document/dir}} attribute, if any, or an appropriate fallback
-              if that is not available.
+              SHOULD be presented using the language and locale-based
+              formatting that matches the |document|'s [=document
+              element|document element's=] [=Node/language=], if any, or an
+              appropriate fallback if that is not available.
             </p>
             <aside class="note" title=
             "Localization of the payments user interface">

--- a/index.html
+++ b/index.html
@@ -1143,7 +1143,7 @@
               locale-based formatting that matches the |document|'s [=document
               element|document element's=] [=Node/language=] and
               {{Document/dir}} attribute, if any, or an appropriate fallback
-              locale if that is not available.
+              if that is not available.
             </p>
             <aside class="note" title=
             "Localization of the payments user interface">


### PR DESCRIPTION
Related to, but does not close #327, #946, #948, #951

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec errors/warnings.
 * [ ] Modified Web platform tests (link)
 * [ ] Modified MDN Docs (link)
 * [ ] Has undergone security/privacy review (link)
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/956.html" title="Last updated on May 20, 2021, 2:40 AM UTC (d894b79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/956/79e23d4...d894b79.html" title="Last updated on May 20, 2021, 2:40 AM UTC (d894b79)">Diff</a>