### PR TITLE
Revert "Drop PaymentAddress, shipping + billing address support (#955)"

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
     };
     </script>
   </head>
-  <body data-cite="payment-method-id">
+  <body data-cite="payment-method-id contact-picker">
     <h1 id="title">
       Payment Request API
     </h1>
@@ -273,10 +273,15 @@
         </li>
         <li>The |details|: The details of the transaction, as a
         <a>PaymentDetailsInit</a> dictionary. This includes total cost, and
-        optionally a list of goods or services being purchased. Additionally,
-        it can optionally include "modifiers" to how payments are made. For
-        example, "if you pay with a card belonging to network X, it incurs a
-        US$3.00 processing fee".
+        optionally a list of goods or services being purchased, for physical
+        goods, and shipping options. Additionally, it can optionally include
+        "modifiers" to how payments are made. For example, "if you pay with a
+        card belonging to network X, it incurs a US$3.00 processing fee".
+        </li>
+        <li>The |options|: Optionally, a list of things as {{PaymentOptions}}
+        that the site needs to deliver the good or service (e.g., for physical
+        goods, the merchant will typically need a physical address to ship to.
+        For digital goods, an email will usually suffice).
         </li>
       </ul>
       <p>
@@ -340,18 +345,42 @@
                 label: "Value-Added Tax (VAT)",
                 amount: { currency: "GBP", value: "5.00" },
               },
-              {
-                label: "Standard shipping",
-                amount: { currency: "GBP", value: "5.00" },
-              },
             ],
             total: {
               label: "Total due",
               // The total is GBP£65.00 here because we need to
-              // add tax and shipping.
+              // add shipping (below). The selected shipping
+              // costs GBP£5.00.
               amount: { currency: "GBP", value: "65.00" },
             },
           };
+        </pre>
+      </section>
+      <section>
+        <h3>
+          Adding shipping options
+        </h3>
+        <p>
+          Here we see an example of how to add two shipping options to the
+          |details|.
+        </p>
+        <pre class="example js" title="Adding shipping options">
+          const shippingOptions = [
+            {
+              id: "standard",
+              // Shipping by truck, 2 days
+              label: "🚛  Envío por camión (2 dias)",
+              amount: { currency: "EUR", value: "5.00" },
+              selected: true,
+            },
+            {
+              id: "drone",
+              // Drone shipping, 2 hours
+              label: "🚀 Drone Express (2 horas)",
+              amount: { currency: "EUR", value: "25.00" }
+            },
+          ];
+          Object.assign(details, { shippingOptions });
         </pre>
       </section>
       <section>
@@ -390,6 +419,30 @@
       </section>
       <section>
         <h3>
+          Requesting specific information from the end user
+        </h3>
+        <p>
+          Some financial transactions require a user to provide specific
+          information in order for a merchant to fulfill a purchase (e.g., the
+          user's shipping address, in case a physical good needs to be
+          shipped). To request this information, a merchant can pass a third
+          optional argument (|options:PaymentOptions |) to the
+          {{PaymentRequest}} constructor indicating what information they
+          require. When the payment request is shown, the user agent will
+          request this information from the end user and return it to the
+          merchant when the user accepts the payment request.
+        </p>
+        <pre class="example js" title="The `options` argument">
+          const options = {
+            requestPayerEmail: false,
+            requestPayerName: true,
+            requestPayerPhone: false,
+            requestShipping: true,
+          }
+        </pre>
+      </section>
+      <section>
+        <h3>
           Constructing a <code>PaymentRequest</code>
         </h3>
         <p>
