### PR TITLE
fix: restore transient activation requirement in show()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,31 +1012,24 @@
           <li data-tests=
           "payment-request-show-method.https.html, show-method-postmessage-manual.https.html">
           If the [=relevant global object=] of [=request=] does not have
-          [=transient activation=], the user agent MAY:
+          [=transient activation=]:
             <ol>
               <li>Return [=a promise rejected with=] with a {{"SecurityError"}}
               {{DOMException}}.
               </li>
             </ol>
             <div class="note">
-              <p>
-                This allows the user agent to not require user activation, for
-                example to support redirect flows where a user activation may
-                not be present upon redirect. See <a href=
-                "#user-activation-requirement"></a> for security
-                considerations.
-              </p>
-              <p>
-                See also <a href=
-                "https://github.com/w3c/payment-request/issues/1022">issue
-                #1022</a> for discussion around providing more guidance in the
-                specification on when user agents should or should not require
-                a user activation for {{PaymentRequest/show()}}.
-              </p>
+              Redirect flows can cause legitimate loss of transient activation
+              before a call to {{PaymentRequest/show()}}. This is a known
+              platform-wide problem affecting Payment Request, Digital
+              Credentials, WebAuthn, and other APIs that require user
+              activation. A general solution is being tracked in <a href=
+              "https://github.com/w3c/payment-request/issues/1064">issue
+              #1064</a>.
             </div>
           </li>
-          <li data-tests="show-consume-activation.https.html">Otherwise,
-          [=consume user activation=] of the [=relevant global object=].
+          <li data-tests="show-consume-activation.https.html">[=Consume user
+          activation=] of the [=relevant global object=].
           </li>
           <li>Let |document| be |request|'s [=relevant global object=]'s
           [=associated `Document`=].
@@ -4614,32 +4607,6 @@
           with repeated calls, whether it is the cost of managing multiple
           [=host/registrable domains=] or the user experience friction of
           opening multiple windows (tabs or pop-ups).
-        </p>
-      </section>
-      <section>
-        <h2 id="user-activation-requirement">
-          User activation requirement
-        </h2>
-        <p>
-          If the user agent does not require user activation as part of the
-          {{PaymentRequest/show()}} method, some additional security
-          mitigations should be considered. Not requiring user activation
-          increases the risk of spam and click-jacking attacks, by allowing a
-          Payment Request UI to be initiated without the user interacting with
-          the page immediately beforehand.
-        </p>
-        <p>
-          In order to mitigate spam, the user agent may decide to enforce a
-          user activation requirement after some threshold, for example after
-          the user has already been shown a Payment Request UI without a user
-          activation on the current page. In order to mitigate click-jacking
-          attacks, the user agent may implement a time threshold in which
-          clicks are ignored immediately after a dialog is shown.
-        </p>
-        <p>
-          Another relevant mitigation exists in step 6 of
-          {{PaymentRequest/show()}}, where the document must be visible in
-          order to initiate the user interaction.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1025,7 +1025,9 @@
               Credentials, WebAuthn, and other APIs that require user
               activation. A general solution is being tracked in <a href=
               "https://github.com/w3c/payment-request/issues/1064">issue
-              #1064</a>.
+              #1064</a>. Some user agents have legacy behavior that allows
+              certain calls to {{PaymentRequest/show()}} without requiring
+              user activation.
             </div>
           </li>
           <li data-tests="show-consume-activation.https.html">[=Consume user


### PR DESCRIPTION
Reverts the relaxation introduced in #1009 and removes the non-normative "User activation requirement" section.

## What changed

- Restores `[=transient activation=]` as a hard requirement in `show()` (removes the MAY)
- Removes the "User activation requirement" security considerations section
- Replaces both with a note acknowledging the redirect flow problem and pointing to the general solution being tracked in #1064

## Why

The MAY introduced in #1009 means a conformant browser can skip the activation check entirely with no normative constraints. The security mitigations in the removed section were all non-normative suggestions. That is not a spec constraint.

This is also part of a pattern: Digital Credentials and WebAuthn have the same problem and are reaching for the same local workarounds. The right fix is a sanctioned-continuation primitive at the HTML level (see [WICG Capability Delegation](https://wicg.github.io/capability-delegation/spec.html)), tracked in #1064.

Keeping the activation requirement strict here maintains pressure to find the general solution rather than normalizing per-spec workarounds.

closes #1064 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link)
 
Implementation commitment:

 * [ ] WebKit (link to issue)
 * [ ] Chromium (link to issue)
 * [ ] Gecko (link to issue)

Optional, impact on Payment Handler spec?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1066.html" title="Last updated on May 11, 2026, 7:28 AM UTC (791f837)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1066/0e99859...791f837.html" title="Last updated on May 11, 2026, 7:28 AM UTC (791f837)">Diff</a>