### PR TITLE
Revert spec to REC state

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,9 +543,9 @@
         </p>
         <ol class="algorithm">
           <li>If [=this=]'s [=relevant global object=]'s [=associated
-          `Document`=] is not <a>allowed to use</a> the
-          <a>"payment"</a> permission, then [=exception/throw=]
-          a {{"SecurityError"}} {{DOMException}}.
+          `Document`=] is not <a>allowed to use</a> the <a>"payment"</a>
+          permission, then [=exception/throw=] a {{"SecurityError"}}
+          {{DOMException}}.
           </li>
           <li>Establish the request's id:
             <ol>
@@ -1954,8 +1954,8 @@
               If
               |errorFields:PaymentValidationErrors|.{{PaymentValidationErrors/paymentMethod}}
               member was passed, and if required by the specification that
-              defines |response|.{{PaymentResponse/methodName}}, then [=converted
-              to an IDL value|convert=] |errorFields|'s
+              defines |response|.{{PaymentResponse/methodName}}, then
+              [=converted to an IDL value|convert=] |errorFields|'s
               {{PaymentValidationErrors/paymentMethod}} member to an IDL value
               of the type specified there. Otherwise, [=converted to an IDL
               value|convert=] to {{object}}.
@@ -2273,8 +2273,8 @@
       <p>
         This specification defines a [=policy-controlled feature=] identified
         by the string <dfn class="permission">"payment"</dfn>
-        [[permissions-policy]]. Its
-        [=policy-controlled feature/default allowlist=] is '<code>self</code>'.
+        [[permissions-policy]]. Its [=policy-controlled feature/default
+        allowlist=] is '<code>self</code>'.
       </p>
       <aside class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         facilitate the payment flow between merchant and user.
       </p>
     </section>
-    <section id='sotd' class="updateable-rec">
+    <section id='sotd'>
       <p>
         The working group maintains <a href=
         "https://github.com/w3c/payment-request/issues?utf8=%E2%9C%93&amp;q=is%3Aopen%20is%3Aissue%20-label%3A%22Priority%3A%20Postponed%22%20">

--- a/index.html
+++ b/index.html
@@ -812,6 +812,9 @@
           not [=Document/fully active=], then return <a>a promise rejected
           with</a> an {{"AbortError"}} {{DOMException}}.
           </li>
+          <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
+          then return <a>a promise rejected with</a> an {{"AbortError"}}
+          {{DOMException}}.
           <li>
             <p>
               Optionally, if the <a>user agent</a> wishes to disallow the call

--- a/index.html
+++ b/index.html
@@ -542,9 +542,9 @@
           |details|)</dfn></code> constructor MUST act as follows:
         </p>
         <ol class="algorithm">
-          <li>If the <a>current settings object</a>'s [=relevant global
-          object=]'s [=associated `Document`=] is not <a>allowed to use</a> the
-          "[=payment-permission|payment=]" permission, then [=exception/throw=]
+          <li>If [=this=]'s [=relevant global object=]'s [=associated
+          `Document`=] is not <a>allowed to use</a> the
+          <a>"payment"</a> permission, then [=exception/throw=]
           a {{"SecurityError"}} {{DOMException}}.
           </li>
           <li>Establish the request's id:
@@ -1924,7 +1924,7 @@
           |response|.{{PaymentResponse/[[request]]}}.
           </li>
           <li>Let |document:Document| be |request|'s <a>relevant global
-          object</a>'s <a>associated Document</a>.
+          object</a>'s <a>associated `Document`</a>.
           </li>
           <li data-tests=
           "payment-response/rejects_if_not_active-manual.https.html">If
@@ -1954,7 +1954,7 @@
               If
               |errorFields:PaymentValidationErrors|.{{PaymentValidationErrors/paymentMethod}}
               member was passed, and if required by the specification that
