### PR TITLE
Define JSON-serialize using the Infra algorithm for it.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3302,10 +3302,10 @@
           "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
           slot</dfn> is defined [[ECMASCRIPT]].
           <p>
-            <dfn data-local-lt="JSON-serialized|JSON-serializing" data-export=
-            "">JSON-serialize</dfn> runs JSON {{JSON/stringify()}}, passing the
-            supplied object as the sole argument, and returns the resulting
-            string. This can throw an exception.
+            To <dfn
+            data-local-lt="JSON-serialized|JSON-serializing">JSON-serialize</dfn>
+            a value, [=serialize a JavaScript value to a JSON string=] given
+            that value. This can throw an exception.
           </p>
         </dd>
       </dl>


### PR DESCRIPTION
And avoid exporting the term, since other specs should be calling Infra
instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/payment-request/pull/999.html" title="Last updated on Oct 6, 2022, 9:10 PM UTC (f7b69dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/999/4eba3ac...jyasskin:f7b69dd.html" title="Last updated on Oct 6, 2022, 9:10 PM UTC (f7b69dd)">Diff</a>