@@ -400,7 +453,10 @@
         <pre class="example js" title="Constructing a `PaymentRequest`">
           async function doPaymentRequest() {
             try {
-              const request = new PaymentRequest(methodData, details);
+              const request = new PaymentRequest(methodData, details, options);
+              // See below for a detailed example of handling these events
+              request.onshippingaddresschange = ev =&gt; ev.updateWith(details);
+              request.onshippingoptionchange = ev =&gt; ev.updateWith(details);
               const response = await request.show();
               await validateResponse(response);
             } catch (err) {
@@ -424,6 +480,80 @@
           // Must be called as a result of a click
           // or some explicit user action.
           doPaymentRequest();
+        </pre>
+      </section>
+      <section>
+        <h3>
+          Handling events and updating the payment request
+        </h3>
+        <p>
+          Prior to the user accepting to make payment, the site is given an
+          opportunity to update the payment request in response to user input.
+          This can include, for example, providing additional shipping options
+          (or modifying their cost), removing items that cannot ship to a
+          particular address, etc.
+        </p>
+        <pre class="example js" title="Registering event handlers">
+          const request = new PaymentRequest(methodData, details, options);
+          // Async update to details
+          request.onshippingaddresschange = ev =&gt; {
+            ev.updateWith(checkShipping(request));
+          };
+          // Sync update to the total
+          request.onshippingoptionchange = ev =&gt; {
+            // selected shipping option
+            const { shippingOption } = request;
+            const newTotal = {
+              currency: "USD",
+              label: "Total due",
+              value: calculateNewTotal(shippingOption),
+            };
+            ev.updateWith({ total: newTotal });
+          };
+          async function checkShipping(request) {
+            try {
+              const { shippingAddress } = request;
+
+              await ensureCanShipTo(shippingAddress);
+              const { shippingOptions, total } = await calculateShipping(shippingAddress);
+
+              return { shippingOptions, total };
+            } catch (err) {
+              // Shows error to user in the payment sheet.
+              return { error: `Sorry! we can't ship to your address.` };
+            }
+          }
+        </pre>
+      </section>
+      <section>
+        <h3>
+          Fine-grained error reporting
+        </h3>
+        <p>
+          A developer can use the
+          {{PaymentDetailsUpdate/shippingAddressErrors}} member of the
+          {{PaymentDetailsUpdate}} dictionary to indicate that there are
+          validation errors with specific attributes of a {{ContactAddress}}.
+          The {{PaymentDetailsUpdate/shippingAddressErrors}} member is a
+          {{AddressErrors}} dictionary, whose members specifically demarcate
+          the fields of a [=physical address=] that are erroneous while also
+          providing helpful error messages to be displayed to the end user.
+        </p>
+        <pre class="example js">
+          request.onshippingaddresschange = ev =&gt; {
+            ev.updateWith(validateAddress(request.shippingAddress));
+          };
+          function validateAddress(shippingAddress) {
+            const error = "Can't ship to this address.";
+            const shippingAddressErrors = {
+              city: "FarmVille is not a real place.",
+              postalCode: "Unknown postal code for your country.",
+            };
+            // Empty shippingOptions implies that we can't ship
+            // to this address.
+            const shippingOptions = [];
+            return { error, shippingAddressErrors, shippingOptions };
+          }
         </pre>
       </section>
       <section>
@@ -492,7 +622,8 @@
         interface PaymentRequest : EventTarget {
           constructor(
             sequence&lt;PaymentMethodData&gt; methodData,
-            PaymentDetailsInit details
+            PaymentDetailsInit details,
+            optional PaymentOptions options = {}
           );
           [NewObject]
           Promise&lt;PaymentResponse&gt; show(optional Promise&lt;PaymentDetailsUpdate&gt; detailsPromise);
@@ -502,7 +633,12 @@
           Promise&lt;boolean&gt; canMakePayment();
 
           readonly attribute DOMString id;
+          readonly attribute ContactAddress? shippingAddress;
+          readonly attribute DOMString? shippingOption;
+          readonly attribute PaymentShippingType? shippingType;
 
+          attribute EventHandler onshippingaddresschange;
+          attribute EventHandler onshippingoptionchange;
           attribute EventHandler onpaymentmethodchange;
         };
       </pre>
@@ -516,6 +652,12 @@
           allows developers to exchange information with the <a>user agent</a>
           while the user is providing input (up to the point of user approval
           or denial of the payment request).
+        </p>
+        <p>
+          The {{PaymentRequest/shippingAddress}},
+          {{PaymentRequest/shippingOption}}, and
+          {{PaymentRequest/shippingType}} attributes are populated during
+          processing if the {{PaymentOptions/requestShipping}} member is set.
         </p>
       </div>
       <p>
@@ -540,14 +682,15 @@
         <p>
           The {{PaymentRequest}} is constructed using the supplied sequence of
           <a>PaymentMethodData</a> |methodData| including any <a>payment
-          method</a> specific {{PaymentMethodData/data}}, and the
-          <a>PaymentDetailsInit</a> |details|.
+          method</a> specific {{PaymentMethodData/data}}, the
+          <a>PaymentDetailsInit</a> |details|, and the {{PaymentOptions}}
+          |options|.
         </p>
         <p data-tests=
         "payment-request-constructor.https.sub.html, payment-request-insecure.http.html">
           The <code><dfn data-lt=
           "PaymentRequest.PaymentRequest()">PaymentRequest(|methodData|,
-          |details|)</dfn></code> constructor MUST act as follows:
+          |details|, |options|)</dfn></code> constructor MUST act as follows:
         </p>
         <ol class="algorithm">
           <li>If [=this=]'s [=relevant global object=]'s [=associated
@@ -668,6 +811,48 @@
               </li>
             </ol>
           </li>
+          <li>Let |selectedShippingOption| be null.
+          </li>
+          <li>If the {{PaymentOptions/requestShipping}} member of |options| is
+          present and set to true, process shipping options:
+            <ol>
+              <li>Let |options:PaymentShippingOption| be an empty
+              <code><a>sequence</a></code>&lt;{{PaymentShippingOption}}&gt;.
+              </li>
+              <li>If the {{PaymentDetailsBase/shippingOptions}} member of
+              |details| is present, then:
+                <ol>
+                  <li>Let |seenIDs| be an empty set.
+                  </li>
+                  <li>For each |option:PaymentShippingOption| in
+                  |details|.{{PaymentDetailsBase/shippingOptions}}:
+                    <ol>
+                      <li data-tests=
+                      "payment-request-ctor-currency-code-checks.https.sub.html">
+                        <a>Check and canonicalize amount</a>
+                        |item|.{{PaymentItem/amount}}. Rethrow any exceptions.
+                      </li>
+                      <li>If |seenIDs| contains
+                      |option|.{{PaymentShippingOption/id}}, then throw a
+                      {{TypeError}}. Optionally, inform the developer that
+                      shipping option IDs must be unique.
+                      </li>
+                      <li>Otherwise, append
+                      |option|.{{PaymentShippingOption/id}} to |seenIDs|.
+                      </li>
+                      <li>If |option|.{{PaymentShippingOption/selected}} is
+                      true, then set |selectedShippingOption| to
+                      |option|.{{PaymentShippingOption/id}}.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>Set |details|.{{PaymentDetailsBase/shippingOptions}} to
+              |options|.
+              </li>
+            </ol>
+          </li>
           <li>Let |serializedModifierData| be an empty list.
           </li>
           <li>Process payment details modifiers:
@@ -735,6 +920,8 @@
           </li>
           <li>Set |request|.{{PaymentRequest/[[handler]]}} to `null`.
           </li>
+          <li>Set |request|.{{PaymentRequest/[[options]]}} to |options|.
+          </li>
           <li>Set |request|.{{PaymentRequest/[[state]]}} to
           "[=PaymentRequest/created=]".
           </li>
@@ -749,6 +936,17 @@
           |serializedMethodData|.
           </li>
           <li>Set |request|.{{PaymentRequest/[[response]]}} to null.
+          </li>
+          <li>Set the value of |request|'s {{PaymentRequest/shippingOption}}
+          attribute to |selectedShippingOption|.
+          </li>
+          <li>Set the value of the {{PaymentRequest/shippingAddress}} attribute
+          on |request| to null.
+          </li>
+          <li>If |options|.{{PaymentOptions/requestShipping}} is set to true,
+          then set the value of the {{PaymentRequest/shippingType}} attribute
+          on |request| to |options|.{{PaymentOptions/shippingType}}. Otherwise,
+          set it to null.
           </li>
           <li>Return |request|.
           </li>
@@ -1210,6 +1408,64 @@
       </section>
       <section data-dfn-for="PaymentRequest">
         <h2>
+          <dfn>shippingAddress</dfn> attribute
+        </h2>
+        <p data-tests="shipping-address-changed-manual.https.html">
+          A {{PaymentRequest}}'s {{PaymentRequest/shippingAddress}} attribute
+          is populated when the user provides a shipping address. It is null by
+          default. When a user provides a shipping address, the <a>shipping
+          address changed algorithm</a> runs.
+        </p>
+      </section>
+      <section data-dfn-for="PaymentRequest">
+        <h2>
+          <dfn>shippingType</dfn> attribute
+        </h2>
+        <p data-tests="payment-request-shippingType-attribute.https.html">
+          A {{PaymentRequest}}'s {{PaymentRequest/shippingType}} attribute is
+          the type of shipping used to fulfill the transaction. Its value is
+          either a {{PaymentShippingType}} enum value, or null if none is
+          provided by the developer during
+          [=PaymentRequest.PaymentRequest()|construction=] (see
+          {{PaymentOptions}}'s {{PaymentOptions/shippingType}} member).
+        </p>
+      </section>
+      <section data-dfn-for="PaymentRequest">
+        <h2>
+          <dfn>onshippingaddresschange</dfn> attribute
+        </h2>
+        <p data-tests=
+        "shipping-address-changed-manual.https.html, payment-request-onshippingaddresschange-attribute.https.html, algorithms-manual.https.html#shipping-address-changed-algo">
+          A {{PaymentRequest}}'s {{PaymentRequest/onshippingaddresschange}}
+          attribute is an {{EventHandler}} for a {{PaymentRequestUpdateEvent}}
+          named <a>shippingaddresschange</a>.
+        </p>
+      </section>
+      <section data-dfn-for="PaymentRequest">
+        <h2>
+          <dfn>shippingOption</dfn> attribute
+        </h2>
+        <p data-tests=
+        "payment-request-shippingOption-attribute.https.html, change-shipping-option-manual.https.html">
+          A {{PaymentRequest}}'s {{PaymentRequest/shippingOption}} attribute is
+          populated when the user chooses a shipping option. It is null by
+          default. When a user chooses a shipping option, the <a>shipping
+          option changed algorithm</a> runs.
+        </p>
+      </section>
+      <section data-dfn-for="PaymentRequest">
+        <h2>
+          <dfn>onshippingoptionchange</dfn> attribute
+        </h2>
+        <p data-tests=
+        "payment-request-onshippingoptionchange-attribute.https.html">
+          A {{PaymentRequest}}'s {{PaymentRequest/onshippingoptionchange}}
+          attribute is an {{EventHandler}} for a {{PaymentRequestUpdateEvent}}
+          named <a>shippingoptionchange</a>.
+        </p>
+      </section>
+      <section data-dfn-for="PaymentRequest">
+        <h2>
           <dfn>onpaymentmethodchange</dfn> attribute
         </h2>
         <p>
@@ -1276,7 +1532,16 @@
           </tr>
           <tr>
             <td>
-              <dfn data-dfn-for="PaymentRequest">[[\state]]</dfn>
+              <dfn data-export="" data-dfn-for=
+              "PaymentRequest">[[\options]]</dfn>
+            </td>
+            <td>
+              The {{PaymentOptions}} supplied to the constructor.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>[[\state]]</dfn>
             </td>
             <td>
               <p>
@@ -1571,6 +1836,7 @@
         <pre class="idl">
         dictionary PaymentDetailsBase {
           sequence&lt;PaymentItem&gt; displayItems;
+          sequence&lt;PaymentShippingOption&gt; shippingOptions;
           sequence&lt;PaymentDetailsModifier&gt; modifiers;
         };
         </pre>
@@ -1585,6 +1851,41 @@
               It is the developer's responsibility, when generating or updating
               a {{PaymentRequest}}, to verify that the
               {{PaymentDetailsInit/total}} amount is the sum of these items.
+            </aside>
+          </dd>
+          <dt>
+            <dfn>shippingOptions</dfn> member
+          </dt>
+          <dd>
+            <p>
+              A sequence containing the different shipping options for the user
+              to choose from.
+            </p>
+            <p data-tests=
+            "change-shipping-option-select-last-manual.https.html">
+              If an item in the sequence has the
+              {{PaymentShippingOption/selected}} member set to true, then this
+              is the shipping option that will be used by default and
+              {{PaymentRequest/shippingOption}} will be set to the
+              {{PaymentShippingOption/id}} of this option without running the
+              <a>shipping option changed algorithm</a>. If more than one item
+              in the sequence has {{PaymentShippingOption/selected}} set to
+              true, then the <a>user agent</a> selects the last one in the
+              sequence.
+            </p>
+            <p>
+              The {{PaymentDetailsBase/shippingOptions}} member is only used if
+              the {{PaymentRequest}} was constructed with {{PaymentOptions}}
+              and {{PaymentOptions/requestShipping}} set to true.
+            </p>
+            <aside class="note">
+              If the sequence has an item with the
+              {{PaymentShippingOption/selected}} member set to true, then
+              authors are responsible for ensuring that the
+              {{PaymentDetailsInit/total}} member includes the cost of the
+              shipping option. This is because no <a>shippingoptionchange</a>
+              event will be fired for this option unless the user selects an
+              alternative option first.
             </aside>
           </dd>
           <dt>
@@ -1650,7 +1951,10 @@
         </h2>
         <pre class="idl">
           dictionary PaymentDetailsUpdate : PaymentDetailsBase {
+            DOMString error;
             PaymentItem total;
+            AddressErrors shippingAddressErrors;
+            PayerErrors payerErrors;
             object paymentMethodErrors;
           };
         </pre>
@@ -1665,6 +1969,21 @@
         </p>
         <dl>
           <dt>
+            <dfn>error</dfn> member
+          </dt>
+          <dd>
+            A human-readable string that explains why goods cannot be shipped
+            to the chosen shipping address, or any other reason why no shipping
+            options are available. When the payment request is updated using
+            {{PaymentRequestUpdateEvent/updateWith()}}, the
+            {{PaymentDetailsUpdate}} can contain a message in the
+            {{PaymentDetailsUpdate/error}} member that will be displayed to the
+            user if the {{PaymentDetailsUpdate}} indicates that there are no
+            valid {{PaymentDetailsBase/shippingOptions}} (and the
+            {{PaymentRequest}} was constructed with the
+            {{PaymentOptions/requestShipping}} option set to true).
+          </dd>
+          <dt>
             <dfn>total</dfn> member
           </dt>
           <dd>
@@ -1675,6 +1994,19 @@
               {{PaymentDetailsUpdate/total}}.{{PaymentItem/amount}}.{{PaymentCurrencyAmount/value}}
               is a negative number.
             </p>
+          </dd>
+          <dt>
+            <dfn>shippingAddressErrors</dfn> member
+          </dt>
+          <dd>
+            Represents validation errors with the shipping address that is
+            associated with the <a>potential event target</a>.
+          </dd>
+          <dt>
+            <dfn>payerErrors</dfn> member
+          </dt>
+          <dd>
+            Validation errors related to the <a>payer details</a>.
           </dd>
           <dt>
             <dfn>paymentMethodErrors</dfn> member
@@ -1749,6 +2081,133 @@
           An object that provides optional information that might be needed by
           the supported payment methods. If supplied, it will be [=serialize a
           JavaScript value to a JSON string|serialized=].
+        </dd>
+      </dl>
+    </section>
+    <section data-dfn-for="PaymentShippingType">
+      <h2>
+        <dfn>PaymentShippingType</dfn> enum
+      </h2>
+      <pre class="idl">
+        enum PaymentShippingType {
+          "shipping",
+          "delivery",
+          "pickup"
+        };
+      </pre>
+      <dl>
+        <dt>
+          "<dfn>shipping</dfn>"
+        </dt>
+        <dd>
+          This is the default and refers to the [=physical address|address=]
+          being collected as the destination for [=shipping address|shipping=].
+        </dd>
+        <dt>
+          "<dfn>delivery</dfn>"
+        </dt>
+        <dd>
+          This refers to the [=physical address|address=] being collected as
+          the destination for delivery. This is commonly faster than [=shipping
+          address|shipping=]. For example, it might be used for food delivery.
+        </dd>
+        <dt>
+          "<dfn>pickup</dfn>"
+        </dt>
+        <dd>
+          This refers to the [=physical address|address=] being collected as
+          part of a service pickup. For example, this could be the address for
+          laundry pickup.
+        </dd>
+      </dl>
+    </section>
+    <section data-dfn-for="PaymentOptions">
+      <h2>
+        <dfn>PaymentOptions</dfn> dictionary
+      </h2>
+      <pre class="idl">
+        dictionary PaymentOptions {
+          boolean requestPayerName = false;
+          boolean requestBillingAddress = false;
+          boolean requestPayerEmail = false;
+          boolean requestPayerPhone = false;
+          boolean requestShipping = false;
+          PaymentShippingType shippingType = "shipping";
+        };
+      </pre>
+      <p class="note">
+        The {{PaymentOptions}} dictionary is passed to the {{PaymentRequest}}
+        constructor and provides information about the options desired for the
+        payment request.
+      </p>
+      <dl>
+        <dt>
+          <dfn>requestBillingAddress</dfn> member
+        </dt>
+        <dd>
+          A boolean that indicates whether the <a>user agent</a> SHOULD collect
+          and return the [=billing address=] associated with a <a>payment
+          method</a> (e.g., the billing address associated with a credit card).
+          Typically, the user agent will return the billing address as part of
+          the {{PaymentMethodChangeEvent}}'s
+          {{PaymentMethodChangeEvent/methodDetails}}. A merchant can use this
+          information to, for example, calculate tax in certain jurisdictions
+          and update the displayed total. See below for privacy considerations
+          regarding <a href="#user-info">exposing user information</a>.
+        </dd>
+        <dt>
+          <dfn>requestPayerName</dfn> member
+        </dt>
+        <dd>
+          A boolean that indicates whether the <a>user agent</a> SHOULD collect
+          and return the payer's name as part of the payment request. For
+          example, this would be set to true to allow a merchant to make a
+          booking in the payer's name.
+        </dd>
+        <dt>
+          <dfn>requestPayerEmail</dfn> member
+        </dt>
+        <dd>
+          A boolean that indicates whether the <a>user agent</a> SHOULD collect
+          and return the payer's email address as part of the payment request.
+          For example, this would be set to true to allow a merchant to email a
+          receipt.
+        </dd>
+        <dt>
+          <dfn>requestPayerPhone</dfn> member
+        </dt>
+        <dd>
+          A boolean that indicates whether the <a>user agent</a> SHOULD collect
+          and return the payer's phone number as part of the payment request.
+          For example, this would be set to true to allow a merchant to phone a
+          customer with a billing enquiry.
+        </dd>
+        <dt>
+          <dfn>requestShipping</dfn> member
+        </dt>
+        <dd>
+          A boolean that indicates whether the <a>user agent</a> SHOULD collect
+          and return a [=shipping address=] as part of the payment request. For
+          example, this would be set to true when physical goods need to be
+          shipped by the merchant to the user. This would be set to false for
+          the purchase of digital goods.
+        </dd>
+        <dt>
+          <dfn>shippingType</dfn> member
+        </dt>
+        <dd>
+          A {{PaymentShippingType}} enum value. Some transactions require an
+          [=physical address|address=] for delivery but the term "shipping"
+          isn't appropriate. For example, "pizza delivery" not "pizza shipping"
+          and "laundry pickup" not "laundry shipping". If
+          {{PaymentOptions/requestShipping}} is set to true, then the
+          {{PaymentOptions/shippingType}} member can influence the way the
+          <a>user agent</a> presents the user interface for gathering the
+          shipping address.
+          <p>
+            The {{PaymentOptions/shippingType}} member only affects the user
+            interface for the payment request.
+          </p>
         </dd>
       </dl>
     </section>
@@ -1869,6 +2328,58 @@
         </dd>
       </dl>
     </section>
+    <section data-dfn-for="PaymentShippingOption">
+      <h2>
+        <dfn>PaymentShippingOption</dfn> dictionary
+      </h2>
+      <pre class="idl">
+        dictionary PaymentShippingOption {
+          required DOMString id;
+          required DOMString label;
+          required PaymentCurrencyAmount amount;
+          boolean selected = false;
+        };
+      </pre>
+      <p>
+        The {{PaymentShippingOption}} dictionary has members describing a
+        shipping option. Developers can provide the user with one or more
+        shipping options by calling the
+        {{PaymentRequestUpdateEvent/updateWith()}} method in response to a
+        change event.
+      </p>
+      <dl>
+        <dt>
+          <dfn>id</dfn> member
+        </dt>
+        <dd>
+          A string identifier used to reference this {{PaymentShippingOption}}.
+          It MUST be unique for a given {{PaymentRequest}}.
+        </dd>
+        <dt>
+          <dfn>label</dfn> member
+        </dt>
+        <dd>
+          A human-readable string description of the item. The <a>user
+          agent</a> SHOULD use this string to display the shipping option to
+          the user.
+        </dd>
+        <dt>
+          <dfn>amount</dfn> member
+        </dt>
+        <dd>
+          A {{PaymentCurrencyAmount}} containing the monetary amount for the
+          item.
+        </dd>
+        <dt>
+          <dfn>selected</dfn> member
+        </dt>
+        <dd>
+          A boolean. When true, it indicates that this is the default selected
+          {{PaymentShippingOption}} in a sequence. <a>User agents</a> SHOULD
+          display this option by default in the user interface.
+        </dd>
+      </dl>
+    </section>
     <section data-dfn-for="PaymentResponse">
       <h2>
         <dfn>PaymentResponse</dfn> interface
@@ -1881,6 +2392,11 @@
           readonly attribute DOMString requestId;
           readonly attribute DOMString methodName;
           readonly attribute object details;
+          readonly attribute ContactAddress? shippingAddress;
+          readonly attribute DOMString? shippingOption;
+          readonly attribute DOMString? payerName;
+          readonly attribute DOMString? payerEmail;
+          readonly attribute DOMString? payerPhone;
 
           [NewObject]
           Promise&lt;undefined&gt; complete(
@@ -1889,6 +2405,8 @@
           );
           [NewObject]
           Promise&lt;undefined&gt; retry(optional PaymentValidationErrors errorFields = {});
+
+          attribute EventHandler onpayerdetailchange;
         };
       </pre>
       <p class="note">
@@ -1928,7 +2446,7 @@
             during {{PaymentResponse/retry()}}.
           </p>
         </aside>
-        <p>
+        <p data-tests="payment-response/retry-method-manual.https.html">
           The <code>retry(|errorFields:PaymentValidationErrors|)</code> method
           MUST act as follows:
         </p>
@@ -1964,6 +2482,35 @@
           </li>
           <li>If |errorFields:PaymentValidationErrors| was passed:
             <ol>
+              <li>Optionally, show a warning in the developer console if any of
+              the following are true:
+                <ol>
+                  <li>
+                  |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestPayerName}}
+                  is false, and
+                  |errorFields|.{{PaymentValidationErrors/payer}}.{{PayerErrors/name}}
+                  is present.
+                  </li>
+                  <li>
+                  |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestPayerEmail}}
+                  is false, and
+                  |errorFields|.{{PaymentValidationErrors/payer}}.{{PayerErrors/email}}
+                  is present.
+                  </li>
+                  <li>
+                  |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestPayerPhone}}
+                  is false, and
+                  |errorFields|.{{PaymentValidationErrors/payer}}.{{PayerErrors/phone}}
+                  is present.
+                  </li>
+                  <li>
+                  |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestShipping}}
+                  is false, and
+                  |errorFields|.{{PaymentValidationErrors/shippingAddress}} is
+                  present.
+                  </li>
+                </ol>
+              </li>
               <li data-tests=
               "PaymentValidationErrors/retry-shows-error-member-manual.https.html">
               If
