### PR TITLE
Allow payment handlers to report back errors via Payment Request API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1318,10 +1318,11 @@
               </p>
             </aside>
             <p>
-              The |acceptPromise| will later be resolved or rejected by either
-              the <a>user accepts the payment request algorithm</a> or the
-              <a>user aborts the payment request algorithm</a>, which are
-              triggered through interaction with the user interface.
+              The |acceptPromise| will later be resolved or rejected by
+              the <a>user accepts the payment request algorithm</a>, the
+              <a>user aborts the payment request algorithm</a> (which are
+              triggered through interaction with the user interface), or
+              the <a>payment handler indicates an internal error algorithm</a>.
             </p>
             <p data-tests="rejects_if_not_active.https.html">
               If |document| stops being [=Document/fully active=] while the
@@ -2600,9 +2601,10 @@
           <li>Return |retryPromise|.
             <p class="note">
               The |retryPromise| will later be resolved by the <a>user accepts
-              the payment request algorithm</a>, or rejected by either the
-              <a>user aborts the payment request algorithm</a> or <a>abort the
-              update</a>.
+              the payment request algorithm</a>, or rejected by the <a>user
+              aborts the payment request algorithm</a>, <a>abort the update</a>,
+              or the <a>payment handler indicates an internal error
+              algorithm</a>.
             </p>
           </li>
         </ol>
@@ -3946,6 +3948,56 @@
           user interface.
           </li>
         </ol>
+      </section>
+      <section>
+        <h2>
+          Payment handler indicates an internal error algorithm
+        </h2>
+        <p>
+	  The <dfn>payment handler indicates an internal error algorithm</dfn>
+          runs when the payment handler that the user has selected reports an
+          internal error to the user agent. It MUST <a>queue a task</a> on the
+          <a>user interaction task source</a> to perform the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
+          that the user is interacting with.
+          </li>
+          <li>If |request|.{{PaymentRequest/[[state]]}} is not
+          "[=PaymentRequest/interactive=]", then terminate this algorithm and
+          take no further action.
+          </li>
+          <li>Set |request|.{{PaymentRequest/[[state]]}} to
+          "[=PaymentRequest/closed=]".
+          </li>
+          <li>Set |request|'s <a>payment-relevant browsing context</a>'s
+          <a>payment request is showing</a> boolean to false.
+          </li>
+          <li>Let |error| be an {{"OperationError"}} {{DOMException}}.
+          </li>
+          <li>Let |response:PaymentResponse| be
+          |request|.{{PaymentRequest/[[response]]}}.
+          </li>
+          <li>If |response| is not null:
+            <ol>
+              <li>Set |response|.{{PaymentResponse/[[complete]]}} to true.
+              </li>
+              <li>Assert: |response|.{{PaymentResponse/[[retryPromise]]}} is
+              not null.
+              </li>
+              <li>Reject |response|.{{PaymentResponse/[[retryPromise]]}} with
+              |error|.
+              </li>
+            </ol>
+          </li>
+          <li>Otherwise, reject |request|.{{PaymentRequest/[[acceptPromise]]}}
+          with |error|.
+          </li>
+          <li>Abort the current user interaction and close down any remaining
+          user interface.
+          </li>
+        </ol>
+        </p>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -3956,8 +3956,8 @@
         <p>
 	  The <dfn>payment handler indicates an internal error algorithm</dfn>
           runs when the payment handler that the user has selected reports an
-          internal error to the user agent. It takes in a {{DOMException}}
-          |error| from the payment handler to report back to the website.
+          internal error to the user agent. It takes in a Javascript value
+          |reason| from the payment handler, to report back to the website.
         </p>
         <ol class="algorithm">
           <li><a>Queue a task</a> on the <a>user interaction task source</a> to
@@ -3987,12 +3987,12 @@
                 not null.
                 </li>
                 <li>Reject |response|.{{PaymentResponse/[[retryPromise]]}} with
