### PR TITLE
Editorial: fix a markup typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1877,7 +1877,7 @@
               If
               |errorFields:PaymentValidationErrors|.{{PaymentValidationErrors/paymentMethod}}
               member was passed, and if required by the specification that
-              defines |response|.{{PaymentResponse/payment}}/a&gt;, then
+              defines |response|.{{PaymentResponse/payment}}, then
               [=converted to an IDL value|convert=] |errorFields|'s
               {{PaymentValidationErrors/paymentMethod}} member to an IDL value
               of the type specified there. Otherwise, [=converted to an IDL


### PR DESCRIPTION
The following tasks have been completed:

 * [x] Confirmed there are no ReSpec errors/warnings.
 * [ ] Modified Web platform tests N/A
 * [ ] Modified MDN Docs N/A
 * [ ] Has undergone security/privacy review N/A
 
Implementation commitment: N/A

Optional, impact on Payment Handler spec?
None. I checked if it had the same typo, and it did not.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zcorpan/browser-payment-api/pull/968.html" title="Last updated on Sep 30, 2021, 8:23 PM UTC (ecb8a44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/968/e4d0687...zcorpan:ecb8a44.html" title="Last updated on Sep 30, 2021, 8:23 PM UTC (ecb8a44)">Diff</a>