@@ -2039,11 +2586,26 @@
           </h3>
           <pre class="idl">
             dictionary PaymentValidationErrors {
+              PayerErrors payer;
+              AddressErrors shippingAddress;
               DOMString error;
               object paymentMethod;
             };
           </pre>
           <dl>
+            <dt>
+              <dfn>payer</dfn> member
+            </dt>
+            <dd>
+              Validation errors related to the <a>payer details</a>.
+            </dd>
+            <dt>
+              <dfn>shippingAddress</dfn> member
+            </dt>
+            <dd>
+              Represents validation errors with the {{PaymentResponse}}'s
+              {{PaymentResponse/shippingAddress}}.
+            </dd>
             <dt>
               <dfn>error</dfn> member
             </dt>
@@ -2073,6 +2635,63 @@
               A payment method specific errors.
             </dd>
           </dl>
+        </section>
+        <section data-dfn-for="PayerErrors">
+          <h3>
+            <dfn>PayerErrors</dfn> dictionary
+          </h3>
+          <pre class="idl">
+          dictionary PayerErrors {
+            DOMString email;
+            DOMString name;
+            DOMString phone;
+          };
+          </pre>
+          <p>
+            The {{PayerErrors}} is used to represent validation errors with one
+            or more <a>payer details</a>.
+          </p>
+          <p>
+            <dfn>Payer details</dfn> are any of the payer's name, payer's phone
+            number, and payer's email.
+          </p>
+          <dl>
+            <dt>
+              <dfn>email</dfn> member
+            </dt>
+            <dd>
+              Denotes that the payer's email suffers from a validation error.
+              In the user agent's UI, this member corresponds to the input
+              field that provided the {{PaymentResponse}}'s
+              {{PaymentResponse/payerEmail}} attribute's value.
+            </dd>
+            <dt>
+              <dfn>name</dfn> member
+            </dt>
+            <dd>
+              Denotes that the payer's name suffers from a validation error. In
+              the user agent's UI, this member corresponds to the input field
+              that provided the {{PaymentResponse}}'s
+              {{PaymentResponse/payerName}} attribute's value.
+            </dd>
+            <dt>
+              <dfn>phone</dfn> member
+            </dt>
+            <dd>
+              Denotes that the payer's phone number suffers from a validation
+              error. In the user agent's UI, this member corresponds to the
+              input field that provided the {{PaymentResponse}}'s
+              {{PaymentResponse/payerPhone}} attribute's value.
+            </dd>
+          </dl>
+          <pre class="example js" title="Payer-related validation errors">
+            const payer = {
+              email: "The domain is invalid.",
+              phone: "Unknown country code.",
+              name: "Not in database.",
+            };
+            await response.retry({ payer });
+          </pre>
         </section>
       </section>
       <section>
