### PR TITLE
[Editorial] Update spec to reference web-based-payment-handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -1147,7 +1147,7 @@
                 <aside class="note" title="Payment Handler registration">
                   Mechanisms to register a payment handler are outside the
                   scope of this specification. For one mechanism, see
-                  [[[payment-handler]]].
+                  [[[web-based-payment-handler]]].
                 </aside>
               </li>
               <li>For each |handler| in |registeredHandlers|:
@@ -4430,7 +4430,7 @@
           data models used by existing payment methods, prescribing data
           specifics in this API would limit its usefulness. The
           {{PaymentResponse/details}} member carries data from the payment
-          handler, whether Web-based (as defined by the [[[payment-handler]]])
+          handler, whether Web-based (as defined by the [[[web-based-payment-handler]]])
           or proprietary. The [=user agent=] MUST NOT support payment handlers
           unless they include adequate user consent mechanisms (such as
           awareness of parties to the transaction and mechanisms for


### PR DESCRIPTION
Rather than the old [[[payment-handler]]]. No change on spec text since the spec database already had corrected for the rename.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1054.html" title="Last updated on Feb 24, 2026, 5:59 PM UTC (44f302f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1054/ab02bc1...44f302f.html" title="Last updated on Feb 24, 2026, 5:59 PM UTC (44f302f)">Diff</a>