-              defines |response|.{{PaymentResponse/payment}}, then [=converted
+              defines |response|.{{PaymentResponse/methodName}}, then [=converted
               to an IDL value|convert=] |errorFields|'s
               {{PaymentValidationErrors/paymentMethod}} member to an IDL value
               of the type specified there. Otherwise, [=converted to an IDL
@@ -2272,8 +2272,8 @@
       </h2>
       <p>
         This specification defines a [=policy-controlled feature=] identified
-        by the string "<code><dfn data-lt="payment-permission" data-nodefault=
-        "">payment</dfn></code>" [[permissions-policy]]. Its
+        by the string <dfn class="permission">"payment"</dfn>
+        [[permissions-policy]]. Its
         [=policy-controlled feature/default allowlist=] is '<code>self</code>'.
       </p>
       <aside class="note">

--- a/index.html
+++ b/index.html
@@ -594,8 +594,8 @@
                   </li>
                   <li>If the {{PaymentMethodData/data}} member of
                   |paymentMethod| is missing, let |serializedData| be null.
-                  Otherwise, let |serializedData| be the result of
-                  <a>JSON-serializing</a>
+                  Otherwise, let |serializedData| be the result of [=serialize
+                  a JavaScript value to a JSON string|serialize=]
                   |paymentMethod|.{{PaymentMethodData/data}} into a string.
                   Rethrow any exceptions.
                   </li>
@@ -701,7 +701,8 @@
                       <li>If the {{PaymentDetailsModifier/data}} member of
                       |modifier| is missing, let |serializedData| be null.
                       Otherwise, let |serializedData| be the result of
-                      <a>JSON-serializing</a>
+                      [=serialize a JavaScript value to a JSON
+                      string|serialize=]
                       |modifier|.{{PaymentDetailsModifier/data}} into a string.
                       Rethrow any exceptions.
                       </li>
@@ -1380,8 +1381,8 @@
         </dt>
         <dd>
           An object that provides optional information that might be needed by
-          the supported payment methods. If supplied, it will be
-          <a>JSON-serialized</a>.
+          the supported payment methods. If supplied, it will be [=serialize a
+          JavaScript value to a JSON string|serialized=].
         </dd>
       </dl>
       <p class="note">
@@ -1733,8 +1734,8 @@
         </dt>
         <dd>
           An object that provides optional information that might be needed by
-          the supported payment methods. If supplied, it will be
-          <a>JSON-serialized</a>.
+          the supported payment methods. If supplied, it will be [=serialize a
+          JavaScript value to a JSON string|serialized=].
         </dd>
       </dl>
     </section>
@@ -1815,7 +1816,8 @@
         <dd>
           An object that provides optional information that might be needed by
           the {{PaymentResponse}} associated [=payment method=]. If supplied,
-          it will be <a>JSON-serialized</a>.
+          it will be [=serialize a JavaScript value to a JSON
+          string|serialize=].
         </dd>
       </dl>
     </section>
@@ -2149,7 +2151,8 @@
           </li>
           <li>Let |promise:Promise| be <a>a new promise</a>.
           </li>
-          <li>Let |serializedData| be the result of <a>JSON-serializing</a>
+          <li>Let |serializedData| be the result of [=serialize a JavaScript
+          value to a JSON string|serialize=]
           |details|.{{PaymentCompleteDetails/data}} into a string.
           </li>
           <li>If serializing [=exception/throws=] an exception, return <a>a
@@ -2909,12 +2912,12 @@
                           </li>
                           <li>If the {{PaymentDetailsModifier/data}} member of
                           |modifier| is missing, let |serializedData| be null.
-                          Otherwise, let |serializedData| be the result of <a>
-                            JSON-serializing</a>
-                            |modifier|.{{PaymentDetailsModifier/data}} into a
-                            string. If <a>JSON-serializing</a> throws an
-                            exception, then <a>abort the update</a> with
-                            |request| and that exception.
+                          Otherwise, let |serializedData| be the result of
+                          [=serialize a JavaScript value to a JSON
+                          string|serialize=]
+                          |modifier|.{{PaymentDetailsModifier/data}} into a
+                          string. If it throws an exception, then <a>abort the
+                          update</a> with |request| and that exception.
                           </li>
                           <li>Add |serializedData| to |serializedModifierData|.
                           </li>
@@ -3268,12 +3271,6 @@
           The term <dfn data-cite=
           "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
           slot</dfn> is defined [[ECMASCRIPT]].
-          <p>
-            To <dfn
-            data-local-lt="JSON-serialized|JSON-serializing">JSON-serialize</dfn>
-            a value, [=serialize a JavaScript value to a JSON string=] given
-            that value. This can throw an exception.
-          </p>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -815,6 +815,7 @@
           <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
           then return <a>a promise rejected with</a> an {{"AbortError"}}
           {{DOMException}}.
+          </li>
           <li>
             <p>
               Optionally, if the <a>user agent</a> wishes to disallow the call

--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
         <pre class="example js" title="Constructing a `PaymentRequest`">
           async function doPaymentRequest() {
             try {
-              const request = new PaymentRequest(methodData, details, options);
+              const request = new PaymentRequest(methodData, details);
               const response = await request.show();
               await validateResponse(response);
             } catch (err) {
@@ -432,7 +432,7 @@
         </p>
         <pre class="example js" title="POSTing with `fetch()`">
           async function doPaymentRequest() {
-            const payRequest = new PaymentRequest(methodData, details, options);
+            const payRequest = new PaymentRequest(methodData, details);
             const payResponse = await payRequest.show();
             let result = "";
             try {

--- a/index.html
+++ b/index.html
@@ -2282,7 +2282,7 @@
         This specification defines a [=policy-controlled feature=] identified
         by the string <dfn class="permission">"payment"</dfn>
         [[permissions-policy]]. Its [=policy-controlled feature/default
-        allowlist=] is '<code>self</code>'.
+        allowlist=] is [=default allowlist/'self'=].
       </p>
       <aside class="note">
         <p>

--- a/index.html
+++ b/index.html
@@ -3269,10 +3269,10 @@
           "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
           slot</dfn> is defined [[ECMASCRIPT]].
           <p>
-            <dfn data-local-lt="JSON-serialized|JSON-serializing" data-export=
-            "">JSON-serialize</dfn> runs JSON {{JSON/stringify()}}, passing the
-            supplied object as the sole argument, and returns the resulting
-            string. This can throw an exception.
+            To <dfn
+            data-local-lt="JSON-serialized|JSON-serializing">JSON-serialize</dfn>
+            a value, [=serialize a JavaScript value to a JSON string=] given
+            that value. This can throw an exception.
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -596,8 +596,8 @@
                   |paymentMethod| is missing, let |serializedData| be null.
                   Otherwise, let |serializedData| be the result of [=serialize
                   a JavaScript value to a JSON string|serialize=]
-                  |paymentMethod|.{{PaymentMethodData/data}} into a string.
-                  Rethrow any exceptions.
+                  |paymentMethod|.{{PaymentMethodData/data}} into a JSON
+                  string. Rethrow any exceptions.
                   </li>
                   <li>If |serializedData| is not null, and if the specification
                   that defines the
@@ -703,8 +703,8 @@
                       Otherwise, let |serializedData| be the result of
                       [=serialize a JavaScript value to a JSON
                       string|serialize=]
-                      |modifier|.{{PaymentDetailsModifier/data}} into a string.
-                      Rethrow any exceptions.
+                      |modifier|.{{PaymentDetailsModifier/data}} into a JSON
+                      string. Rethrow any exceptions.
                       </li>
                       <li>Add the tuple
                       (|modifier|.{{PaymentDetailsModifier/supportedMethods}},
@@ -2153,7 +2153,7 @@
           </li>
           <li>Let |serializedData| be the result of [=serialize a JavaScript
           value to a JSON string|serialize=]
-          |details|.{{PaymentCompleteDetails/data}} into a string.
+          |details|.{{PaymentCompleteDetails/data}} into a JSON string.
           </li>
           <li>If serializing [=exception/throws=] an exception, return <a>a
           promise rejected with</a> that exception.
@@ -2916,8 +2916,8 @@
                           [=serialize a JavaScript value to a JSON
                           string|serialize=]
                           |modifier|.{{PaymentDetailsModifier/data}} into a
-                          string. If it throws an exception, then <a>abort the
-                          update</a> with |request| and that exception.
+                          JSON string. If it throws an exception, then <a>abort
+                          the update</a> with |request| and that exception.
                           </li>
                           <li>Add |serializedData| to |serializedModifierData|.
                           </li>

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset='utf-8'>
     <title>
-      Payment Request API 1.1
+      Payment Request API
     </title>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class=
     'remove'></script>
     <script class='remove'>
     var respecConfig = {
-      shortName: "payment-request-1.1",
+      shortName: "payment-request",
       github: "w3c/payment-request",
       specStatus: "ED",
       group: "payments",
@@ -74,13 +74,13 @@
       },
       doJsonLd: true,
       xref: "web-platform",
-      mdn: "payment-request",
+      mdn: true,
     };
     </script>
   </head>
   <body data-cite="payment-method-id">
     <h1 id="title">
-      Payment Request API 1.1
+      Payment Request API
     </h1>
     <section id='abstract'>
       <p>
@@ -91,33 +91,6 @@
       </p>
     </section>
     <section id='sotd' class="updateable-rec">
-      <p>
-        The W3C <a href=
-        "https://www.w3.org/TR/2021/PR-payment-request-20210930/">published
-        Payment Request API 1.0</a> as a Proposed Recommendation in September
-        2021. Since then, W3C has been working to resolve two Formal Objections
-        from W3C Members; see the <a href=
-        "https://www.w3.org/2022/03/prapi-fo-report.html">Team Report</a> for
-        details. At this time, a Council is evaluating the Formal Objections to
-        determine whether Payment Request API 1.0 should advance to
-        Recommendation or be returned to the Working Group for changes.
-      </p>
-      <p>
-        In the meantime, the Editors have continued to update this
-        specification with new features (see change log below). To provide
-        devellopers and implementers with more confidence about these features,
-        the working group has decided to formally publish the a new W3C Working
-        Draft. This will also provide the group with a foundation for potential
-        discussion at TPAC about the future of Payment Request.
-      </p>
-      <p>
-        It is not uncommon for a Working Group to work on different revisions
-        of a specification simultaneously (e.g., see the CSS WG). With that in
-        mind, and because our current <a href=
-        "https://www.w3.org/Payments/WG/charter-201912.html">charter</a>
-        anticipates enhancements to Payment Request 1.0, we've publish this 1.1
-        draft.
-      </p>
       <p>
         The working group maintains <a href=
         "https://github.com/w3c/payment-request/issues?utf8=%E2%9C%93&amp;q=is%3Aopen%20is%3Aissue%20-label%3A%22Priority%3A%20Postponed%22%20">
@@ -569,10 +542,10 @@
           |details|)</dfn></code> constructor MUST act as follows:
         </p>
         <ol class="algorithm">
-          <li>If [=this=]'s [=relevant global object=]'s [=associated
-          `Document`=] is not <a>allowed to use</a> the <a>"payment"</a>
-          permission, then [=exception/throw=] a {{"SecurityError"}}
-          {{DOMException}}.
+          <li>If the <a>current settings object</a>'s [=relevant global
+          object=]'s [=associated `Document`=] is not <a>allowed to use</a> the
+          "[=payment-permission|payment=]" permission, then [=exception/throw=]
+          a {{"SecurityError"}} {{DOMException}}.
           </li>
           <li>Establish the request's id:
             <ol>
@@ -614,18 +587,17 @@
                     </ol>
                   </li>
                   <li>If |seenPMIs| [=set/contain|contains=] |pmi| throw a
-                  {{RangeError}} {{DOMException}} optionally informing the
-                  developer that this [=payment method identifier=] is a
-                  duplicate.
+                  {{RangeError}} {{DOMException}} optionally letting the
+                  developer this [=payment method identifier=] is a duplicate.
                   </li>
                   <li>[=set/Append=] |pmi| to |seenPMIs|.
                   </li>
                   <li>If the {{PaymentMethodData/data}} member of
                   |paymentMethod| is missing, let |serializedData| be null.
-                  Otherwise, let |serializedData| be the result of [=serialize
-                  a JavaScript value to a JSON string|serialize=]
-                  |paymentMethod|.{{PaymentMethodData/data}} into a JSON
-                  string. Rethrow any exceptions.
+                  Otherwise, let |serializedData| be the result of
+                  <a>JSON-serializing</a>
+                  |paymentMethod|.{{PaymentMethodData/data}} into a string.
+                  Rethrow any exceptions.
                   </li>
                   <li>If |serializedData| is not null, and if the specification
                   that defines the
@@ -729,10 +701,9 @@
                       <li>If the {{PaymentDetailsModifier/data}} member of
                       |modifier| is missing, let |serializedData| be null.
                       Otherwise, let |serializedData| be the result of
-                      [=serialize a JavaScript value to a JSON
-                      string|serialize=]
-                      |modifier|.{{PaymentDetailsModifier/data}} into a JSON
-                      string. Rethrow any exceptions.
+                      <a>JSON-serializing</a>
+                      |modifier|.{{PaymentDetailsModifier/data}} into a string.
+                      Rethrow any exceptions.
                       </li>
                       <li>Add the tuple
                       (|modifier|.{{PaymentDetailsModifier/supportedMethods}},
@@ -823,21 +794,15 @@
           <li data-tests=
           "payment-request-show-method.https.html, show-method-postmessage-manual.https.html">
           If the [=relevant global object=] of [=request=] does not have
-          [=transient activation=], the user agent MAY:
+          [=transient activation=]:
             <ol>
               <li>Return [=a promise rejected with=] with a {{"SecurityError"}}
               {{DOMException}}.
               </li>
             </ol>
-            <p class="note">
-              This allows the user agent to not require user activation, for
-              example to support redirect flows where a user activation may not
-              be present upon redirect. See <a href=
-              "#user-activation-requirement"></a> for security considerations.
-            </p>
           </li>
-          <li data-tests="show-consume-activation.https.html">Otherwise,
-          [=consume user activation=] of the [=relevant global object=].
+          <li data-tests="show-consume-activation.https.html">[=Consume user
+          activation=] of the [=relevant global object=].
           </li>
           <li>Let |document| be |request|'s [=relevant global object=]'s
           [=associated `Document`=].
@@ -845,10 +810,6 @@
           <li data-tests="rejects_if_not_active.https.html">If |document| is
           not [=Document/fully active=], then return <a>a promise rejected
           with</a> an {{"AbortError"}} {{DOMException}}.
-          </li>
-          <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
-          then return <a>a promise rejected with</a> an {{"AbortError"}}
-          {{DOMException}}.
           </li>
           <li>
             <p>
@@ -1419,8 +1380,8 @@
         </dt>
         <dd>
           An object that provides optional information that might be needed by
-          the supported payment methods. If supplied, it will be [=serialize a
-          JavaScript value to a JSON string|serialized=].
+          the supported payment methods. If supplied, it will be
+          <a>JSON-serialized</a>.
         </dd>
       </dl>
       <p class="note">
@@ -1772,8 +1733,8 @@
         </dt>
         <dd>
           An object that provides optional information that might be needed by
-          the supported payment methods. If supplied, it will be [=serialize a
-          JavaScript value to a JSON string|serialized=].
+          the supported payment methods. If supplied, it will be
+          <a>JSON-serialized</a>.
         </dd>
       </dl>
     </section>
@@ -1854,8 +1815,7 @@
         <dd>
           An object that provides optional information that might be needed by
           the {{PaymentResponse}} associated [=payment method=]. If supplied,
-          it will be [=serialize a JavaScript value to a JSON
-          string|serialize=].
+          it will be <a>JSON-serialized</a>.
         </dd>
       </dl>
     </section>
@@ -1964,7 +1924,7 @@
           |response|.{{PaymentResponse/[[request]]}}.
           </li>
           <li>Let |document:Document| be |request|'s <a>relevant global
-          object</a>'s <a>associated `Document`</a>.
+          object</a>'s <a>associated Document</a>.
           </li>
           <li data-tests=
           "payment-response/rejects_if_not_active-manual.https.html">If
@@ -1994,8 +1954,8 @@
               If
               |errorFields:PaymentValidationErrors|.{{PaymentValidationErrors/paymentMethod}}
               member was passed, and if required by the specification that
-              defines |response|.{{PaymentResponse/methodName}}, then
-              [=converted to an IDL value|convert=] |errorFields|'s
+              defines |response|.{{PaymentResponse/payment}}, then [=converted
+              to an IDL value|convert=] |errorFields|'s
               {{PaymentValidationErrors/paymentMethod}} member to an IDL value
               of the type specified there. Otherwise, [=converted to an IDL
               value|convert=] to {{object}}.
@@ -2189,9 +2149,8 @@
           </li>
           <li>Let |promise:Promise| be <a>a new promise</a>.
           </li>
-          <li>Let |serializedData| be the result of [=serialize a JavaScript
-          value to a JSON string|serialize=]
-          |details|.{{PaymentCompleteDetails/data}} into a JSON string.
+          <li>Let |serializedData| be the result of <a>JSON-serializing</a>
+          |details|.{{PaymentCompleteDetails/data}} into a string.
           </li>
           <li>If serializing [=exception/throws=] an exception, return <a>a
           promise rejected with</a> that exception.
@@ -2313,9 +2272,9 @@
       </h2>
       <p>
         This specification defines a [=policy-controlled feature=] identified
-        by the string <dfn class="permission">"payment"</dfn>
-        [[permissions-policy]]. Its [=policy-controlled feature/default
-        allowlist=] is '<code>self</code>'.
+        by the string "<code><dfn data-lt="payment-permission" data-nodefault=
+        "">payment</dfn></code>" [[permissions-policy]]. Its
+        [=policy-controlled feature/default allowlist=] is '<code>self</code>'.
       </p>
       <aside class="note">
         <p>
@@ -2742,7 +2701,7 @@
           |request|.{{PaymentRequest/[[response]]}} if |isRetry| is true, or a
           new {{PaymentResponse}} otherwise.
           </li>
-          <li>If |isRetry| is false, initialize the newly created |response|:
+          <li>If |isRetry| if false, initialize the newly created |response|:
             <ol>
               <li>Set |response|.{{PaymentResponse/[[request]]}} to |request|.
               </li>
@@ -2950,12 +2909,12 @@
                           </li>
                           <li>If the {{PaymentDetailsModifier/data}} member of
                           |modifier| is missing, let |serializedData| be null.
-                          Otherwise, let |serializedData| be the result of
-                          [=serialize a JavaScript value to a JSON
-                          string|serialize=]
-                          |modifier|.{{PaymentDetailsModifier/data}} into a
-                          JSON string. If it throws an exception, then <a>abort
-                          the update</a> with |request| and that exception.
+                          Otherwise, let |serializedData| be the result of <a>
+                            JSON-serializing</a>
+                            |modifier|.{{PaymentDetailsModifier/data}} into a
+                            string. If <a>JSON-serializing</a> throws an
+                            exception, then <a>abort the update</a> with
+                            |request| and that exception.
                           </li>
                           <li>Add |serializedData| to |serializedModifierData|.
                           </li>
@@ -3255,9 +3214,9 @@
           The {{PaymentRequest/canMakePayment()}} method provides feature
           detection for different payment methods. It may become a
           fingerprinting vector if in the future, a large number of payment
-          methods are available. User agents are expected to protect the user
-          from abuse of the method. For example, user agents can reduce user
-          fingerprinting by:
+          methods are available. purposes. User agents are expected to protect
+          the user from abuse of the method. For example, user agents can
+          reduce user fingerprinting by:
         </p>
         <ul>
           <li>Rate-limiting the frequency of calls with different parameters.
@@ -3281,32 +3240,6 @@
           with repeated calls, whether it is the cost of managing multiple
           [=host/registrable domains=] or the user experience friction of
           opening multiple windows (tabs or pop-ups).
-        </p>
-      </section>
-      <section>
-        <h2 id="user-activation-requirement">
-          User activation requirement
-        </h2>
-        <p>
-          If the user agent does not require user activation as part of the
-          {{PaymentRequest/show()}} method, some additional security
-          mitigations should be considered. Not requiring user activation
-          increases the risk of spam and click-jacking attacks, by allowing a
-          Payment Request UI to be initiated without the user interacting with
-          the page immediately beforehand.
-        </p>
-        <p>
-          In order to mitigate spam, the user agent may decide to enforce a
-          user activation requirement after some threshold, for example after
-          the user has already been shown a Payment Request UI without a user
-          activation on the current page. In order to mitigate click-jacking
-          attacks, the user agent may implement a time threshold in which
-          clicks are ignored immediately after a dialog is shown.
-        </p>
-        <p>
-          Another relevant mitigation exists in step 6 of
-          {{PaymentRequest/show()}}, where the document must be visible in
-          order to initiate the user interaction.
         </p>
       </section>
     </section>
@@ -3335,6 +3268,12 @@
           The term <dfn data-cite=
           "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal
           slot</dfn> is defined [[ECMASCRIPT]].
+          <p>
+            <dfn data-local-lt="JSON-serialized|JSON-serializing" data-export=
+            "">JSON-serialize</dfn> runs JSON {{JSON/stringify()}}, passing the
+            supplied object as the sole argument, and returns the resulting
+            string. This can throw an exception.
+          </p>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -587,8 +587,8 @@
                     </ol>
                   </li>
                   <li>If |seenPMIs| [=set/contain|contains=] |pmi| throw a
-                  {{RangeError}} {{DOMException}} optionally letting the
-                  developer this [=payment method identifier=] is a duplicate.
+                  {{RangeError}} {{DOMException}} optionally informing the
+                  developer that this [=payment method identifier=] is a duplicate.
                   </li>
                   <li>[=set/Append=] |pmi| to |seenPMIs|.
                   </li>
@@ -2708,7 +2708,7 @@
           |request|.{{PaymentRequest/[[response]]}} if |isRetry| is true, or a
           new {{PaymentResponse}} otherwise.
           </li>
-          <li>If |isRetry| if false, initialize the newly created |response|:
+          <li>If |isRetry| is false, initialize the newly created |response|:
             <ol>
               <li>Set |response|.{{PaymentResponse/[[request]]}} to |request|.
               </li>
@@ -3221,7 +3221,7 @@
           The {{PaymentRequest/canMakePayment()}} method provides feature
           detection for different payment methods. It may become a
           fingerprinting vector if in the future, a large number of payment
-          methods are available. purposes. User agents are expected to protect
+          methods are available. User agents are expected to protect
           the user from abuse of the method. For example, user agents can
           reduce user fingerprinting by:
         </p>

--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
         <pre class="example js" title="Constructing a `PaymentRequest`">
           async function doPaymentRequest() {
             try {
-              const request = new PaymentRequest(methodData, details);
+              const request = new PaymentRequest(methodData, details, options);
               const response = await request.show();
               await validateResponse(response);
             } catch (err) {
@@ -432,7 +432,7 @@
         </p>
         <pre class="example js" title="POSTing with `fetch()`">
           async function doPaymentRequest() {
-            const payRequest = new PaymentRequest(methodData, details);
+            const payRequest = new PaymentRequest(methodData, details, options);
             const payResponse = await payRequest.show();
             let result = "";
             try {

--- a/index.html
+++ b/index.html
@@ -588,7 +588,8 @@
                   </li>
                   <li>If |seenPMIs| [=set/contain|contains=] |pmi| throw a
                   {{RangeError}} {{DOMException}} optionally informing the
-                  developer that this [=payment method identifier=] is a duplicate.
+                  developer that this [=payment method identifier=] is a
+                  duplicate.
                   </li>
                   <li>[=set/Append=] |pmi| to |seenPMIs|.
                   </li>
@@ -3221,9 +3222,9 @@
           The {{PaymentRequest/canMakePayment()}} method provides feature
           detection for different payment methods. It may become a
           fingerprinting vector if in the future, a large number of payment
-          methods are available. User agents are expected to protect
-          the user from abuse of the method. For example, user agents can
-          reduce user fingerprinting by:
+          methods are available. User agents are expected to protect the user
+          from abuse of the method. For example, user agents can reduce user
+          fingerprinting by:
         </p>
         <ul>
           <li>Rate-limiting the frequency of calls with different parameters.

--- a/index.html
+++ b/index.html
@@ -90,7 +90,34 @@
         facilitate the payment flow between merchant and user.
       </p>
     </section>
-    <section id='sotd'>
+    <section id='sotd' class="updateable-rec">
+      <p>
+        The W3C <a href=
+        "https://www.w3.org/TR/2021/PR-payment-request-20210930/">published
+        Payment Request API 1.0</a> as a Proposed Recommendation in September
+        2021. Since then, W3C has been working to resolve two Formal Objections
+        from W3C Members; see the <a href=
+        "https://www.w3.org/2022/03/prapi-fo-report.html">Team Report</a> for
+        details. At this time, a Council is evaluating the Formal Objections to
+        determine whether Payment Request API 1.0 should advance to
+        Recommendation or be returned to the Working Group for changes.
+      </p>
+      <p>
+        In the meantime, the Editors have continued to update this
+        specification with new features (see change log below). To provide
+        devellopers and implementers with more confidence about these features,
+        the working group has decided to formally publish the a new W3C Working
+        Draft. This will also provide the group with a foundation for potential
+        discussion at TPAC about the future of Payment Request.
+      </p>
+      <p>
+        It is not uncommon for a Working Group to work on different revisions
+        of a specification simultaneously (e.g., see the CSS WG). With that in
+        mind, and because our current <a href=
+        "https://www.w3.org/Payments/WG/charter-201912.html">charter</a>
+        anticipates enhancements to Payment Request 1.0, we've publish this 1.1
+        draft.
+      </p>
       <p>
         The working group maintains <a href=
         "https://github.com/w3c/payment-request/issues?utf8=%E2%9C%93&amp;q=is%3Aopen%20is%3Aissue%20-label%3A%22Priority%3A%20Postponed%22%20">
@@ -116,13 +143,36 @@
           Changes since last publication
         </h3>
         <p>
-          This version of the specification removes data features from the API,
-          essentially pushing data details to payment method descriptions. The
-          complete list of changes, including all editorial changes, is
-          viewable in the <a href=
-          "https://github.com/w3c/payment-request/commits/gh-pages">commit
-          history</a>. Key set of changes are viewable in the <a href=
-          "#changelog">Changelog</a>.
+          In September 2022 the Web Payments Working Group published a <a href=
+          "https://www.w3.org/TR/2022/REC-payment-request-20220908/">Payment
+          Request Recommendation</a>. Following privacy and
+          internationalization reviews, the Recommendation excluded <a href=
+          "https://lists.w3.org/Archives/Public/public-payments-wg/2021Jun/0000.html">
+          capabilities</a> related to billing and shipping addresses. However,
+          implementations have continued to support those features
+          interoperably, and so the Working Group has decided to try to
+          re-align the specification with implementations, and re-engage the
+          community on associated issues.
+        </p>
+        <p>
+          This document is a Candidate Recommendation Snapshot based on the
+          text of the original Recommendation. A subsequent Candidate
+          Recommendation Draft will add back address capabilities and a small
+          number of other changes made since publication of the Recommendation.
+        </p>
+        <p>
+          In adding back support for addresses, the group plans to refer to the
+          address components defined in the <a href=
+          "https://w3c.github.io/contact-picker/">Contact Picker API</a> rather
+          than define those components itself. Indeed, the Contact Picker API
+          is derived from the original definitions found in Payment Request
+          API, and pulled out of the specification because addresses are useful
+          on the Web beyond payments.
+        </p>
+        <p>
+          The Working Group would engage in discussion and follow the usual
+          review process before advancing the specification to Proposed
+          Recommendation status.
         </p>
       </section>
     </section>


### PR DESCRIPTION
This PR gets us back to where we were when we went to REC. It cherry-picks all the editorial and xref fixes. 

Additionally: 

- Reverts spec to no longer having a version number
- Reclaims the payment-request namespace on /TR/
- Excludes [[[Spec] Relax user activation requirement for show() ](https://github.com/w3c/payment-request/commit/d9352e287aea631c322b4e3d94752ba59bcc78bb)](https://github.com/w3c/payment-request/commit/d9352e287aea631c322b4e3d94752ba59bcc78bb) - hi @stephenmcgruer, @rsolomakhin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1021.html" title="Last updated on Apr 22, 2024, 10:57 PM UTC (eb4b985)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1021/dbee0c0...eb4b985.html" title="Last updated on Apr 22, 2024, 10:57 PM UTC (eb4b985)">Diff</a>