@@ -2110,6 +2729,66 @@
             <a>details</a> object.
           </p>
         </aside>
+      </section>
+      <section>
+        <h2>
+          <dfn>shippingAddress</dfn> attribute
+        </h2>
+        <p data-tests=
+        "payment-response/shippingAddress-attribute-manual.https.html">
+          If the {{PaymentOptions/requestShipping}} member was set to true in
+          the {{PaymentOptions}} passed to the {{PaymentRequest}} constructor,
+          then {{PaymentRequest/shippingAddress}} will be the full and final
+          [=shipping address=] chosen by the user.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>shippingOption</dfn> attribute
+        </h2>
+        <p data-tests=
+        "payment-response/shippingOption-attribute-manual.https.html">
+          If the {{PaymentOptions/requestShipping}} member was set to true in
+          the {{PaymentOptions}} passed to the {{PaymentRequest}} constructor,
+          then {{PaymentRequest/shippingOption}} will be the
+          {{PaymentShippingOption/id}} attribute of the selected shipping
+          option.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>payerName</dfn> attribute
+        </h2>
+        <p data-tests="payment-response/payerName-attribute-manual.https.html">
+          If the {{PaymentOptions/requestPayerName}} member was set to true in
+          the {{PaymentOptions}} passed to the {{PaymentRequest}} constructor,
+          then {{PaymentResponse/payerName}} will be the name provided by the
+          user.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>payerEmail</dfn> attribute
+        </h2>
+        <p data-tests=
+        "payment-response/payerEmail-attribute-manual.https.html">
+          If the {{PaymentOptions/requestPayerEmail}} member was set to true in
+          the {{PaymentOptions}} passed to the {{PaymentRequest}} constructor,
+          then {{PaymentResponse/payerEmail}} will be the email address chosen
+          by the user.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>payerPhone</dfn> attribute
+        </h2>
+        <p data-tests=
+        "payment-response/payerPhone-attribute-manual.https.html">
+          If the {{PaymentOptions/requestPayerPhone}} member was set to true in
+          the {{PaymentOptions}} passed to the {{PaymentRequest}} constructor,
+          then {{PaymentResponse/payerPhone}} will be the phone number chosen
+          by the user.
+        </p>
       </section>
       <section>
         <h2>
