### PR TITLE
[Spec] Only allow show() to be called in a foreground tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,7 +839,7 @@
           not [=Document/fully active=], then return <a>a promise rejected
           with</a> an {{"AbortError"}} {{DOMException}}.
           </li>
-          <li class="addition proposed">If |document|'s [=Document/visibility state=] is not `"visible"`,
+          <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
           then return <a>a promise rejected with</a> an {{"AbortError"}}
           {{DOMException}}.
           <li>

--- a/index.html
+++ b/index.html
@@ -839,7 +839,7 @@
           not [=Document/fully active=], then return <a>a promise rejected
           with</a> an {{"AbortError"}} {{DOMException}}.
           </li>
-          <li>If |document|'s [=Document/visibilityState=] is not `"visible"`,
+          <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
           then return <a>a promise rejected with</a> an {{"AbortError"}}
           {{DOMException}}.
           <li>

--- a/index.html
+++ b/index.html
@@ -839,6 +839,9 @@
           not [=Document/fully active=], then return <a>a promise rejected
           with</a> an {{"AbortError"}} {{DOMException}}.
           </li>
+          <li>If |document|'s [=Document/visibilityState=] is not `"visible"`,
+          then return <a>a promise rejected with</a> an {{"AbortError"}}
+          {{DOMException}}.
           <li>
             <p>
               Optionally, if the <a>user agent</a> wishes to disallow the call

--- a/index.html
+++ b/index.html
@@ -839,7 +839,7 @@
           not [=Document/fully active=], then return <a>a promise rejected
           with</a> an {{"AbortError"}} {{DOMException}}.
           </li>
-          <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
+          <li class="addition proposed">If |document|'s [=Document/visibility state=] is not `"visible"`,
           then return <a>a promise rejected with</a> an {{"AbortError"}}
           {{DOMException}}.
           <li>


### PR DESCRIPTION
This addresses this issue in SPC - https://w3c.github.io/secure-payment-confirmation/#issue-e92619e9

The behavior spec'd in SPC appears to already be followed in general Payment Request implementations already, based on testing in both Safari and Chrome, so it seems safe to just spec it here instead.

The following tasks have been completed:

 * [x] Modified Web platform tests ([link](https://github.com/web-platform-tests/wpt/pull/40256))
 
Implementation commitment:

 * [x] WebKit (already passes test)
 * [x] Chromium (already passes test)
 * [x] Gecko (doesn't implement Payment Request)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1005.html" title="Last updated on May 30, 2023, 1:19 PM UTC (1e7e2d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1005/08be866...1e7e2d4.html" title="Last updated on May 30, 2023, 1:19 PM UTC (1e7e2d4)">Diff</a>