### PR TITLE
Add internationalization support for human readable labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,9 +915,7 @@
                 The API does not currently provide a way for developers to
                 specify the language and base direction in which the payment
                 sheet is presented to end users. Instead, the API relies on
-                localization information inherited from the document. The
-                working group is considering support for requesting specific
-                localization of the user interface.
+                localization information inherited from the document.
               </p>
             </aside>
           </li>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,11 @@
         There has been no change in dependencies on other workings groups
         during the development of this specification.
       </p>
+      <div class="correction">
+        This specification includes <a href=
+        "https://www.w3.org/Consortium/Process/#candidate-correction">Candidate
+        corrections</a>, which are marked in the document.
+      </div>
       <section>
         <h3>
           Changes since last publication
@@ -1706,6 +1711,16 @@
       <h2>
         <dfn>PaymentItem</dfn> dictionary
       </h2>
+      <div class="correction" id="c1">
+        <span class="marker">Candidate Correction 1:</span> This dictionary
+        should include definitions for optional members "language" and
+        "direction" to support use cases where document context is insufficient
+        for the proper internationalization of "label". Values for these
+        members would be the same as for "lang" and "dir" in HTML. The Working
+        Group is monitoring progress on <a href=
+        "https://github.com/w3c/string-meta/issues/54">Localizable in
+        WebIDL</a>.
+      </div>
       <pre class="idl">
         dictionary PaymentItem {
           required DOMString label;
@@ -1945,6 +1960,16 @@
           <h3>
             <dfn>PaymentValidationErrors</dfn> dictionary
           </h3>
+          <div class="correction" id="c2">
+            <span class="marker">Candidate Correction 2:</span> This dictionary
+            should include definitions for optional members "language" and
+            "direction" to support use cases where document context is
+            insufficient for the proper internationalization of "error". Values
+            for these members would be the same as for "lang" and "dir" in
+            HTML. The Working Group is monitoring progress on <a href=
+            "https://github.com/w3c/string-meta/issues/54">Localizable in
+            WebIDL</a>.
+          </div>
           <pre class="idl">
             dictionary PaymentValidationErrors {
               DOMString error;

--- a/index.html
+++ b/index.html
@@ -111,11 +111,6 @@
         There has been no change in dependencies on other workings groups
         during the development of this specification.
       </p>
-      <p>
-        This specification includes <a href=
-        "https://www.w3.org/2020/Process-20200915/#candidate-addition">Candidate
-        additions</a>, which are marked in the document.
-      </p>
       <section>
         <h3>
           Changes since last publication
@@ -922,9 +917,7 @@
                 sheet is presented to end users. Instead, the API relies on
                 localization information inherited from the document. The
                 working group is considering support for requesting specific
-                localization of the user interface and of individual
-                {{PaymentItems}} and user-facing error messages in a future
-                version of this API.
+                localization of the user interface.
               </p>
             </aside>
           </li>
@@ -1711,16 +1704,6 @@
       <h2>
         <dfn>PaymentItem</dfn> dictionary
       </h2>
-      <aside class="addition" id="a1">
-        <p>
-        <span class="marker">Candidate Addition 1:</span>
-         This dictionary might include definitions for optional members `lang` and
-        `dir` to indicate the language and base direction of the {{PaymentItem/label}} member. 
-        The Working Group is monitoring progress on <a href=
-        "https://github.com/whatwg/webidl/issues/1025">
-        WebIDL issue 1025</a>. 
-        </p>
-      </aside>
       <pre class="idl">
         dictionary PaymentItem {
           required DOMString label;
@@ -1740,6 +1723,15 @@
         <dd>
           A human-readable description of the item. The <a>user agent</a> may
           display this to the user.
+          <aside class="note" title="Internationalization of the label">
+            <p>
+              The language and direction of the {{PaymentItem/label}} may often
+              be determined from information inherited from the document.
+              However, this approach may not suffice for some use cases. The
+              working group intends to fix this in a future version by aligning
+              with general approaches for the Web that are in development.
+            </p>
+          </aside>
         </dd>
         <dt>
           <dfn>amount</dfn> member
@@ -1960,16 +1952,6 @@
           <h3>
             <dfn>PaymentValidationErrors</dfn> dictionary
           </h3>
-
-          <aside class="addition" id="a2">
-           <p><span class="marker">Candidate Addition 1:</span>
-           This dictionary might include definitions for optional members `lang` and
-           `dir` to indicate the language and base direction of the {{PaymentValidationErrors/error}} member. 
-           The Working Group is monitoring progress on <a href=
-            "https://github.com/whatwg/webidl/issues/1025">
-             WebIDL issue 1025</a>. 
-           </p>
-          </aside>
           <pre class="idl">
             dictionary PaymentValidationErrors {
               DOMString error;
@@ -1988,6 +1970,16 @@
               general overview of validation issues, or it can be passed in
               combination with other members of the {{PaymentValidationErrors}}
               dictionary.
+              <aside class="note" title="Internationalization of the error">
+                <p>
+                  The language and direction of the
+                  {{PaymentValidationErrors/error}} may often be determined
+                  from information inherited from the document. However, this
+                  approach may not suffice for some use cases. The working
+                  group intends to fix this in a future version by aligning
+                  with general approaches for the Web that are in development.
+                </p>
+              </aside>
             </dd>
             <dt>
               <dfn>paymentMethod</dfn> member

--- a/index.html
+++ b/index.html
@@ -111,11 +111,11 @@
         There has been no change in dependencies on other workings groups
         during the development of this specification.
       </p>
-      <div class="correction">
+      <p>
         This specification includes <a href=
-        "https://www.w3.org/Consortium/Process/#candidate-correction">Candidate
-        corrections</a>, which are marked in the document.
-      </div>
+        "https://www.w3.org/2020/Process-20200915/#candidate-addition">Candidate
+        additions</a>, which are marked in the document.
+      </p>
       <section>
         <h3>
           Changes since last publication
@@ -1711,16 +1711,16 @@
       <h2>
         <dfn>PaymentItem</dfn> dictionary
       </h2>
-      <div class="correction" id="c1">
-        <span class="marker">Candidate Correction 1:</span> This dictionary
-        should include definitions for optional members "language" and
-        "direction" to support use cases where document context is insufficient
-        for the proper internationalization of "label". Values for these
-        members would be the same as for "lang" and "dir" in HTML. The Working
-        Group is monitoring progress on <a href=
-        "https://github.com/w3c/string-meta/issues/54">Localizable in
-        WebIDL</a>.
-      </div>
+      <aside class="correction" id="c1">
+        <p>
+        <span class="marker">Candidate Correction 1:</span>
+         This dictionary might include definitions for optional members `lang` and
+        `dir` to indicate the language and text-direction override of {{PaymentItem/label}}. 
+        The Working Group is monitoring progress on <a href=
+        "https://github.com/whatwg/webidl/issues/1025">
+        WebIDL issue 1025</a>. 
+        </p>
+      </aside>
       <pre class="idl">
         dictionary PaymentItem {
           required DOMString label;
@@ -1960,16 +1960,16 @@
           <h3>
             <dfn>PaymentValidationErrors</dfn> dictionary
           </h3>
-          <div class="correction" id="c2">
-            <span class="marker">Candidate Correction 2:</span> This dictionary
-            should include definitions for optional members "language" and
-            "direction" to support use cases where document context is
-            insufficient for the proper internationalization of "error". Values
-            for these members would be the same as for "lang" and "dir" in
-            HTML. The Working Group is monitoring progress on <a href=
-            "https://github.com/w3c/string-meta/issues/54">Localizable in
-            WebIDL</a>.
-          </div>
+
+          <aside class="correction" id="c2">
+           <p><span class="marker">Candidate Correction 1:</span>
+           This dictionary might include definitions for optional members `lang` and
+           `dir` to indicate the language and text-direction override of {{PaymentValidationErrors/error}}. 
+           The Working Group is monitoring progress on <a href=
+            "https://github.com/whatwg/webidl/issues/1025">
+             WebIDL issue 1025</a>. 
+           </p>
+          </aside>
           <pre class="idl">
             dictionary PaymentValidationErrors {
               DOMString error;

--- a/index.html
+++ b/index.html
@@ -1711,7 +1711,7 @@
       <h2>
         <dfn>PaymentItem</dfn> dictionary
       </h2>
-      <aside class="correction" id="c1">
+      <aside class="addition" id="a1">
         <p>
         <span class="marker">Candidate Addition 1:</span>
          This dictionary might include definitions for optional members `lang` and
@@ -1961,7 +1961,7 @@
             <dfn>PaymentValidationErrors</dfn> dictionary
           </h3>
 
-          <aside class="correction" id="c2">
+          <aside class="addition" id="a2">
            <p><span class="marker">Candidate Addition 1:</span>
            This dictionary might include definitions for optional members `lang` and
            `dir` to indicate the language and text-direction override of {{PaymentValidationErrors/error}}. 

--- a/index.html
+++ b/index.html
@@ -1715,7 +1715,7 @@
         <p>
         <span class="marker">Candidate Addition 1:</span>
          This dictionary might include definitions for optional members `lang` and
-        `dir` to indicate the language and text-direction override of {{PaymentItem/label}}. 
+        `dir` to indicate the language and base direction of the {{PaymentItem/label}} member. 
         The Working Group is monitoring progress on <a href=
         "https://github.com/whatwg/webidl/issues/1025">
         WebIDL issue 1025</a>. 
@@ -1964,7 +1964,7 @@
           <aside class="addition" id="a2">
            <p><span class="marker">Candidate Addition 1:</span>
            This dictionary might include definitions for optional members `lang` and
-           `dir` to indicate the language and text-direction override of {{PaymentValidationErrors/error}}. 
+           `dir` to indicate the language and base direction of the {{PaymentValidationErrors/error}} member. 
            The Working Group is monitoring progress on <a href=
             "https://github.com/whatwg/webidl/issues/1025">
              WebIDL issue 1025</a>. 

--- a/index.html
+++ b/index.html
@@ -1713,7 +1713,7 @@
       </h2>
       <aside class="correction" id="c1">
         <p>
-        <span class="marker">Candidate Correction 1:</span>
+        <span class="marker">Candidate Addition 1:</span>
          This dictionary might include definitions for optional members `lang` and
         `dir` to indicate the language and text-direction override of {{PaymentItem/label}}. 
         The Working Group is monitoring progress on <a href=
@@ -1962,7 +1962,7 @@
           </h3>
 
           <aside class="correction" id="c2">
-           <p><span class="marker">Candidate Correction 1:</span>
+           <p><span class="marker">Candidate Addition 1:</span>
            This dictionary might include definitions for optional members `lang` and
            `dir` to indicate the language and text-direction override of {{PaymentValidationErrors/error}}. 
            The Working Group is monitoring progress on <a href=


### PR DESCRIPTION
The Internationalization Working Group has raised concerns about lack of Internationalization support for two strings in the specification (see issues #948 and #951). 

I agree that the specification should support internationalization.

I believe the following is deployment reality:

* In most cases, language context from the document will suffice for the proper representation of the two strings. That is: I believe that explicit metadata for these strings will rarely be needed.
* These strings are either rendered in the browser "sheet" or in "first party" payment apps (e.g., Google Pay and Apple Pay). These strings are not passed to Web-based payment handlers (through Payment Handler API) and, I believe, not passed to "third party" Android native payment handlers.  (There are no third party payment apps with Safari.)
* I also believe that most real-world uses of payment request API involve "skipping" the sheet. That is: calls to Payment Request API involve a single payment method and a single payment app matches, so the browser launches the payment app directly without displaying the sheet. Thus, in practice, rendering these strings in the sheet is rare. 
* In Chrome the sheet has been used as part of built-in support for Basic Card. However, Chrome has signaled that they plan to deprecate their built-in support for Basic Card, so that use of the sheet is likely to go away. The Web Payments Working Group has also retired the Basic Card payment method specification.

Summary: In practice these strings are used almost exclusively used by the Google Pay and Apple Pay native apps. 

Other observations:

* The Web community is working on a platform-wide solution ("Localizable").
* I believe that browser vendors will consider it a low priority to add support for features that will be rarely necessary and for strings that are not directly handled in the browser (but are passed to a small number of native applications).

Given this context, the current pull request seeks a balance:

* Recognize more visibly the need for internationalization support in this specification. Indicate via Candidate Additions [1] that two dictionaries lack "language" and "direction" members. We can continue to work with Google and Apple on support for these features in Google Pay and Apple Pay.
* Indicate that the Working Group is monitoring the Localizable discussion. It may turn out that a platform-wide solution is preferable to a one-off solution; we don't know yet. We have to consider both backward and forward compatibility in determining how to modify the spec in the future.
* Because these features are expected to be used rarely in the near term, allow the specification to advance to Recommendation with the Candidate Additions. 

[Added after posting: if people disagree with the above characterization, please weigh in on that. Thanks!]

I look forward to feedback from @aphillips, @r12a, and the Internationalization Working Group, as well as @marcoscaceres, @stephenmcgruer, @rsolomakhin, and @nickjshearer.

[1] https://www.w3.org/2020/Process-20200915/#candidate-addition

The following tasks have been completed:

 * [✅] Confirmed there are no ReSpec errors/warnings.
 * [ ] Modified Web platform tests (link)
 * [ ] Modified MDN Docs (link)
 
Implementation commitment:

 * [ ] Safari (link to issue)
 * [ ] Chrome (link to issue)
 * [ ] Firefox (link to issue)
 * [ ] Edge (public signal)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/971.html" title="Last updated on Oct 27, 2021, 8:35 PM UTC (8282cae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/971/ee3bd03...8282cae.html" title="Last updated on Oct 27, 2021, 8:35 PM UTC (8282cae)">Diff</a>