@@ -2232,6 +2911,14 @@
           </li>
         </ol>
       </section>
+      <section data-dfn-for="PaymentResponse">
+        <h2>
+          <dfn>onpayerdetailchange</dfn> attribute
+        </h2>
+        <p>
+          Allows a developer to handle "<a>payerdetailchange</a>" events.
+        </p>
+      </section>
       <section>
         <h2>
           Internal Slots
@@ -2282,6 +2969,142 @@
         </table>
       </section>
     </section>
+    <section>
+      <h2>
+        Shipping and billing addresses
+      </h2>
+      <p>
+        The {{PaymentRequest}} interface allows a merchant to request from the
+        user [=physical address|physical addresses=] for the purposes of
+        shipping and/or billing. A <dfn>shipping address</dfn> and <dfn>billing
+        address</dfn> are [=physical address|physical addresses=].
+      </p>
+      <section data-dfn-for="AddressErrors">
+        <h2>
+          <dfn>AddressErrors</dfn> dictionary
+        </h2>
+        <pre class="idl">
+          dictionary AddressErrors {
+            DOMString addressLine;
+            DOMString city;
+            DOMString country;
+            DOMString dependentLocality;
+            DOMString organization;
+            DOMString phone;
+            DOMString postalCode;
+            DOMString recipient;
+            DOMString region;
+            DOMString sortingCode;
+          };
+        </pre>
+        <p>
+          The members of the {{AddressErrors}} dictionary represent validation
+          errors with specific parts of a [=physical address=]. Each
+          dictionary member has a dual function: firstly, its presence denotes
+          that a particular part of an address is suffering from a validation
+          error. Secondly, the string value allows the developer to describe
+          the validation error (and possibly how the end user can fix the
+          error).
+        </p>
+        <p class="note">
+          Developers need to be aware that users might not have the ability to
+          fix certain parts of an address. As such, they need to be mindful not
+          to ask the user to fix things they might not have control over.
+        </p>
+        <dl>
+          <dt>
+            <dfn>addressLine</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/address line=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/addressLine}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>city</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/city=] has a validation error.
+            In the user agent's UI, this member corresponds to the input field
+            that provided the {{ContactAddress}}'s {{ContactAddress/city}}
+            attribute's value.
+          </dd>
+          <dt>
+            <dfn>country</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/country=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/country}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>dependentLocality</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/dependent locality=] has a
+            validation error. In the user agent's UI, this member corresponds
+            to the input field that provided the {{ContactAddress}}'s
+            {{ContactAddress/dependentLocality}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>organization</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/organization=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/organization}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>phone</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/phone number=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/phone}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>postalCode</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/postal code=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/postalCode}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>recipient</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/recipient=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/addressLine}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>region</dfn> member
+          </dt>
+          <dd>
+            Denotes that the [=physical address/region=] has a validation
+            error. In the user agent's UI, this member corresponds to the input
+            field that provided the {{ContactAddress}}'s
+            {{ContactAddress/region}} attribute's value.
+          </dd>
+          <dt>
+            <dfn>sortingCode</dfn> member
+          </dt>
+          <dd>
+            The [=physical address/sorting code=] has a validation error. In
+            the user agent's UI, this member corresponds to the input field
+            that provided the {{ContactAddress}}'s
+            {{ContactAddress/sortingCode}} attribute's value.
+          </dd>
+        </dl>
+      </section>
+    </section>
     <section id="permissions-policy" data-cite="permissions-policy">
       <h2>
         Permissions Policy integration
@@ -2324,6 +3147,49 @@
             <th>
               Target
             </th>
