### PR TITLE
Chore: set spec to auto-publish as CRD status

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -20,4 +20,4 @@ jobs:
           W3C_WG_DECISION_URL: "https://www.w3.org/2016/04/14-wpwg-minutes.html#item02"
           W3C_NOTIFICATIONS_CC: "${{ secrets.CC }}"
           W3C_BUILD_OVERRIDE: |
-            specStatus: WD
+            specStatus: CRD

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
         },
       ],
       previousMaturity: "CR",
+      crEnd: "2024-10-01",
       testSuiteURI: "https://wpt.live/payment-request/",
       implementationReportURI:
         "https://w3c.github.io/test-results/payment-request/all.html",


### PR DESCRIPTION
Now that we are back in CR, we can continue to update the spec via CRD status.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1027.html" title="Last updated on Aug 12, 2024, 3:58 PM UTC (65b8de1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1027/91d3530...65b8de1.html" title="Last updated on Aug 12, 2024, 3:58 PM UTC (65b8de1)">Diff</a>