### PR TITLE
Editorial: clarify payment-relevant browsing context definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,9 +670,9 @@
         </p>
       </div>
       <p>
-        A |request|'s <dfn>payment-relevant browsing context</dfn> is that
-        {{PaymentRequest}}'s [=relevant global object=]'s browsing context's
-        <a>top-level browsing context</a>. Every <a>payment-relevant browsing
+        A |request|'s <dfn>payment-relevant browsing context</dfn> is the
+        <a>top-level browsing context</a> of that {{PaymentRequest}}'s
+        [=relevant global object=]'s browsing context. Every <a>payment-relevant browsing
         context</a> has a <dfn>payment request is showing</dfn> boolean, which
         prevents showing more than one payment UI at a time.
       </p>

--- a/index.html
+++ b/index.html
@@ -672,7 +672,7 @@
       <p>
         A |request|'s <dfn>payment-relevant browsing context</dfn> is the
         <a>top-level browsing context</a> of that {{PaymentRequest}}'s
-        [=relevant global object=]'s browsing context. Every <a>payment-relevant browsing
+        [=relevant global object=]'s [=Window/browsing context=]. Every <a>payment-relevant browsing
         context</a> has a <dfn>payment request is showing</dfn> boolean, which
         prevents showing more than one payment UI at a time.
       </p>


### PR DESCRIPTION
This is an editorial change to improve readability.

As I was reading the spec, this sentence stood out as difficult to parse due to placement of **"that"** and long chain of possessives.

Proposed variant (hopefully) makes it easier to understand. 

Before:
```
A request's payment-relevant browsing context is that PaymentRequest's relevant global object's browsing context's top-level browsing context.
```

After:
```
A request's payment-relevant browsing context is the top-level browsing context of that PaymentRequest's relevant global object's browsing context.
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmonch/payment-request/pull/1052.html" title="Last updated on Jan 26, 2026, 7:59 AM UTC (0ff8692)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1052/07c63ac...webmonch:0ff8692.html" title="Last updated on Jan 26, 2026, 7:59 AM UTC (0ff8692)">Diff</a>