-                |error|.
+                |reason|.
                 </li>
               </ol>
             </li>
             <li>Otherwise, reject |request|.{{PaymentRequest/[[acceptPromise]]}}
-            with |error|.
+            with |reason|.
             </li>
             <li>Abort the current user interaction and close down any remaining
             user interface.

--- a/index.html
+++ b/index.html
@@ -1319,7 +1319,7 @@
             </aside>
             <p>
               The |acceptPromise| will later be resolved or rejected by
-              the <a>user accepts the payment request algorithm</a>, the
+              the <a>user accepts the payment request algorithm</a>, or the
               <a>user aborts the payment request algorithm</a> (which are
               triggered through interaction with the user interface), or
               the <a>payment handler indicates an internal error algorithm</a>.
@@ -2602,8 +2602,8 @@
             <p class="note">
               The |retryPromise| will later be resolved by the <a>user accepts
               the payment request algorithm</a>, or rejected by the <a>user
-              aborts the payment request algorithm</a>, <a>abort the update</a>,
-              or the <a>payment handler indicates an internal error
+              aborts the payment request algorithm</a>, or <a>abort the
+              update</a>, or the <a>payment handler indicates an internal error
               algorithm</a>.
             </p>
           </li>
@@ -3956,45 +3956,50 @@
         <p>
 	  The <dfn>payment handler indicates an internal error algorithm</dfn>
           runs when the payment handler that the user has selected reports an
-          internal error to the user agent. It MUST <a>queue a task</a> on the
-          <a>user interaction task source</a> to perform the following steps:
+          internal error to the user agent.
         </p>
         <ol class="algorithm">
-          <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
-          that the user is interacting with.
-          </li>
-          <li>If |request|.{{PaymentRequest/[[state]]}} is not
-          "[=PaymentRequest/interactive=]", then terminate this algorithm and
-          take no further action.
-          </li>
-          <li>Set |request|.{{PaymentRequest/[[state]]}} to
-          "[=PaymentRequest/closed=]".
-          </li>
-          <li>Set |request|'s <a>payment-relevant browsing context</a>'s
-          <a>payment request is showing</a> boolean to false.
-          </li>
-          <li>Let |error| be an {{"OperationError"}} {{DOMException}}.
-          </li>
-          <li>Let |response:PaymentResponse| be
-          |request|.{{PaymentRequest/[[response]]}}.
-          </li>
-          <li>If |response| is not null:
-            <ol>
-              <li>Set |response|.{{PaymentResponse/[[complete]]}} to true.
-              </li>
-              <li>Assert: |response|.{{PaymentResponse/[[retryPromise]]}} is
-              not null.
-              </li>
-              <li>Reject |response|.{{PaymentResponse/[[retryPromise]]}} with
-              |error|.
-              </li>
-            </ol>
-          </li>
-          <li>Otherwise, reject |request|.{{PaymentRequest/[[acceptPromise]]}}
-          with |error|.
-          </li>
-          <li>Abort the current user interaction and close down any remaining
-          user interface.
+          <li><a>Queue a task</a> on the <a>user interaction task source</a> to
+          perform the following steps:
+          <ol>
+            <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
+            that the user is interacting with.
+            </li>
+            <li>If |request|.{{PaymentRequest/[[state]]}} is not
+            "[=PaymentRequest/interactive=]", then terminate this algorithm and
+            take no further action.
+            </li>
+            <li>Set |request|.{{PaymentRequest/[[state]]}} to
+            "[=PaymentRequest/closed=]".
+            </li>
+            <li>Set |request|'s <a>payment-relevant browsing context</a>'s
+            <a>payment request is showing</a> boolean to false.
+            </li>
+            <li>Let |error| be the appropriate {{DOMException}} for the error
+            reported by the payment handler.
+            </li>
+            <li>Let |response:PaymentResponse| be
+            |request|.{{PaymentRequest/[[response]]}}.
+            </li>
+            <li>If |response| is not null:
+              <ol>
+                <li>Set |response|.{{PaymentResponse/[[complete]]}} to true.
+                </li>
+                <li>Assert: |response|.{{PaymentResponse/[[retryPromise]]}} is
+                not null.
+                </li>
+                <li>Reject |response|.{{PaymentResponse/[[retryPromise]]}} with
+                |error|.
+                </li>
+              </ol>
+            </li>
+            <li>Otherwise, reject |request|.{{PaymentRequest/[[acceptPromise]]}}
+            with |error|.
+            </li>
+            <li>Abort the current user interaction and close down any remaining
+            user interface.
+            </li>
+          </ol>
           </li>
         </ol>
         </p>