+          </tr>
+          <tr>
+            <td>
+              <code><dfn>shippingaddresschange</dfn></code>
+            </td>
+            <td>
+              {{PaymentRequestUpdateEvent}}
+            </td>
+            <td>
+              The user provides a new shipping address.
+            </td>
+            <td>
+              {{PaymentRequest}}
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code><dfn>shippingoptionchange</dfn></code>
+            </td>
+            <td>
+              {{PaymentRequestUpdateEvent}}
+            </td>
+            <td>
+              The user chooses a new shipping option.
+            </td>
+            <td>
+              {{PaymentRequest}}
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code><dfn>payerdetailchange</dfn></code>
+            </td>
+            <td>
+              {{PaymentRequestUpdateEvent}}
+            </td>
+            <td>
+              The user changes the payer name, the payer email, or the payer
+              phone (see <a>payer detail changed algorithm</a>).
+            </td>
+            <td>
+              {{PaymentResponse}}
+            </td>
           </tr>
           <tr>
             <td>
@@ -2456,13 +3322,50 @@
               changes made by the end user through the UI), developers need to
               immediately call {{PaymentRequestUpdateEvent/updateWith()}}.
             </p>
+            <pre class="example js" title=
+            "how to use `updateWith()` correctly.">
+              // ❌ Bad - this won't work!
+              request.onshippingaddresschange = async ev =&gt; {
+                // await goes to next tick, and updateWith()
+                // was not called.
+                const details = await getNewDetails(oldDetails);
+                // 💥 So it's now too late! updateWith()
+                // throws "InvalidStateError".
+                ev.updateWith(details);
+              };
+
+              // ✅ Good - UI will wait.
+              request.onshippingaddresschange = ev =&gt; {
+                // Calling updateWith() with a promise is ok 👍
+                const promiseForNewDetails = getNewDetails(oldDetails);
+                ev.updateWith(promiseForNewDetails);
+              };
+            </pre>
             <p>
               Additionally, {{PaymentRequestUpdateEvent/[[waitForUpdate]]}}
               prevents reuse of {{PaymentRequestUpdateEvent}}.
             </p>
+            <pre class="example js" title="can only call `updateWith()` once">
+              // ❌ Bad - calling updateWith() twice doesn't work!
+              request.addEventListener("shippingaddresschange", ev =&gt; {
+                ev.updateWith(details); // this is ok.
+                // 💥 [[waitForUpdate]] is true, throws "InvalidStateError".
+                ev.updateWith(otherDetails);
+              });
+
+              // ❌ Bad - this won't work either!
+              request.addEventListener("shippingaddresschange", async ev =&gt; {
+                const p = Promise.resolve({ ...details });
+                ev.updateWith(p);
+                await p;
+                // 💥 Only one call to updateWith() is allowed,
+                // so the following throws "InvalidStateError"
+                ev.updateWith({ ...newDetails });
+              });
+            </pre>
           </aside>
           <p data-tests=
-          "PaymentRequestUpdateEvent/updatewith-method.https.html">
+          "PaymentRequestUpdateEvent/updatewith-method.https.html, PaymentRequestUpdateEvent/updateWith-incremental-update-manual.https.html">
             The {{PaymentRequestUpdateEvent/updateWith()}} with
             |detailsPromise:Promise| method MUST act as follows:
           </p>
@@ -2613,6 +3516,88 @@
       </section>
       <section>
         <h2>
+          Shipping address changed algorithm
+        </h2>
+        <p data-tests=
+        "algorithms-manual.https.html#shipping-address-changed-algo">
+          The <dfn>shipping address changed algorithm</dfn> runs when the user
+          provides a new shipping address. It MUST run the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
+          that the user is interacting with.
+          </li>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            run the following steps:
+            <ol>
+              <li>
+                <div class="note" title="Privacy of recipient information">
+                  <p>
+                    The |redactList| limits the amount of personal information
+                    about the recipient that the API shares with the merchant.
+                  </p>
+                  <p>
+                    For merchants, the resulting {{ContactAddress}} object
+                    provides enough information to, for example, calculate
+                    shipping costs, but, in most cases, not enough information
+                    to physically locate and uniquely identify the recipient.
+                  </p>
+                  <p>
+                    Unfortunately, even with the |redactList|, recipient
+                    anonymity cannot be assured. This is because in some
+                    countries postal codes are so fine-grained that they can
+                    uniquely identify a recipient.
+                  </p>
+                </div>
+              </li>
+              <li>Let |redactList:list| be the empty list. Set |redactList| to
+              « "organization", "phone", "recipient", "addressLine" ».
+              </li>
+              <li>Let |address:ContactAddress| be the result of running the
+              steps to [=create a `ContactAddress` from user-provided input=]
+              with |redactList|.
+              </li>
+              <li>Set |request|.{{PaymentRequest/shippingAddress}} to
+              |address|.
+              </li>
+              <li>Run the <a>PaymentRequest updated algorithm</a> with
+              |request| and "<a>shippingaddresschange</a>".
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          Shipping option changed algorithm
+        </h2>
+        <p data-tests=
+        "algorithms-manual.https.html#shipping-option-changed-algo">
+          The <dfn>shipping option changed algorithm</dfn> runs when the user
+          chooses a new shipping option. It MUST run the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
+          that the user is interacting with.
+          </li>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            run the following steps:
+            <ol>
+              <li>Set the {{PaymentRequest/shippingOption}} attribute on
+              |request| to the <code>id</code> string of the
+              {{PaymentShippingOption}} provided by the user.
+              </li>
+              <li>Run the <a>PaymentRequest updated algorithm</a> with
+              |request| and "<a>shippingoptionchange</a>".
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
           Payment method changed algorithm
         </h2>
         <p>
@@ -2623,6 +3608,16 @@
           |methodName|, which is a DOMString that represents the <a>payment
           method identifier</a> of the <a>payment handler</a> the user is
           interacting with.
+        </p>
+        <p class="note" title=
+        "Privacy of information shared by paymentmethodchange event">
+          When the user selects or changes a payment method (e.g., a credit
+          card), the {{PaymentMethodChangeEvent}} includes redacted billing
+          address information for the purpose of performing tax calculations.
+          Redacted attributes include, but are not limited to, [=physical
+          address/address line=], [=physical address/dependent locality=],
+          [=physical address/organization=], [=physical address/phone number=],
+          and [=physical address/recipient=].
         </p>
         <ol class="algorithm">
           <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
@@ -2654,7 +3649,7 @@
         <h2>
           PaymentRequest updated algorithm
         </h2>
-        <p>
+        <p data-tests="algorithms-manual.https.html">
           The <dfn>PaymentRequest updated algorithm</dfn> is run by other
           algorithms above to <a>fire an event</a> to indicate that a user has
           made a change to a {{PaymentRequest}} called |request| with an event
@@ -2687,9 +3682,83 @@
       </section>
       <section>
         <h2>
-          User accepts the payment request algorithm
+          Payer detail changed algorithm
         </h2>
         <p>
