### PR TITLE
fix: use InvalidStateError for non-fully-active document checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1043,7 +1043,7 @@
           </li>
           <li data-tests="rejects_if_not_active.https.html">If |document| is
           not [=Document/fully active=], then return <a>a promise rejected
-          with</a> an {{"AbortError"}} {{DOMException}}.
+          with</a> an {{"InvalidStateError"}} {{DOMException}}.
           </li>
           <li>If |document|'s [=Document/visibility state=] is not `"visible"`,
           then return <a>a promise rejected with</a> an {{"AbortError"}}
@@ -2488,7 +2488,7 @@
           <li data-tests=
           "payment-response/rejects_if_not_active-manual.https.html">If
           |document| is not [=Document/fully active=], then return <a>a promise
-          rejected with</a> an {{"AbortError"}} {{DOMException}}.
+          rejected with</a> an {{"InvalidStateError"}} {{DOMException}}.
           </li>
           <li>If |response|.{{PaymentResponse/[[complete]]}} is true, return
           <a>a promise rejected with</a> an {{"InvalidStateError"}}

--- a/index.html
+++ b/index.html
@@ -3525,6 +3525,13 @@
           "[=PaymentRequest/created=]", then return <a>a promise rejected
           with</a> an {{"InvalidStateError"}} {{DOMException}}.
           </li>
+          <li>Let |document| be |request|'s [=relevant global object=]'s
+          [=associated `Document`=].
+          </li>
+          <li>If |document| is not [=Document/fully active=], then return
+          <a>a promise rejected with</a> an {{"InvalidStateError"}}
+          {{DOMException}}.
+          </li>
           <li data-tests="">Optionally, at the <a>top-level browsing
           context</a>'s discretion, return <a>a promise rejected with</a> a
           {{"NotAllowedError"}} {{DOMException}}.

--- a/index.html
+++ b/index.html
@@ -1331,8 +1331,16 @@
             <ol>
               <li>Close down the user interface.
               </li>
+              <li>Set |request|.{{PaymentRequest/[[state]]}} to
+              "[=PaymentRequest/closed=]".
+              </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
+              </li>
+              <li>
+                <a>Queue a task</a> on the <a>user interaction task source</a>
+                to [=reject=] |acceptPromise| with an {{"AbortError"}}
+                {{DOMException}}.
               </li>
             </ol>
           </li>
@@ -2589,8 +2597,16 @@
             <ol>
               <li>Close down the user interface.
               </li>
+              <li>Set |request|.{{PaymentRequest/[[state]]}} to
+              "[=PaymentRequest/closed=]".
+              </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
+              </li>
+              <li>
+                <a>Queue a task</a> on the <a>user interaction task source</a>
+                to [=reject=] |retryPromise| with an {{"AbortError"}}
+                {{DOMException}}.
               </li>
             </ol>
           </li>
@@ -2919,6 +2935,11 @@
               </li>
               <li>Set |request|'s <a>payment-relevant browsing context</a>'s
               <a>payment request is showing</a> boolean to false.
+              </li>
+              <li>
+                <a>Queue a task</a> on the <a>user interaction task source</a>
+                to [=reject=] |promise| with an {{"AbortError"}}
+                {{DOMException}}.
               </li>
             </ol>
           </li>
@@ -4430,11 +4451,11 @@
           data models used by existing payment methods, prescribing data
           specifics in this API would limit its usefulness. The
           {{PaymentResponse/details}} member carries data from the payment
-          handler, whether Web-based (as defined by the [[[web-based-payment-handler]]])
-          or proprietary. The [=user agent=] MUST NOT support payment handlers
-          unless they include adequate user consent mechanisms (such as
-          awareness of parties to the transaction and mechanisms for
-          demonstrating the intention to share data).
+          handler, whether Web-based (as defined by the
+          [[[web-based-payment-handler]]]) or proprietary. The [=user agent=]
+          MUST NOT support payment handlers unless they include adequate user
+          consent mechanisms (such as awareness of parties to the transaction
+          and mechanisms for demonstrating the intention to share data).
         </p>
         <p>
           The <a>user agent</a> MUST NOT share the values of the


### PR DESCRIPTION
Per TAG Design Principles §3.2.2, InvalidStateError should be used for document state issues, while AbortError is reserved for user-initiated and developer-initiated aborts (e.g., navigating or removing a traversable).

See: https://www.w3.org/TR/design-principles/#handle-non-fully-active-documents

part of #1040 

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/58210)
 
Implementation commitment:

 * [x] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=309027) [patch](https://github.com/WebKit/WebKit/pull/59870)
 * [ ] [Chromium](https://crbug.com/489361935)
 * [ ] Gecko (link to issue)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1056.html" title="Last updated on Mar 4, 2026, 6:05 AM UTC (0f898c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1056/a473a75...0f898c0.html" title="Last updated on Mar 4, 2026, 6:05 AM UTC (0f898c0)">Diff</a>