--- a/index.html
+++ b/index.html
@@ -1318,11 +1318,11 @@
               </p>
             </aside>
             <p>
-              The |acceptPromise| will later be resolved or rejected by
-              the <a>user accepts the payment request algorithm</a>, or the
-              <a>user aborts the payment request algorithm</a> (which are
-              triggered through interaction with the user interface), or
-              the <a>payment handler indicates an internal error algorithm</a>.
+              The |acceptPromise| will later be resolved or rejected by the
+              <a>user accepts the payment request algorithm</a>, or the <a>user
+              aborts the payment request algorithm</a> (which are triggered
+              through interaction with the user interface), or the <a>payment
+              handler indicates an internal error algorithm</a>.
             </p>
             <p data-tests="rejects_if_not_active.https.html">
               If |document| stops being [=Document/fully active=] while the
@@ -3954,52 +3954,66 @@
           Payment handler indicates an internal error algorithm
         </h2>
         <p>
-	  The <dfn>payment handler indicates an internal error algorithm</dfn>
-          runs when the payment handler that the user has selected reports an
-          internal error to the user agent. It takes in a Javascript value
-          |reason| from the payment handler, to report back to the website.
+          The <dfn>payment handler indicates an internal error algorithm</dfn>
+          runs when the <a>payment handler</a> that the user has selected
+          encounters an internal error that prevents it from completing the
+          payment. This can occur due to reasons such as the operating system
+          terminating the payment handler (e.g., due to memory pressure), or
+          the payment handler itself encountering an unrecoverable error.
         </p>
         <ol class="algorithm">
-          <li><a>Queue a task</a> on the <a>user interaction task source</a> to
-          perform the following steps:
-          <ol>
-            <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
-            that the user is interacting with.
-            </li>
-            <li>If |request|.{{PaymentRequest/[[state]]}} is not
-            "[=PaymentRequest/interactive=]", then terminate this algorithm and
-            take no further action.
-            </li>
-            <li>Set |request|.{{PaymentRequest/[[state]]}} to
-            "[=PaymentRequest/closed=]".
-            </li>
-            <li>Set |request|'s <a>payment-relevant browsing context</a>'s
-            <a>payment request is showing</a> boolean to false.
-            </li>
-            <li>Let |response:PaymentResponse| be
-            |request|.{{PaymentRequest/[[response]]}}.
-            </li>
-            <li>If |response| is not null:
-              <ol>
-                <li>Set |response|.{{PaymentResponse/[[complete]]}} to true.
-                </li>
-                <li>Assert: |response|.{{PaymentResponse/[[retryPromise]]}} is
-                not null.
-                </li>
-                <li>Reject |response|.{{PaymentResponse/[[retryPromise]]}} with
-                |reason|.
-                </li>
-              </ol>
-            </li>
-            <li>Otherwise, reject |request|.{{PaymentRequest/[[acceptPromise]]}}
-            with |reason|.
-            </li>
-            <li>Abort the current user interaction and close down any remaining
-            user interface.
-            </li>
-          </ol>
+          <li>
+            <a>Queue a task</a> on the <a>user interaction task source</a> to
+            perform the following steps:
+            <ol>
+              <li>Let |request:PaymentRequest| be the {{PaymentRequest}} object
+              that the user is interacting with.
+              </li>
+              <li>If |request|.{{PaymentRequest/[[state]]}} is not
+              "[=PaymentRequest/interactive=]", then terminate this algorithm
+              and take no further action.
+              </li>
+              <li>Let |error| be an {{"OperationError"}} {{DOMException}}.
+              </li>
+              <li>Set |request|.{{PaymentRequest/[[state]]}} to
+              "[=PaymentRequest/closed=]".
+              </li>
+              <li>Set |request|'s <a>payment-relevant browsing context</a>'s
+              <a>payment request is showing</a> boolean to false.
+              </li>
+              <li>Let |response:PaymentResponse| be
+              |request|.{{PaymentRequest/[[response]]}}.
+              </li>
+              <li>If |response| is not null:
+                <ol>
+                  <li>Set |response|.{{PaymentResponse/[[complete]]}} to true.
+                  </li>
+                  <li>Assert: |response|.{{PaymentResponse/[[retryPromise]]}}
+                  is not null.
+                  </li>
+                  <li>Reject |response|.{{PaymentResponse/[[retryPromise]]}}
+                  with |error|.
+                  </li>
+                </ol>
+              </li>
+              <li>Otherwise, reject
+              |request|.{{PaymentRequest/[[acceptPromise]]}} with |error|.
+              </li>
+              <li>Optionally, show a generic error message to the user
+              indicating that the payment could not be completed.
+              </li>
+              <li>Optionally, log detailed error information to the developer
+              console for debugging purposes.
+              </li>
+              <li>Abort the current user interaction and close down any
+              remaining user interface.
+              </li>
+            </ol>
           </li>
         </ol>