+          The user agent MUST run the <dfn>payer detail changed algorithm</dfn>
+          when the user changes the |payer name|, or the |payer email|, or the
+          |payer phone| in the user interface:
+        </p>
+        <ol class="algorithm">
+          <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
+          that the user is interacting with.
+          </li>
+          <li>If |request|.{{PaymentRequest/[[response]]}} is null, return.
+          </li>
+          <li>Let |response:PaymentResponse| be
+          |request|.{{PaymentRequest/[[response]]}}.
+          </li>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            run the following steps:
+            <ol>
+              <li>Assert: |request|.{{PaymentRequest/[[updating]]}} is false.
+              </li>
+              <li>Assert: |request|.{{PaymentRequest/[[state]]}} is
+              "[=PaymentRequest/interactive=]".
+              </li>
+              <li>Let |options:PaymentOptions| be
+              |request|.{{PaymentRequest/[[options]]}}.
+              </li>
+              <li>If |payer name| changed and
+              |options|.{{PaymentOptions/requestPayerName}} is true:
+                <ol>
+                  <li>Set |response|.{{PaymentResponse/payerName}} attribute to
+                  |payer name|.
+                  </li>
+                </ol>
+              </li>
+              <li>If |payer email| changed and
+              |options|.{{PaymentOptions/requestPayerEmail}} is true:
+                <ol>
+                  <li>Set |response|.{{PaymentResponse/payerEmail}} to |payer
+                  email|.
+                  </li>
+                </ol>
+              </li>
+              <li>If |payer phone| changed and
+              |options|.{{PaymentOptions/requestPayerPhone}} is true:
+                <ol>
+                  <li>Set |response|.{{PaymentResponse/payerPhone}} to |payer
+                  phone|.
+                  </li>
+                </ol>
+              </li>
+              <li>Let |event:PaymentRequestUpdateEvent| be the result of
+              <a>creating an event</a> using {{PaymentRequestUpdateEvent}}.
+              </li>
+              <li>Initialize |event|'s {{Event/type}} attribute to
+              "<a>payerdetailchange</a>".
+              </li>
+              <li>
+                <a>Dispatch</a> |event| at |response|.
+              </li>
+              <li>If |event|.{{PaymentRequestUpdateEvent/[[waitForUpdate]]}} is
+              true, disable any part of the user interface that could cause
+              another change to the payer details to be fired.
+              </li>
+              <li>Otherwise, set
+              |event|.{{PaymentRequestUpdateEvent/[[waitForUpdate]]}} to true.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          User accepts the payment request algorithm
+        </h2>
+        <p data-tests="user-accepts-payment-request-algo-manual.https.html">
           The <dfn data-local-lt="user accepts the payment request"
           data-export="">user accepts the payment request algorithm</dfn> runs
           when the user accepts the payment request and confirms that they want
@@ -2708,6 +3777,13 @@
           "[=PaymentRequest/interactive=]", then terminate this algorithm and
           take no further action. The <a>user agent</a> user interface SHOULD
           ensure that this never occurs.
+          </li>
+          <li>If the {{PaymentOptions/requestShipping}} value of
+          |request|.{{PaymentRequest/[[options]]}} is true, then if the
+          {{PaymentRequest/shippingAddress}} attribute of |request| is null or
+          if the {{PaymentRequest/shippingOption}} attribute of |request| is
+          null, then terminate this algorithm and take no further action. The
+          <a>user agent</a> SHOULD ensure that this never occurs.
           </li>
           <li>Let |isRetry:boolean| be true if
           |request|.{{PaymentRequest/[[response]]}} is not null, false
@@ -2742,6 +3818,47 @@
           <li>Set the {{PaymentResponse/details}} attribute value of |response|
           to an object resulting from running the |handler|'s <a>steps to
           respond to a payment request</a>.
+          </li>
+          <li>If the {{PaymentOptions/requestShipping}} value of
+          |request|.{{PaymentRequest/[[options]]}} is false, then set the
+          {{PaymentResponse/shippingAddress}} attribute value of |response| to
+          null. Otherwise:
+            <ol>
+              <li>Let |shippingAddress:ContactAddress| be the result of
+              <a>create a `ContactAddress` from user-provided input</a>.
+              </li>
+              <li>Set the {{PaymentResponse/shippingAddress}} attribute value
+              of |response| to |shippingAddress|.
+              </li>
+              <li>Set the {{PaymentResponse/shippingAddress}} attribute value
+              of |request| to |shippingAddress|.
+              </li>
+            </ol>
+          </li>
+          <li>If the {{PaymentOptions/requestShipping}} value of
+          |request|.{{PaymentRequest/[[options]]}} is true, then set the
+          {{PaymentResponse/shippingOption}} attribute of |response| to the
+          value of the {{PaymentResponse/shippingOption}} attribute of
+          |request|. Otherwise, set it to null.
+          </li>
+          <li>If the {{PaymentOptions/requestPayerName}} value of
+          |request|.{{PaymentRequest/[[options]]}} is true, then set the
+          {{PaymentResponse/payerName}} attribute of |response| to the payer's
+          name provided by the user, or to null if none was provided.
+          Otherwise, set it to null.
+          </li>
+          <li>If the {{PaymentOptions/requestPayerEmail}} value of
+          |request|.{{PaymentRequest/[[options]]}} is true, then set the
+          {{PaymentResponse/payerEmail}} attribute of |response| to the payer's
+          email address provided by the user, or to null if none was provided.
+          Otherwise, set it to null.
+          </li>
+          <li>If the {{PaymentOptions/requestPayerPhone}} value of
+          |request|.{{PaymentRequest/[[options]]}} is true, then set the
+          {{PaymentResponse/payerPhone}} attribute of |response| to the payer's
+          phone number provided by the user, or to null if none was provided.
+          When setting the {{PaymentResponse/payerPhone}} value, the user agent
+          SHOULD format the phone number to adhere to [[E.164]].
           </li>
           <li>Set |request|.{{PaymentRequest/[[state]]}} to
           "[=PaymentRequest/closed=]".
@@ -2854,6 +3971,11 @@
               </li>
               <li>Let |serializedModifierData| be an empty list.
               </li>
+              <li>Let |selectedShippingOption| be null.
+              </li>
+              <li>Let |shippingOptions| be an empty
+              <code><a>sequence</a></code>&lt;{{PaymentShippingOption}}&gt;.
+              </li>
               <li>Validate and canonicalize the details:
                 <ol>
                   <li>If the {{PaymentDetailsUpdate/total}} member of |details|
@@ -2879,6 +4001,41 @@
                       </li>
                     </ol>
                   </li>
+                  <li>If the {{PaymentDetailsBase/shippingOptions}} member of
+                  |details| is present, and
+                  |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestShipping}}
+                  is true, then:
+                    <ol>
+                      <li>Let |seenIDs| be an empty set.
+                      </li>
+                      <li>For each |option| in
+                      |details|.{{PaymentDetailsBase/shippingOptions}}:
+                        <ol>
+                          <li>
+                            <a>Check and canonicalize amount</a>
+                            |option|.{{PaymentShippingOption/amount}}. If an
+                            exception is thrown, then <a>abort the update</a>
+                            with |request| and that exception.
+                          </li>
+                          <li data-tests=
+                          "PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html">
+                          If |seenIDs|[|option|.{{PaymentShippingOption/id}]
+                          exists, then <a>abort the update</a> with |request|
+                          and a {{TypeError}}.
+                          </li>
+                          <li>Append |option|.{{PaymentShippingOption/id}} to
+                          |seenIDs|.
+                          </li>
+                          <li>Append |option| to |shippingOptions|.
+                          </li>
+                          <li>If |option|.{{PaymentShippingOption/selected}} is
+                          true, then set |selectedShippingOption| to
+                          |option|.{{PaymentShippingOption/id}}.
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
                   <li>If the {{PaymentDetailsBase/modifiers}} member of
                   |details| is present, then:
                     <ol>
@@ -2890,7 +4047,9 @@
                       <li>For each {{PaymentDetailsModifier}} |modifier| in
                       |modifiers|:
                         <ol>
-                          <li>Run the steps to <a>validate a payment method
+                          <li data-tests=
+                          "updateWith-method-pmi-handling-manual.https.html">
+                          Run the steps to <a>validate a payment method
                           identifier</a> with
                           |modifier|.{{PaymentDetailsModifier/supportedMethods}}.
                           If it returns false, then <a>abort the update</a>
@@ -2979,6 +4138,21 @@
                       </li>
                     </ol>
                   </li>
+                  <li>If the {{PaymentDetailsBase/shippingOptions}} member of
+                  |details| is present, and
+                  |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestShipping}}
+                  is true, then:
+                    <ol>
+                      <li>Set
+                      |request|.{{PaymentRequest/[[details]]}}.{{PaymentDetailsBase/shippingOptions}}
+                      to |shippingOptions|.
+                      </li>
+                      <li>Set the value of |request|'s
+                      {{PaymentRequest/shippingOption}} attribute to
+                      |selectedShippingOption|.
+                      </li>
+                    </ol>
+                  </li>
                   <li>If the {{PaymentDetailsBase/modifiers}} member of
                   |details| is present, then:
                     <ol>
