### PR TITLE
Define concepts for converting and validating `.data`

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,30 @@
         </li>
       </ul>
       <p>
+        A payment method defines:
+      </p>
+      <dl>
+        <dt>
+          <dfn>Payment Method additional data type</dfn>
+        </dt>
+        <dd>
+          An IDL type that defines the data the <a>payment method</a> expects
+          to receive in the {{PaymentMethodData/data}} member of the
+          {{PaymentMethodData}}. If not specified for a given payment method,
+          no conversion to IDL is done and the payment method will receive
+          {{PaymentMethodData/data}} as JSON.
+        </dd>
+        <dt>
+          <dfn>Steps to validate payment method data</dfn>
+        </dt>
+        <dd>
+          How a <a>payment method</a> validates the {{PaymentMethodData/data}}
+          member of the {{PaymentMethodData}}, after it is converted to the
+          <a>payment method additional data type</a>. If not specified for a
+          given payment method, no validation is done.
+        </dd>
+      </dl>
+      <p>
         The details of how to fulfill a payment request for a given <a>payment
         method</a> is an implementation detail of a <dfn data-export="">payment
         handler</dfn>, which is an application or service that handles requests
@@ -573,27 +597,28 @@
                   |paymentMethod|.{{PaymentMethodData/data}} into a string.
                   Rethrow any exceptions.
                   </li>
-                  <li>If |serializedData| is not null, and if required by the
-                  specification that defines the
-                  |paymentMethod|.{{PaymentMethodData/supportedMethods}}:
+                  <li>If |serializedData| is not null, and if the specification
+                  that defines the
+                  |paymentMethod|.{{PaymentMethodData/supportedMethods}}
+                  specifies a <a>payment method additional data type</a>:
                     <ol>
                       <li>Let |object| be the result of <a data-cite=
                       "ECMASCRIPT#sec-json.parse">JSON-parsing</a>
                       |serializedData|.
                       </li>
                       <li>
-                        <p>
-                          Let |idl| be the result of [=converted to an IDL
+                        <p>Let |idl| be the result of [=converted to an IDL
                           value|converting=] |object| to an IDL value of the
-                          type specified by the specification that defines the
-                          |paymentMethod|.{{PaymentMethodData/supportedMethods}}.
-                          Rethrow any exceptions.
+                          type specified by the <a>payment method additional
+                          data type</a>. Rethrow any exceptions.
                         </p>
+                      </li>
+                      <li>
                         <p>
-                          If required by the specification that defines the
-                          |paymentMethod|.{{PaymentMethodData/supportedMethods}},
-                          validate the members of |idl|. If a member's value is
-                          invalid, throw a {{TypeError}}.
+                          Run the <a>steps to validate payment method data</a>,
+                          if any, from the specification that defines the
+                          |paymentMethod|.{{PaymentMethodData/supportedMethods}}
+                          on |object|. Rethrow any exceptions.
                         </p>
                         <p class="note">
                           These step assures that any IDL type conversion and
@@ -855,10 +880,11 @@
               "ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
               in the |paymentMethod| tuple.
               </li>
-              <li>If required by the specification that defines the
-              |identifier|, then [=converted to an IDL value|convert=] |data|
-              to an IDL value of the type specified there. Otherwise,
-              [=converted to an IDL value|convert=] to {{object}}.
+              <li>If the specification that defines the |identifier| specifies a
+              <a>payment method additional data type</a>, then [=converted to an
+              IDL value|convert=] |data| to an IDL value of that type.
+              Otherwise, [=converted to an IDL value|convert=] |data| to
+              {{object}}.
               </li>
               <li>If conversion results in an <a>exception</a> |error|:
                 <ol>

--- a/index.html
+++ b/index.html
@@ -153,23 +153,24 @@
       </p>
       <dl>
         <dt>
-          <dfn>Payment Method additional data type</dfn>
+          An optional <dfn data-dfn-for="Payment Method">additional data type</dfn>
         </dt>
         <dd>
-          An IDL type that defines the data the <a>payment method</a> expects
-          to receive in the {{PaymentMethodData/data}} member of the
-          {{PaymentMethodData}}. If not specified for a given payment method,
-          no conversion to IDL is done and the payment method will receive
+          Optionally, an IDL type that the <a>payment method</a> expects
+          to receive as the {{PaymentMethodData}}'s {{PaymentMethodData/data}}
+          member. If not specified for a given payment method, no conversion to
+          IDL is done and the payment method will receive
           {{PaymentMethodData/data}} as JSON.
         </dd>
         <dt>
           <dfn>Steps to validate payment method data</dfn>
         </dt>
         <dd>
-          How a <a>payment method</a> validates the {{PaymentMethodData/data}}
-          member of the {{PaymentMethodData}}, after it is converted to the
-          <a>payment method additional data type</a>. If not specified for a
-          given payment method, no validation is done.
+          Algorithmic steps that specify how a <a>payment method</a> validates
+          the {{PaymentMethodData/data}} member of the {{PaymentMethodData}},
+          after it is converted to the payment method's
+          [=Payment Method/additional data type=]. If not specified for a given
+          payment method, no validation is done.
         </dd>
       </dl>
       <p>
@@ -600,17 +601,18 @@
                   <li>If |serializedData| is not null, and if the specification
                   that defines the
                   |paymentMethod|.{{PaymentMethodData/supportedMethods}}
-                  specifies a <a>payment method additional data type</a>:
+                  specifies an [=Payment Method/additional data type=]:
                     <ol>
                       <li>Let |object| be the result of <a data-cite=
                       "ECMASCRIPT#sec-json.parse">JSON-parsing</a>
                       |serializedData|.
                       </li>
                       <li>
-                        <p>Let |idl| be the result of [=converted to an IDL
+                        <p>
+                          Let |idl| be the result of [=converted to an IDL
                           value|converting=] |object| to an IDL value of the
-                          type specified by the <a>payment method additional
-                          data type</a>. Rethrow any exceptions.
+                          [=Payment Method/additional data type=]. Rethrow any
+                          exceptions.
                         </p>
                       </li>
                       <li>
@@ -880,8 +882,8 @@
               "ECMASCRIPT#sec-json.parse">JSON-parsing</a> the second element
               in the |paymentMethod| tuple.
               </li>
-              <li>If the specification that defines the |identifier| specifies a
-              <a>payment method additional data type</a>, then [=converted to an
+              <li>If the specification that defines the |identifier| specifies
+              an [=Payment Method/additional data type=], then [=converted to an
               IDL value|convert=] |data| to an IDL value of that type.
               Otherwise, [=converted to an IDL value|convert=] |data| to
               {{object}}.


### PR DESCRIPTION
This PR introduces two new definitions (`dfn`) for both the IDL type that
`PaymentMethodData/data` should be converted into, and for the validation
steps that a payment method will perform on it. This allows payment method
specs to define these in a way that is cross-linkable to the PaymentRequest
specification.

This change is mostly editorial, **except** that it allows for arbitrary error types
to be thrown during validation (previously only `TypeError` would be thrown).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/977.html" title="Last updated on Jul 6, 2022, 1:30 PM UTC (05f8d67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/977/b6b0630...05f8d67.html" title="Last updated on Jul 6, 2022, 1:30 PM UTC (05f8d67)">Diff</a>