+        <p class="note">
+          The {{"OperationError"}} type allows merchants to distinguish payment
+          handler errors from user cancellation (which uses {{"AbortError"}}).
         </p>
       </section>
       <section>
@@ -4311,8 +4325,8 @@
             {{PaymentRequest}} |request| and <a>exception</a> |exception|:
           </p>
           <ol class="algorithm">
-            <li>Optionally, show an error message to the user when letting them
-            know an error has occurred.
+            <li>Optionally, inform the developer via the console that an error
+            occurred while updating the payment request.
             </li>
             <li>Abort the current user interaction and close down any remaining
             user interface.

--- a/index.html
+++ b/index.html
@@ -3956,7 +3956,8 @@
         <p>
 	  The <dfn>payment handler indicates an internal error algorithm</dfn>
           runs when the payment handler that the user has selected reports an
-          internal error to the user agent.
+          internal error to the user agent. It takes in a {{DOMException}}
+          |error| from the payment handler to report back to the website.
         </p>
         <ol class="algorithm">
           <li><a>Queue a task</a> on the <a>user interaction task source</a> to
@@ -3974,9 +3975,6 @@
             </li>
             <li>Set |request|'s <a>payment-relevant browsing context</a>'s
             <a>payment request is showing</a> boolean to false.
-            </li>
-            <li>Let |error| be the appropriate {{DOMException}} for the error
-            reported by the payment handler.
             </li>
             <li>Let |response:PaymentResponse| be
             |request|.{{PaymentRequest/[[response]]}}.


### PR DESCRIPTION
See https://github.com/w3c/payment-request/issues/1040

Co-authored by: @marcoscaceres

The following tasks have been completed:

 * [ ] Modified Web platform tests (link) - **not possible to test**, as a test cannot make an app throw an internal error. We could potentially test this via web-based payment handlers, but those tests would only work in Chromium and not WebKit (as it doesn't ship web-based payment handlers). Otherwise we could define some sort of WebDriver API to install a fake payment app, similar to how WebAuthn works?
 
Implementation commitment:

 * [x] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=309077)
 * [x] [Chromium](https://crbug.com/473478138)
 * [ ] Gecko (link to issue) - N/A, don't ship Payment Request

Optional, impact on Payment Handler spec?
https://github.com/w3c/web-based-payment-handler/issues/428


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1050.html" title="Last updated on Mar 3, 2026, 5:33 PM UTC (236c39b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1050/feba7f3...236c39b.html" title="Last updated on Mar 3, 2026, 5:33 PM UTC (236c39b)">Diff</a>