@@ -2991,6 +4165,50 @@
                       to |serializedModifierData|.
                       </li>
                     </ol>
+                  </li>
+                  <li>
+                    <p>
+                      If
+                      |request|.{{PaymentRequest/[[options]]}}.{{PaymentOptions/requestShipping}}
+                      is true, and
+                      |request|.{{PaymentRequest/[[details]]}}.{{PaymentDetailsBase/shippingOptions}}
+                      is empty, then the developer has signified that there are
+                      no valid shipping options for the currently-chosen
+                      shipping address (given by |request|'s
+                      {{PaymentRequest/shippingAddress}}).
+                    </p>
+                    <p>
+                      In this case, the user agent SHOULD display an error
+                      indicating this, and MAY indicate that the
+                      currently-chosen shipping address is invalid in some way.
+                      The user agent SHOULD use the
+                      {{PaymentDetailsUpdate/error}} member of |details|, if it
+                      is present, to give more information about why there are
+                      no valid shipping options for that address.
+                    </p>
+                    <p>
+                      Further, if
+                      |details|["{{PaymentDetailsUpdate/shippingAddressErrors}}"]
+                      member is present, the user agent SHOULD display an error
+                      specifically for each erroneous field of the shipping
+                      address. This is done by matching each present member of
+                      the {{AddressErrors}} to a corresponding input field in
+                      the shown user interface.
+                    </p>
+                    <p>
+                      Similarly, if |details|["{{payerErrors}}"] member is
+                      present and |request|.{{PaymentRequest/[[options]]}}'s
+                      {{PaymentOptions/requestPayerName}},
+                      {{PaymentOptions/requestPayerEmail}}, or
+                      {{PaymentOptions/requestPayerPhone}} is true, then
+                      display an error specifically for each erroneous field.
+                    </p>
+                    <p>
+                      Likewise, if
+                      |details|.{{PaymentDetailsUpdate/paymentMethodErrors}} is
+                      present, then display errors specifically for each
+                      erroneous input field for the particular payment method.
+                    </p>
                   </li>
                 </ol>
               </li>
@@ -3177,7 +4395,7 @@
         </h2>
         <p>
           The <a>user agent</a> MUST NOT share information about the user with
-          a developer without user consent.
+          a developer (e.g., the [=shipping address=]) without user consent.
         </p>
         <p>
           In particular, the {{PaymentMethodData}}'s {{PaymentMethodData/data}}
@@ -3212,8 +4430,23 @@
           data shared via the {{PaymentMethodChangeEvent}}'s
           {{PaymentMethodChangeEvent/methodDetails}} attribute. Requirements
           and approaches for minimizing shared data are likely to vary by
-          <a>payment method</a>.
+          <a>payment method</a> and might include:
         </p>
+        <ul>
+          <li>Use of a "|redactList|" for <a>physical addresses</a>. The
+          current specification makes use of a "|redactList|" to redact the
+          [=physical address/address line=], [=physical address/organization=],
+          [=physical address/phone number=], and [=physical address/recipient=]
+          from a {{PaymentRequest/shippingAddress}}.
+          </li>
+          <li>Support for instructions from the payee identifying specific
+          elements to exclude or include from the <a>payment method</a>
+          response data (returned through {{PaymentResponse}}.|details|). The
+          payee might provide these instructions via
+          <a>PaymentMethodData</a>.|data|, enabling a <a>payment method</a>
+          definition to evolve without requiring changes to the current API.
+          </li>
+        </ul>
         <p>
           Where sharing of privacy-sensitive information might not be obvious
           to users (e.g., when [=payment handler/payment method changed
@@ -3266,7 +4499,9 @@
       <p>
         For the user-facing aspects of Payment Request API, implementations
         integrate with platform accessibility APIs via form controls and other
-        input modalities.
+        input modalities. Furthermore, to increase the intelligibility of
+        total, shipping addresses, and contact information, implementations
+        format data according to system conventions.
       </p>
     </section>
     <section id="dependencies">

--- a/index.html
+++ b/index.html
@@ -2999,12 +2999,11 @@
         </pre>
         <p>
           The members of the {{AddressErrors}} dictionary represent validation
-          errors with specific parts of a [=physical address=]. Each
-          dictionary member has a dual function: firstly, its presence denotes
-          that a particular part of an address is suffering from a validation
-          error. Secondly, the string value allows the developer to describe
-          the validation error (and possibly how the end user can fix the
-          error).
+          errors with specific parts of a [=physical address=]. Each dictionary
+          member has a dual function: firstly, its presence denotes that a
+          particular part of an address is suffering from a validation error.
+          Secondly, the string value allows the developer to describe the
+          validation error (and possibly how the end user can fix the error).
         </p>
         <p class="note">
           Developers need to be aware that users might not have the ability to
@@ -3555,8 +3554,8 @@
               « "organization", "phone", "recipient", "addressLine" ».
               </li>
               <li>Let |address:ContactAddress| be the result of running the
-              steps to [=create a `ContactAddress` from user-provided input=]
-              with |redactList|.
+              steps to [=ContactsManager/create a contactaddress from
+              user-provided input=] with |redactList|.
               </li>
               <li>Set |request|.{{PaymentRequest/shippingAddress}} to
               |address|.
@@ -3825,7 +3824,8 @@
           null. Otherwise:
             <ol>
               <li>Let |shippingAddress:ContactAddress| be the result of
-              <a>create a `ContactAddress` from user-provided input</a>.
+              [=ContactsManager/create a contactaddress from user-provided
+              input=]
               </li>
               <li>Set the {{PaymentResponse/shippingAddress}} attribute value
               of |response| to |shippingAddress|.


### PR DESCRIPTION
This reverts commit 486c07ae494ac64a31d7f90cf9df026b4250e878.

Bringing back addresses so we can continue to figure out a path forward (given it's now a interop issue)

closes #996

Blocked on: 

- [x] Contacts being published https://github.com/w3c/transitions/issues/457
- [x] bring back the tests. 
- [x]  #1021 

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/44409)
 
Implementation commitment:

 * [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=268783)
 * [ ] [Chromium](https://crbug.com/325000743)
 * [ ] Gecko (link to issue)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/996.html" title="Last updated on Jul 15, 2024, 5:33 AM UTC (120d612)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/996/91d3530...120d612.html" title="Last updated on Jul 15, 2024, 5:33 AM UTC (120d612)">Diff</a>