### PR TITLE
chore: export payment method

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,10 @@
         <li>The payer: the party that makes a purchase at that online store,
         and who authenticates and authorizes payment as required.
         </li>
-        <li>The <dfn>payment method</dfn>: the means that the payer uses to pay
-        the payee (e.g., a card payment or credit transfer). The <dfn>payment
-        method provider</dfn> establishes the ecosystem to support that payment
-        method.
+        <li>The <dfn class="export">payment method</dfn>: the means that the
+        payer uses to pay the payee (e.g., a card payment or credit transfer).
+        The <dfn class="export">payment method provider</dfn> establishes the
+        ecosystem to support that payment method.
         </li>
       </ul>
       <p>
@@ -164,8 +164,8 @@
       </p>
       <dl>
         <dt>
-          An optional <dfn data-dfn-for="Payment Method">additional data
-          type</dfn>
+          An optional <dfn data-dfn-for="Payment Method" class=
+          "export">additional data type</dfn>
         </dt>
         <dd>
           Optionally, an IDL type that the <a>payment method</a> expects to
@@ -175,7 +175,7 @@
           {{PaymentMethodData/data}} as JSON.
         </dd>
         <dt>
-          <dfn>Steps to validate payment method data</dfn>
+          <dfn class="export">Steps to validate payment method data</dfn>
         </dt>
         <dd>
           Algorithmic steps that specify how a <a>payment method</a> validates


### PR DESCRIPTION
Was doing some ReSpec cleanup/fixes and found some random things that should have been exported.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/pull/1073.html" title="Last updated on Jun 22, 2026, 2:40 PM UTC (f6902ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-request/1073/da390e4...f6902ba.html" title="Last updated on Jun 22, 2026, 2:40 PM UTC (f6902ba)">Diff</a>